### PR TITLE
feat: 관리자/응시자 화면 API 연동 및 시험 제출 플로우 연결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ next-env.d.ts
 
 # OS
 Thumbs.db
+
+# CLAUDE
+.claude/

--- a/components/ai-assistant-sidebar.tsx
+++ b/components/ai-assistant-sidebar.tsx
@@ -1,11 +1,11 @@
 "use client"
 
-import { useState, useCallback } from "react"
+import { useState, useCallback, useEffect, useRef } from "react"
 import { ChevronLeft, ChevronRight, Send, Bot, User } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { useChatSocket } from "@/hooks/use-chat-socket"
-import { updateTokenUsage } from "@/lib/api/chat"
+import { updateTokenUsage, getChatHistory } from "@/lib/api/chat"
 
 interface Message {
   id: number
@@ -22,13 +22,13 @@ interface AiAssistantSidebarProps {
   onTokensUpdate: (delta: number) => void
 }
 
-export function AiAssistantSidebar({ 
-  isOpen, 
-  onToggle, 
-  examId, 
-  participantId, 
-  usedTokens, 
-  onTokensUpdate 
+export function AiAssistantSidebar({
+  isOpen,
+  onToggle,
+  examId,
+  participantId,
+  usedTokens,
+  onTokensUpdate,
 }: AiAssistantSidebarProps) {
   const [messages, setMessages] = useState<Message[]>([
     {
@@ -40,42 +40,83 @@ export function AiAssistantSidebar({
   const [inputValue, setInputValue] = useState("")
   const [isSending, setIsSending] = useState(false)
   const [currentTurn, setCurrentTurn] = useState(1)
+  const [isHistoryLoaded, setIsHistoryLoaded] = useState(false)
 
-  // WebSocket 메시지 수신 핸들러
+  // 메시지 목록 하단 자동 스크롤
+  const messagesEndRef = useRef<HTMLDivElement | null>(null)
+
+  // ── 채팅 히스토리 초기 로드 ────────────────────────────────────────────────
+  useEffect(() => {
+    if (isHistoryLoaded) return;
+
+    getChatHistory(examId, participantId)
+      .then((history) => {
+        if (!history || history.messages.length === 0) return;
+
+        const restored: Message[] = history.messages.map((msg) => ({
+          id: msg.id,
+          role: (msg.role.toLowerCase() === "user" ? "user" : "assistant") as "user" | "assistant",
+          content: msg.content,
+        }));
+
+        // 환영 메시지(id=1) 뒤에 히스토리 삽입
+        setMessages([
+          {
+            id: 1,
+            role: "assistant",
+            content: "이전 대화를 불러왔습니다. 이어서 질문하셔도 됩니다!",
+          },
+          ...restored,
+        ]);
+
+        // 마지막 turn 번호로 currentTurn 동기화
+        const lastTurn = history.messages.at(-1)?.turn ?? 0;
+        setCurrentTurn(lastTurn + 1);
+      })
+      .catch((err) => {
+        // 404(히스토리 없음)은 정상 — 초기 메시지 유지
+        if (process.env.NODE_ENV === "development") {
+          console.warn("[AiAssistantSidebar] getChatHistory 로드 실패:", err);
+        }
+      })
+      .finally(() => {
+        setIsHistoryLoaded(true);
+      });
+  // examId/participantId는 마운트 후 변경되지 않으므로 의도적으로 한 번만 실행
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 메시지가 추가될 때 하단으로 스크롤
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  // ── WebSocket 메시지 수신 핸들러 ─────────────────────────────────────────────
   const handleMessageReceived = useCallback((newMessage: Message, response: any) => {
     setMessages((prev) => [...prev, newMessage]);
     setIsSending(false);
-    
-    // turn 증가
     setCurrentTurn((prev) => prev + 1);
 
-    // 토큰 사용량 처리
     let tokensDelta = 0;
-    
+
     if (response.totalCount !== null && response.totalCount !== undefined) {
-      // usedTokens는 부모 상태이므로 최신 값을 기반으로 계산
       tokensDelta = response.tokenCount || (response.totalCount - usedTokens);
-      
       if (tokensDelta <= 0 && response.tokenCount !== null) {
-        tokensDelta = response.tokenCount + 30; 
+        tokensDelta = response.tokenCount + 30;
       }
     } else if (response.tokenCount !== null) {
       tokensDelta = response.tokenCount + 30;
     }
 
     if (tokensDelta > 0) {
-      updateTokenUsage({
-        examId,
-        participantId,
-        tokens: tokensDelta
-      }).then(() => {
-        onTokensUpdate(tokensDelta);
-      }).catch(err => {
-        if (process.env.NODE_ENV === 'development') {
-          console.warn("[WS Chat] Token update failed:", err);
-        }
-        onTokensUpdate(tokensDelta); // 실패해도 상태는 동기화
-      });
+      updateTokenUsage({ examId, participantId, tokens: tokensDelta })
+        .then(() => { onTokensUpdate(tokensDelta); })
+        .catch((err) => {
+          if (process.env.NODE_ENV === "development") {
+            console.warn("[WS Chat] Token update failed:", err);
+          }
+          onTokensUpdate(tokensDelta);
+        });
     }
   }, [examId, participantId, usedTokens, onTokensUpdate]);
 
@@ -89,21 +130,19 @@ export function AiAssistantSidebar({
     if (!inputValue.trim() || isSending || !isConnected) return
 
     const userMessageContent = inputValue.trim()
-    
-    // UI 즉시 반영 (Optimistic UI)
+
     const newUserMessage: Message = {
       id: Date.now(),
       role: "user",
       content: userMessageContent,
     }
-    
+
     setMessages((prev) => [...prev, newUserMessage])
     setInputValue("")
     setIsSending(true)
 
-    // WebSocket으로 메시지 전송
     const success = sendWsMessage(userMessageContent, currentTurn);
-    
+
     if (!success) {
       console.error("[WS Chat] Failed to send message via WebSocket");
       setIsSending(false);
@@ -154,6 +193,17 @@ export function AiAssistantSidebar({
           </button>
         </div>
 
+        {/* 히스토리 로딩 중 표시 */}
+        {!isHistoryLoaded && (
+          <div className="px-4 py-2 text-xs text-[#6B7280] bg-[#F9FAFB] border-b border-[#E5E7EB] flex items-center gap-1">
+            <svg className="animate-spin w-3 h-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+            </svg>
+            이전 대화 불러오는 중…
+          </div>
+        )}
+
         {/* Chat Messages */}
         <div className="flex-1 overflow-y-auto p-4 space-y-4">
           {messages.map((message) => (
@@ -180,6 +230,22 @@ export function AiAssistantSidebar({
               </div>
             </div>
           ))}
+
+          {/* 응답 대기 중 타이핑 인디케이터 */}
+          {isSending && (
+            <div className="flex gap-3">
+              <div className="w-8 h-8 rounded-full bg-[#2563EB] flex items-center justify-center flex-shrink-0">
+                <Bot className="w-4 h-4 text-white" />
+              </div>
+              <div className="px-4 py-3 rounded-2xl bg-[#F3F4F6] rounded-tl-sm flex items-center gap-1">
+                <span className="w-1.5 h-1.5 rounded-full bg-[#9CA3AF] animate-bounce [animation-delay:-0.3s]" />
+                <span className="w-1.5 h-1.5 rounded-full bg-[#9CA3AF] animate-bounce [animation-delay:-0.15s]" />
+                <span className="w-1.5 h-1.5 rounded-full bg-[#9CA3AF] animate-bounce" />
+              </div>
+            </div>
+          )}
+
+          <div ref={messagesEndRef} />
         </div>
 
         {/* Input Area */}
@@ -199,9 +265,9 @@ export function AiAssistantSidebar({
               className="flex-1 bg-white border-[#D0D0D0] resize-none whitespace-normal break-words"
               disabled={isSending || !isConnected}
             />
-            <Button 
-              onClick={handleSend} 
-              size="icon" 
+            <Button
+              onClick={handleSend}
+              size="icon"
               className="bg-[#2563EB] hover:bg-[#1D4ED8] text-white px-3 py-2 disabled:opacity-50 disabled:cursor-not-allowed"
               disabled={isSending || !inputValue.trim() || !isConnected}
             >

--- a/components/analytics-content.tsx
+++ b/components/analytics-content.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState, useMemo, useEffect } from "react"
 import Link from "next/link"
 import { Download, TrendingUp, TrendingDown, Minus, ChevronDown, X, CheckCircle } from "lucide-react"
+import { getExams, getBoard, Exam, ExamineeBoardEntry } from "@/lib/api/admin"
 
 type Trend = "높음" | "보통" | "낮음"
 type Status = "완료" | "진행 중"
@@ -27,164 +28,26 @@ interface Toast {
   description: string
 }
 
-const participantsData: Participant[] = [
-  {
-    id: "1",
-    name: "Sarah Johnson",
-    entryCode: "AIV-2024-001",
-    avgScore: 94,
-    status: "완료",
-    trend: "높음",
-    sparklineData: [65, 72, 80, 88, 94],
-    testDate: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000), // 2 days ago
-    promptScore: 96,
-    performanceScore: 92,
-    correctnessScore: 94,
-  },
-  {
-    id: "2",
-    name: "Michael Chen",
-    entryCode: "AIV-2024-001",
-    avgScore: 91,
-    status: "완료",
-    trend: "높음",
-    sparklineData: [70, 75, 82, 87, 91],
-    testDate: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000), // 5 days ago
-    promptScore: 90,
-    performanceScore: 88,
-    correctnessScore: 95,
-  },
-  {
-    id: "3",
-    name: "Emily Davis",
-    entryCode: "AIV-2024-002",
-    avgScore: 88,
-    status: "완료",
-    trend: "높음",
-    sparklineData: [60, 68, 75, 82, 88],
-    testDate: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000), // 10 days ago
-    promptScore: 85,
-    performanceScore: 90,
-    correctnessScore: 89,
-  },
-  {
-    id: "4",
-    name: "David Wilson",
-    entryCode: "AIV-2024-001",
-    avgScore: 86,
-    status: "완료",
-    trend: "높음",
-    sparklineData: [72, 78, 80, 84, 86],
-    testDate: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000), // 3 days ago
-    promptScore: 88,
-    performanceScore: 84,
-    correctnessScore: 86,
-  },
-  {
-    id: "5",
-    name: "Jessica Lee",
-    entryCode: "AIV-2024-003",
-    avgScore: 82,
-    status: "완료",
+function mapBoardToParticipant(entry: ExamineeBoardEntry, examTitle: string): Participant {
+  const submitted = entry.submitted
+  // tokenUsed를 0~100 스케일로 정규화 (tokenLimit 기준)
+  const tokenRatio =
+    entry.tokenLimit > 0 ? Math.min(100, Math.round((entry.tokenUsed / entry.tokenLimit) * 100)) : 0
+
+  return {
+    id: entry.examParticipantId.toString(),
+    name: entry.name,
+    entryCode: examTitle,
+    avgScore: 0, // 채점 API 미연동 — 채점 완료 후 집계 예정
+    status: submitted ? "완료" : "진행 중",
     trend: "보통",
-    sparklineData: [78, 80, 79, 81, 82],
-    testDate: new Date(Date.now() - 20 * 24 * 60 * 60 * 1000), // 20 days ago
-    promptScore: 80,
-    performanceScore: 82,
-    correctnessScore: 84,
-  },
-  {
-    id: "6",
-    name: "Chris Martinez",
-    entryCode: "AIV-2024-002",
-    avgScore: 78,
-    status: "완료",
-    trend: "보통",
-    sparklineData: [75, 76, 78, 77, 78],
-    testDate: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000), // 8 days ago
-    promptScore: 76,
-    performanceScore: 78,
-    correctnessScore: 80,
-  },
-  {
-    id: "7",
-    name: "Amanda Brown",
-    entryCode: "AIV-2024-001",
-    avgScore: 75,
-    status: "진행 중",
-    trend: "보통",
-    sparklineData: [68, 70, 72, 74, 75],
-    testDate: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000), // 1 day ago
-    promptScore: 74,
-    performanceScore: 75,
-    correctnessScore: 76,
-  },
-  {
-    id: "8",
-    name: "Ryan Taylor",
-    entryCode: "AIV-2024-003",
-    avgScore: 72,
-    status: "완료",
-    trend: "보통",
-    sparklineData: [70, 71, 72, 71, 72],
-    testDate: new Date(Date.now() - 45 * 24 * 60 * 60 * 1000), // 45 days ago
-    promptScore: 70,
-    performanceScore: 72,
-    correctnessScore: 74,
-  },
-  {
-    id: "9",
-    name: "Nicole Garcia",
-    entryCode: "AIV-2024-002",
-    avgScore: 68,
-    status: "완료",
-    trend: "보통",
-    sparklineData: [65, 66, 67, 68, 68],
-    testDate: new Date(Date.now() - 15 * 24 * 60 * 60 * 1000), // 15 days ago
-    promptScore: 66,
-    performanceScore: 68,
-    correctnessScore: 70,
-  },
-  {
-    id: "10",
-    name: "Kevin Robinson",
-    entryCode: "AIV-2024-001",
-    avgScore: 55,
-    status: "완료",
-    trend: "낮음",
-    sparklineData: [62, 58, 55, 54, 55],
-    testDate: new Date(Date.now() - 6 * 24 * 60 * 60 * 1000), // 6 days ago
-    promptScore: 52,
-    performanceScore: 55,
-    correctnessScore: 58,
-  },
-  {
-    id: "11",
-    name: "Laura Thompson",
-    entryCode: "AIV-2024-003",
-    avgScore: 48,
-    status: "진행 중",
-    trend: "낮음",
-    sparklineData: [55, 52, 50, 49, 48],
-    testDate: new Date(Date.now() - 60 * 24 * 60 * 60 * 1000), // 60 days ago
-    promptScore: 45,
-    performanceScore: 48,
-    correctnessScore: 51,
-  },
-  {
-    id: "12",
-    name: "James Anderson",
-    entryCode: "AIV-2024-002",
-    avgScore: 42,
-    status: "완료",
-    trend: "낮음",
-    sparklineData: [50, 48, 45, 43, 42],
-    testDate: new Date(Date.now() - 25 * 24 * 60 * 60 * 1000), // 25 days ago
-    promptScore: 40,
-    performanceScore: 42,
-    correctnessScore: 44,
-  },
-]
+    sparklineData: [0, tokenRatio], // 토큰 사용 추이
+    testDate: new Date(),
+    promptScore: 0,
+    performanceScore: 0,
+    correctnessScore: 0,
+  }
+}
 
 function Sparkline({ data, trend }: { data: number[]; trend: Trend }) {
   const width = 100
@@ -230,7 +93,6 @@ function TrendIcon({ trend }: { trend: Trend }) {
 
 function StatusBadge({ status }: { status: Status }) {
   const styles = status === "완료" ? "bg-[#DCFCE7] text-[#16A34A]" : "bg-[#E0E7FF] text-[#6366F1]"
-
   return <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${styles}`}>{status}</span>
 }
 
@@ -240,7 +102,6 @@ function TrendBadge({ trend }: { trend: Trend }) {
     "보통": "bg-[#F3F4F6] text-[#6B7280]",
     "낮음": "bg-[#FEE2E2] text-[#DC2626]",
   }
-
   return <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${styles[trend]}`}>{trend}</span>
 }
 
@@ -273,14 +134,13 @@ function ParticipantCard({ participant }: { participant: Participant }) {
       <div className="mt-4 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <div>
-            <p className="text-sm text-[#6B7280]">평균 점수</p>
+            <p className="text-sm text-[#6B7280]">제출 상태</p>
             <div className="flex items-center gap-2">
-              <span className="text-2xl font-bold text-[#1A1A1A]">{participant.avgScore}%</span>
+              <span className="text-base font-bold text-[#1A1A1A]">{participant.status}</span>
               <TrendIcon trend={participant.trend} />
             </div>
           </div>
         </div>
-
         <Sparkline data={participant.sparklineData} trend={participant.trend} />
       </div>
 
@@ -288,7 +148,7 @@ function ParticipantCard({ participant }: { participant: Participant }) {
         <Link
           href={{
             pathname: `/admin/results/${encodeURIComponent(participant.entryCode)}/${participant.id}`,
-            query: { from: "analytics" }, // 🔹 2번 루트 표시
+            query: { from: "analytics" },
           }}
           className="text-sm font-medium text-[#3B82F6] transition-colors hover:text-[#2563EB]"
         >
@@ -300,9 +160,60 @@ function ParticipantCard({ participant }: { participant: Participant }) {
 }
 
 export function AnalyticsContent() {
-  const [timeRange, setTimeRange] = useState("전체 기간")
-  const [testSession, setTestSession] = useState("모든 세션")
+  const [exams, setExams] = useState<Exam[]>([])
+  const [participants, setParticipants] = useState<Participant[]>([])
+  const [isLoadingExams, setIsLoadingExams] = useState(true)
+  const [isLoadingBoard, setIsLoadingBoard] = useState(false)
+  const [selectedExamId, setSelectedExamId] = useState<string>("all")
   const [toasts, setToasts] = useState<Toast[]>([])
+
+  // 시험 목록 로드
+  useEffect(() => {
+    async function loadExams() {
+      try {
+        const data = await getExams()
+        setExams(data)
+      } catch (e) {
+        console.error("Failed to load exams", e)
+      } finally {
+        setIsLoadingExams(false)
+      }
+    }
+    loadExams()
+  }, [])
+
+  // 선택된 시험 보드 로드
+  useEffect(() => {
+    async function loadBoard() {
+      if (isLoadingExams) return
+      setIsLoadingBoard(true)
+      try {
+        if (selectedExamId === "all") {
+          // 모든 시험의 보드를 병렬 조회
+          const boards = await Promise.all(
+            exams.map((e) =>
+              getBoard(e.id)
+                .then((entries) => entries.map((p) => mapBoardToParticipant(p, e.title)))
+                .catch(() => [] as Participant[])
+            )
+          )
+          setParticipants(boards.flat())
+        } else {
+          const examId = parseInt(selectedExamId, 10)
+          const exam = exams.find((e) => e.id === examId)
+          const board = await getBoard(examId)
+          setParticipants(board.map((p) => mapBoardToParticipant(p, exam?.title ?? selectedExamId)))
+        }
+      } catch (e) {
+        console.error("Failed to load board", e)
+        setParticipants([])
+      } finally {
+        setIsLoadingBoard(false)
+      }
+    }
+    loadBoard()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedExamId, isLoadingExams])
 
   const showToast = (title: string, description: string) => {
     const id = crypto.randomUUID()
@@ -318,13 +229,8 @@ export function AnalyticsContent() {
 
   const handleExport = () => {
     const csvContent =
-      "이름,입장 코드,평균 점수,상태,성과 수준,프롬프트 점수,성능 점수,정답률 점수\n" +
-      participantsData
-        .map(
-          (p) =>
-            `${p.name},${p.entryCode},${p.avgScore},${p.status},${p.trend},${p.promptScore},${p.performanceScore},${p.correctnessScore}`,
-        )
-        .join("\n")
+      "이름,시험,제출상태\n" +
+      participants.map((p) => `${p.name},${p.entryCode},${p.status}`).join("\n")
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" })
     const url = URL.createObjectURL(blob)
     const link = document.createElement("a")
@@ -337,61 +243,14 @@ export function AnalyticsContent() {
     showToast("내보내기 시작", "통계 분석 결과가 CSV 파일로 다운로드되고 있습니다.")
   }
 
-  const filteredParticipants = useMemo(() => {
-    const now = new Date()
-
-    let dateThreshold: Date | null = null
-    switch (timeRange) {
-      case "최근 7일":
-        dateThreshold = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
-        break
-      case "최근 14일":
-        dateThreshold = new Date(now.getTime() - 14 * 24 * 60 * 60 * 1000)
-        break
-      case "최근 30일":
-        dateThreshold = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000)
-        break
-      case "최근 90일":
-        dateThreshold = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000)
-        break
-      default:
-        dateThreshold = null
-    }
-
-    return participantsData.filter((p) => {
-      const passesTimeFilter = dateThreshold === null || p.testDate >= dateThreshold
-      const passesSessionFilter = testSession === "모든 세션" || p.entryCode === testSession
-      return passesTimeFilter && passesSessionFilter
-    })
-  }, [timeRange, testSession])
-
-  const metrics = useMemo(() => {
-    if (filteredParticipants.length === 0) {
-      return {
-        promptScore: "–",
-        performanceScore: "–",
-        correctnessScore: "–",
-        userCount: "0",
-      }
-    }
-
-    const avgPrompt = filteredParticipants.reduce((sum, p) => sum + p.promptScore, 0) / filteredParticipants.length
-    const avgPerformance =
-      filteredParticipants.reduce((sum, p) => sum + p.performanceScore, 0) / filteredParticipants.length
-    const avgCorrectness =
-      filteredParticipants.reduce((sum, p) => sum + p.correctnessScore, 0) / filteredParticipants.length
-
-    return {
-      promptScore: avgPrompt.toFixed(1),
-      performanceScore: avgPerformance.toFixed(1),
-      correctnessScore: avgCorrectness.toFixed(1),
-      userCount: filteredParticipants.length.toString(),
-    }
-  }, [filteredParticipants])
-
-  const highPerformers = filteredParticipants.filter((p) => p.avgScore >= 85)
-  const midPerformers = filteredParticipants.filter((p) => p.avgScore >= 60 && p.avgScore < 85)
-  const lowPerformers = filteredParticipants.filter((p) => p.avgScore < 60)
+  const completedParticipants = useMemo(
+    () => participants.filter((p) => p.status === "완료"),
+    [participants]
+  )
+  const inProgressParticipants = useMemo(
+    () => participants.filter((p) => p.status === "진행 중"),
+    [participants]
+  )
 
   return (
     <div className="flex h-full flex-1 flex-col">
@@ -399,7 +258,7 @@ export function AnalyticsContent() {
         <div>
           <h1 className="text-2xl font-semibold text-[#1A1A1A]">통계 분석</h1>
           <p className="text-sm text-[#6B7280]">
-            모든 시험 세션의 성능, 정답률, 시스템 추세를 시각화합니다.
+            모든 시험 세션의 참가자 현황 및 제출 상태를 시각화합니다.
           </p>
         </div>
       </header>
@@ -409,29 +268,17 @@ export function AnalyticsContent() {
           <div className="flex items-center gap-3">
             <div className="relative">
               <select
-                value={timeRange}
-                onChange={(e) => setTimeRange(e.target.value)}
-                className="appearance-none rounded-lg border border-[#E5E5E5] bg-white py-2 pl-4 pr-10 text-sm text-[#1A1A1A] outline-none transition-colors focus:border-[#3B82F6] focus:ring-1 focus:ring-[#3B82F6]"
+                value={selectedExamId}
+                onChange={(e) => setSelectedExamId(e.target.value)}
+                disabled={isLoadingExams}
+                className="appearance-none rounded-lg border border-[#E5E5E5] bg-white py-2 pl-4 pr-10 text-sm text-[#1A1A1A] outline-none transition-colors focus:border-[#3B82F6] focus:ring-1 focus:ring-[#3B82F6] disabled:opacity-50"
               >
-                <option>최근 7일</option>
-                <option>최근 14일</option>
-                <option>최근 30일</option>
-                <option>최근 90일</option>
-                <option>전체 기간</option>
-              </select>
-              <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#6B7280]" />
-            </div>
-
-            <div className="relative">
-              <select
-                value={testSession}
-                onChange={(e) => setTestSession(e.target.value)}
-                className="appearance-none rounded-lg border border-[#E5E5E5] bg-white py-2 pl-4 pr-10 text-sm text-[#1A1A1A] outline-none transition-colors focus:border-[#3B82F6] focus:ring-1 focus:ring-[#3B82F6]"
-              >
-                <option>모든 세션</option>
-                <option>AIV-2024-001</option>
-                <option>AIV-2024-002</option>
-                <option>AIV-2024-003</option>
+                <option value="all">모든 세션</option>
+                {exams.map((exam) => (
+                  <option key={exam.id} value={exam.id.toString()}>
+                    {exam.title}
+                  </option>
+                ))}
               </select>
               <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#6B7280]" />
             </div>
@@ -446,65 +293,58 @@ export function AnalyticsContent() {
           </button>
         </div>
 
-        <div className="mb-8 grid grid-cols-4 gap-4">
-          <MetricCard
-            label="프롬프트 점수"
-            value={metrics.promptScore}
-            suffix={metrics.promptScore !== "–" ? "/ 100" : undefined}
-          />
-          <MetricCard
-            label="성능 점수"
-            value={metrics.performanceScore}
-            suffix={metrics.performanceScore !== "–" ? "/ 100" : undefined}
-          />
-          <MetricCard
-            label="정답률 점수"
-            value={metrics.correctnessScore}
-            suffix={metrics.correctnessScore !== "–" ? "/ 100" : undefined}
-          />
-          <MetricCard label="누적 사용자 수" value={metrics.userCount} />
+        {/* 메트릭 카드 — 점수는 채점 완료 후 집계됨 */}
+        <div className="mb-6 grid grid-cols-4 gap-4">
+          <MetricCard label="프롬프트 점수" value="–" />
+          <MetricCard label="성능 점수" value="–" />
+          <MetricCard label="정답률 점수" value="–" />
+          <MetricCard label="누적 사용자 수" value={isLoadingBoard ? "..." : participants.length.toString()} />
         </div>
 
-        {filteredParticipants.length === 0 && (
+        {/* 점수 미집계 안내 */}
+        <div className="mb-6 rounded-lg border border-[#E5E5E5] bg-[#F9FAFB] px-4 py-3">
+          <p className="text-sm text-[#6B7280]">
+            평가 점수는 채점 완료 후 집계됩니다. 현재는 참가자 현황 및 제출 상태를 기준으로 표시합니다.
+          </p>
+        </div>
+
+        {isLoadingBoard ? (
+          <div className="flex flex-col items-center justify-center rounded-xl border border-[#E5E5E5] bg-white py-16">
+            <p className="text-lg font-medium text-[#6B7280]">불러오는 중...</p>
+          </div>
+        ) : participants.length === 0 ? (
           <div className="flex flex-col items-center justify-center rounded-xl border border-[#E5E5E5] bg-white py-16">
             <p className="text-lg font-medium text-[#6B7280]">조회된 참가자가 없습니다</p>
-            <p className="mt-1 text-sm text-[#9CA3AF]">필터 설정을 변경해 결과를 확인해보세요.</p>
+            <p className="mt-1 text-sm text-[#9CA3AF]">시험 세션을 선택하거나 참가자를 확인해보세요.</p>
           </div>
-        )}
+        ) : (
+          <>
+            {completedParticipants.length > 0 && (
+              <div className="mb-8">
+                <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-[#6B7280]">
+                  제출 완료 ({completedParticipants.length}명)
+                </h2>
+                <div className="grid grid-cols-2 gap-6">
+                  {completedParticipants.map((participant) => (
+                    <ParticipantCard key={participant.id} participant={participant} />
+                  ))}
+                </div>
+              </div>
+            )}
 
-        {highPerformers.length > 0 && (
-          <div className="mb-8">
-            <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-[#6B7280]">우수 참가자 (85%+)</h2>
-            <div className="grid grid-cols-2 gap-6">
-              {highPerformers.map((participant) => (
-                <ParticipantCard key={participant.id} participant={participant} />
-              ))}
-            </div>
-          </div>
-        )}
-
-        {midPerformers.length > 0 && (
-          <div className="mb-8">
-            <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-[#6B7280]">중간 성과자 (60–84%)</h2>
-            <div className="grid grid-cols-2 gap-6">
-              {midPerformers.map((participant) => (
-                <ParticipantCard key={participant.id} participant={participant} />
-              ))}
-            </div>
-          </div>
-        )}
-
-        {lowPerformers.length > 0 && (
-          <div className="mb-8">
-            <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-[#6B7280]">
-              저성과자 (&lt;60%)
-            </h2>
-            <div className="grid grid-cols-2 gap-6">
-              {lowPerformers.map((participant) => (
-                <ParticipantCard key={participant.id} participant={participant} />
-              ))}
-            </div>
-          </div>
+            {inProgressParticipants.length > 0 && (
+              <div className="mb-8">
+                <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-[#6B7280]">
+                  진행 중 ({inProgressParticipants.length}명)
+                </h2>
+                <div className="grid grid-cols-2 gap-6">
+                  {inProgressParticipants.map((participant) => (
+                    <ParticipantCard key={participant.id} participant={participant} />
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/components/code-editor-section.tsx
+++ b/components/code-editor-section.tsx
@@ -4,6 +4,7 @@ import type React from "react"
 
 import { useState, useRef } from "react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { submitCode, SubmissionStatus } from "@/lib/api/submissions"
 
 const defaultCodeTemplates: Record<string, string> = {
   python: `# 언어를 선택하시고
@@ -44,13 +45,44 @@ function compressString(s) {
 `,
 }
 
-interface CodeEditorSectionProps {
-  isReadOnly?: boolean;
+// 제출 상태 레이블 매핑
+const STATUS_LABEL: Record<SubmissionStatus, string> = {
+  PENDING:              "제출 완료 — 채점 대기 중",
+  JUDGING:              "채점 중…",
+  ACCEPTED:             "✅ 정답",
+  WRONG_ANSWER:         "❌ 오답",
+  TIME_LIMIT_EXCEEDED:  "⏱ 시간 초과",
+  MEMORY_LIMIT_EXCEEDED:"💾 메모리 초과",
+  RUNTIME_ERROR:        "🔥 런타임 오류",
+  COMPILE_ERROR:        "🔨 컴파일 오류",
+  SYSTEM_ERROR:         "⚠️ 시스템 오류",
 }
 
-export function CodeEditorSection({ isReadOnly = false }: CodeEditorSectionProps) {
+const STATUS_COLOR: Record<SubmissionStatus, string> = {
+  PENDING:              "text-[#6B7280] bg-[#F3F4F6]",
+  JUDGING:              "text-[#2563EB] bg-[#EFF6FF]",
+  ACCEPTED:             "text-[#059669] bg-[#ECFDF5]",
+  WRONG_ANSWER:         "text-[#DC2626] bg-[#FEF2F2]",
+  TIME_LIMIT_EXCEEDED:  "text-[#D97706] bg-[#FFFBEB]",
+  MEMORY_LIMIT_EXCEEDED:"text-[#D97706] bg-[#FFFBEB]",
+  RUNTIME_ERROR:        "text-[#DC2626] bg-[#FEF2F2]",
+  COMPILE_ERROR:        "text-[#DC2626] bg-[#FEF2F2]",
+  SYSTEM_ERROR:         "text-[#6B7280] bg-[#F3F4F6]",
+}
+
+interface CodeEditorSectionProps {
+  isReadOnly?: boolean;
+  examId?: number | null;
+  /** 제출 완료 후 submissionId를 부모에 전달 (SSE 구독 트리거) */
+  onSubmitted?: (submissionId: number) => void;
+}
+
+export function CodeEditorSection({
+  isReadOnly = false,
+  examId,
+  onSubmitted,
+}: CodeEditorSectionProps) {
   const [language, setLanguage] = useState("python")
-  // 각 언어별로 작성한 코드를 저장
   const [languageCodes, setLanguageCodes] = useState<Record<string, string>>({
     python: defaultCodeTemplates.python,
     java: defaultCodeTemplates.java,
@@ -60,21 +92,20 @@ export function CodeEditorSection({ isReadOnly = false }: CodeEditorSectionProps
   const [code, setCode] = useState(defaultCodeTemplates.python)
   const [cursorPosition, setCursorPosition] = useState({ line: 1, col: 1 })
 
+  // 제출 상태
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitStatus, setSubmitStatus] = useState<SubmissionStatus | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
   const lineNumberRef = useRef<HTMLDivElement | null>(null);
 
   const handleLanguageChange = (newLanguage: string) => {
-    // 현재 언어의 코드를 저장하고, 새 언어의 코드를 불러오기
     setLanguageCodes((prev) => {
-      const updated = {
-        ...prev,
-        [language]: code,
-      }
-      // 새 언어의 저장된 코드를 불러오기 (없으면 기본 템플릿 사용)
+      const updated = { ...prev, [language]: code }
       const newCode = updated[newLanguage] || defaultCodeTemplates[newLanguage] || defaultCodeTemplates.python
       setCode(newCode)
       return updated
     })
-    // 새 언어로 변경
     setLanguage(newLanguage)
   }
 
@@ -97,11 +128,36 @@ export function CodeEditorSection({ isReadOnly = false }: CodeEditorSectionProps
     }
   };
 
-  const MIN_LINES = 15;
+  /** 코드 제출 핸들러 */
+  const handleSubmit = async () => {
+    if (!examId) {
+      setSubmitError("시험 정보가 없습니다.")
+      return
+    }
+    if (!code.trim()) {
+      setSubmitError("코드를 작성해주세요.")
+      return
+    }
 
+    setIsSubmitting(true)
+    setSubmitError(null)
+    setSubmitStatus("PENDING")
+
+    try {
+      const result = await submitCode(examId, { lang: language, code })
+      setSubmitStatus(result.status)
+      onSubmitted?.(result.submissionId)
+    } catch (err: any) {
+      setSubmitError(err.message || "코드 제출에 실패했습니다.")
+      setSubmitStatus(null)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const MIN_LINES = 15;
   const actualLineCount = code.split("\n").length || 1;
   const lineCount = Math.max(MIN_LINES, actualLineCount);
-
   const lineNumbers = Array.from({ length: lineCount }, (_, i) => i + 1);
 
   return (
@@ -109,18 +165,58 @@ export function CodeEditorSection({ isReadOnly = false }: CodeEditorSectionProps
       {/* Editor Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#E5E7EB]">
         <span className="text-sm font-medium text-[#1F2937]">Code Editor</span>
-        <Select value={language} onValueChange={handleLanguageChange} disabled={isReadOnly}>
-          <SelectTrigger className="w-[140px] h-8 text-sm">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="python">Python</SelectItem>
-            <SelectItem value="java">Java</SelectItem>
-            <SelectItem value="cpp">C++</SelectItem>
-            <SelectItem value="javascript">JavaScript</SelectItem>
-          </SelectContent>
-        </Select>
+        <div className="flex items-center gap-3">
+          <Select value={language} onValueChange={handleLanguageChange} disabled={isReadOnly}>
+            <SelectTrigger className="w-[140px] h-8 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="python">Python</SelectItem>
+              <SelectItem value="java">Java</SelectItem>
+              <SelectItem value="cpp">C++</SelectItem>
+              <SelectItem value="javascript">JavaScript</SelectItem>
+            </SelectContent>
+          </Select>
+
+          {/* 제출 버튼 — isReadOnly일 때 숨김 */}
+          {!isReadOnly && examId && (
+            <button
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              className="h-8 px-4 text-sm font-medium rounded-md bg-[#2563EB] text-white hover:bg-[#1D4ED8] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              {isSubmitting ? "제출 중…" : "코드 제출"}
+            </button>
+          )}
+        </div>
       </div>
+
+      {/* 제출 상태 배너 */}
+      {(submitStatus || submitError) && (
+        <div
+          className={`px-4 py-2 text-sm font-medium flex items-center gap-2 ${
+            submitError
+              ? "text-[#DC2626] bg-[#FEF2F2]"
+              : submitStatus
+              ? STATUS_COLOR[submitStatus]
+              : ""
+          }`}
+        >
+          {submitError ? (
+            <span>⚠️ {submitError}</span>
+          ) : submitStatus ? (
+            <>
+              <span>{STATUS_LABEL[submitStatus]}</span>
+              {(submitStatus === "PENDING" || submitStatus === "JUDGING") && (
+                <svg className="animate-spin w-4 h-4 ml-1" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                </svg>
+              )}
+            </>
+          ) : null}
+        </div>
+      )}
 
       {/* Editor Content */}
       <div className="flex flex-1 min-h-0">

--- a/components/dashboard-content.tsx
+++ b/components/dashboard-content.tsx
@@ -1,9 +1,11 @@
 "use client"
 
+import { useState, useEffect } from "react"
 import Link from "next/link"
-import { Users, CheckCircle, TrendingUp, Play, Plus, BarChart3, ArrowRight } from "lucide-react"
+import { Users, CheckCircle, Play, Plus, BarChart3, ArrowRight } from "lucide-react"
+import { getExams, getBoard } from "@/lib/api/admin"
 
-// Sample recent activity data
+// Sample recent activity data (정적 - 활동 로그 API 미지원)
 const recentActivity = [
   {
     id: 1,
@@ -43,14 +45,47 @@ function getStatusColor(status: string) {
 }
 
 export function DashboardContent() {
+  const [totalParticipants, setTotalParticipants] = useState<number | null>(null)
+  const [completedCount, setCompletedCount] = useState<number | null>(null)
+  const [runningExams, setRunningExams] = useState<number | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    async function loadStats() {
+      try {
+        const exams = await getExams()
+        const running = exams.filter(
+          (e) => e.state === "RUNNING" || e.state === "IN_PROGRESS"
+        ).length
+        setRunningExams(running)
+
+        // 각 시험의 보드를 병렬로 조회해 참가자 수 집계
+        const boards = await Promise.all(
+          exams.map((e) => getBoard(e.id).catch(() => []))
+        )
+        const allParticipants = boards.flat()
+        setTotalParticipants(allParticipants.length)
+        setCompletedCount(allParticipants.filter((p) => p.submitted).length)
+      } catch (e) {
+        console.error("Failed to load dashboard stats", e)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    loadStats()
+  }, [])
+
+  const displayValue = (val: number | null) =>
+    isLoading ? "..." : val !== null ? val.toLocaleString() : "–"
+
   return (
     <div className="flex h-full flex-1 flex-col">
-      {/* Section 2: Top Header Bar - distinct horizontal section */}
+      {/* Section 2: Top Header Bar */}
       <header className="flex h-[88px] shrink-0 items-center border-b border-[#E5E5E5] bg-white px-8">
         <h1 className="text-2xl font-semibold text-[#1A1A1A]">관리자 대시보드</h1>
       </header>
 
-      {/* Section 3: Main Content Panel - separate content area */}
+      {/* Section 3: Main Content Panel */}
       <main className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-6">
         {/* 1) Metric Summary Cards */}
         <div className="grid grid-cols-4 gap-4">
@@ -62,8 +97,8 @@ export function DashboardContent() {
               </div>
               <span className="text-sm font-medium text-gray-500">총 참가자 수</span>
             </div>
-            <p className="mt-6 text-4xl font-bold text-gray-900">248</p>
-            <p className="mt-1 text-xs text-gray-400">최근 7일 기준</p>
+            <p className="mt-6 text-4xl font-bold text-gray-900">{displayValue(totalParticipants)}</p>
+            <p className="mt-1 text-xs text-gray-400">전체 시험 기준</p>
           </div>
 
           {/* Completed Evaluations */}
@@ -74,20 +109,24 @@ export function DashboardContent() {
               </div>
               <span className="text-sm font-medium text-gray-500">평가 완료 수</span>
             </div>
-            <p className="mt-6 text-4xl font-bold text-gray-900">186</p>
-            <p className="mt-1 text-xs text-gray-400">완료율 75%</p>
+            <p className="mt-6 text-4xl font-bold text-gray-900">{displayValue(completedCount)}</p>
+            <p className="mt-1 text-xs text-gray-400">
+              {!isLoading && totalParticipants !== null && totalParticipants > 0
+                ? `완료율 ${Math.round(((completedCount ?? 0) / totalParticipants) * 100)}%`
+                : "코드 제출 기준"}
+            </p>
           </div>
 
-          {/* Average Prompt Score */}
+          {/* Average Prompt Score - no API available */}
           <div className="flex flex-col rounded-xl border border-[#E5E5E5] bg-white px-6 py-8 shadow-sm">
             <div className="flex items-center gap-3">
               <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-50">
-                <TrendingUp className="h-5 w-5 text-purple-500" />
+                <svg className="h-5 w-5 text-purple-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
               </div>
               <span className="text-sm font-medium text-gray-500">평균 프롬프트 점수</span>
             </div>
-            <p className="mt-6 text-4xl font-bold text-gray-900">78.5</p>
-            <p className="mt-1 text-xs text-gray-400">지난주 대비 +2.3</p>
+            <p className="mt-6 text-4xl font-bold text-gray-900">–</p>
+            <p className="mt-1 text-xs text-gray-400">채점 완료 후 집계</p>
           </div>
 
           {/* Active Test Sessions */}
@@ -98,7 +137,7 @@ export function DashboardContent() {
               </div>
               <span className="text-sm font-medium text-gray-500">진행 중인 테스트 세션</span>
             </div>
-            <p className="mt-6 text-4xl font-bold text-gray-900">4</p>
+            <p className="mt-6 text-4xl font-bold text-gray-900">{displayValue(runningExams)}</p>
             <p className="mt-1 text-xs text-gray-400">현재 진행 중</p>
           </div>
         </div>
@@ -125,7 +164,7 @@ export function DashboardContent() {
                 <div className="absolute left-[5px] top-2 bottom-2 w-[2px] bg-gray-200" />
 
                 <div className="space-y-5">
-                  {recentActivity.map((event, index) => (
+                  {recentActivity.map((event) => (
                     <div key={event.id} className="flex items-start gap-3 pl-6 relative">
                       {/* Timeline dot */}
                       <div className={`absolute left-0 top-1.5 h-3 w-3 rounded-full ${getStatusColor(event.status)}`} />

--- a/components/entry-codes-content.tsx
+++ b/components/entry-codes-content.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { createExam, getExams, createEntryCode, deleteExam, getEntryCodes, startExam, endExam, Exam, LoginFailedError, NetworkError } from "@/lib/api/admin"
+import { createExam, getExams, createEntryCode, deleteExam, getEntryCodes, startExam, endExam, extendExam, Exam, LoginFailedError, NetworkError } from "@/lib/api/admin"
 import { useToast } from "@/hooks/use-toast"
 
 
@@ -79,6 +79,12 @@ export function EntryCodesContent() {
   const [isEndExamModalOpen, setIsEndExamModalOpen] = useState(false)
   const [selectedExamForEnd, setSelectedExamForEnd] = useState<Exam | null>(null)
   const [isEndingExam, setIsEndingExam] = useState(false)
+
+  // 시험 연장 모달 상태
+  const [isExtendExamModalOpen, setIsExtendExamModalOpen] = useState(false)
+  const [selectedExamForExtend, setSelectedExamForExtend] = useState<Exam | null>(null)
+  const [extendMinutes, setExtendMinutes] = useState("30")
+  const [isExtendingExam, setIsExtendingExam] = useState(false)
 
   const { toast } = useToast()
 
@@ -392,6 +398,48 @@ export function EntryCodesContent() {
     }
   }
 
+  // 시험 연장 핸들러
+  const handleExtendExam = (exam: Exam) => {
+    setSelectedExamForExtend(exam)
+    setExtendMinutes("30")
+    setIsExtendExamModalOpen(true)
+  }
+
+  // 시험 연장 확인 핸들러
+  const handleConfirmExtendExam = async () => {
+    if (!selectedExamForExtend) return
+    const mins = parseInt(extendMinutes, 10)
+    if (!mins || mins <= 0) {
+      toast({
+        title: "입력 오류",
+        description: "연장 시간은 1분 이상이어야 합니다.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    setIsExtendingExam(true)
+    try {
+      await extendExam(selectedExamForExtend.id, mins)
+      await handleFetchExams()
+      setIsExtendExamModalOpen(false)
+      setSelectedExamForExtend(null)
+      toast({
+        title: "시험 연장 성공",
+        description: `"${selectedExamForExtend.title}" 시험이 ${mins}분 연장되었습니다.`,
+      })
+    } catch (error) {
+      console.error("Failed to extend exam", error)
+      toast({
+        title: "시험 연장 실패",
+        description: error instanceof Error ? error.message : "시험 연장 중 오류가 발생했습니다.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsExtendingExam(false)
+    }
+  }
+
   // 시험 삭제 핸들러
   const handleDeleteExam = (exam: Exam) => {
     setSelectedExamForDelete(exam)
@@ -583,7 +631,12 @@ export function EntryCodesContent() {
                           <MoreVertical className="h-5 w-5" strokeWidth={1.5} />
                         </button>
                       </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end" className="w-32">
+                      <DropdownMenuContent align="end" className="w-36">
+                        {(exam.state === "RUNNING" || exam.state === "IN_PROGRESS") && (
+                          <DropdownMenuItem onClick={() => handleExtendExam(exam)}>
+                            시간 연장
+                          </DropdownMenuItem>
+                        )}
                         <DropdownMenuItem
                           onClick={() => handleDeleteExam(exam)}
                           className="text-red-600 focus:text-red-600"
@@ -730,6 +783,48 @@ export function EntryCodesContent() {
             </Button>
             <Button onClick={handleConfirmDeleteExam} disabled={isDeletingExam} variant="destructive">
               {isDeletingExam ? "삭제 중..." : "삭제"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Extend Exam Modal */}
+      <Dialog open={isExtendExamModalOpen} onOpenChange={setIsExtendExamModalOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>시험 시간 연장</DialogTitle>
+            <DialogDescription className="pt-2 text-[#6B7280]">
+              {selectedExamForExtend
+                ? `"${selectedExamForExtend.title}" 시험의 종료 시각을 연장합니다.`
+                : "시험 시간을 연장합니다."}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="space-y-2">
+              <label htmlFor="extend-minutes" className="text-sm font-medium text-[#1A1A1A]">
+                연장 시간 (분)
+              </label>
+              <Input
+                id="extend-minutes"
+                type="number"
+                min="1"
+                placeholder="30"
+                value={extendMinutes}
+                onChange={(e) => setExtendMinutes(e.target.value)}
+                disabled={isExtendingExam}
+              />
+            </div>
+          </div>
+          <DialogFooter className="flex flex-row justify-end gap-4">
+            <Button
+              variant="outline"
+              onClick={() => setIsExtendExamModalOpen(false)}
+              disabled={isExtendingExam}
+            >
+              취소
+            </Button>
+            <Button onClick={handleConfirmExtendExam} disabled={isExtendingExam}>
+              {isExtendingExam ? "연장 중..." : "연장"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/components/master-dashboard-content.tsx
+++ b/components/master-dashboard-content.tsx
@@ -33,7 +33,7 @@ const recentLogs = [
 ]
 
 type DashboardContentProps = {
-  onNavigate: (page: string) => void
+  onNavigate?: (page: string) => void
 }
 
 export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {

--- a/components/master-dashboard.tsx
+++ b/components/master-dashboard.tsx
@@ -6,7 +6,7 @@ import { TopNavBar } from "@/components/top-nav-bar"
 import { DashboardContent } from "@/components/dashboard-content"
 import { AdminAccountsContent } from "@/components/admin-accounts-content"
 import { TestSessionsContent } from "@/components/test-sessions-content"
-import { TestSessionDetailsContent } from "@/components/test-session-details-content"
+import TestSessionDetailsContent from "@/components/test-session-details-content"
 import { GlobalSettingsContent } from "@/components/global-settings-content"
 import { ProblemContent } from "@/components/problem-content"
 import { PlatformLogsContent } from "@/components/platform-logs-content"
@@ -49,7 +49,7 @@ export function MasterDashboard() {
         </div>
 
         <main className="flex-1 mt-[80px] overflow-y-auto">
-          {activeItem === "Dashboard" && <DashboardContent onNavigate={handleSidebarItemClick} />}
+          {activeItem === "Dashboard" && <DashboardContent />}
           {activeItem === "Admin Accounts" && <AdminAccountsContent />}
           {activeItem === "Test Sessions" && !selectedSession && (
             <TestSessionsContent onViewDetails={handleViewSessionDetails} />

--- a/components/participant-evaluation-content.tsx
+++ b/components/participant-evaluation-content.tsx
@@ -1,12 +1,14 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Link from "next/link"
 import { ArrowLeft, User, Code, CheckCircle, X } from "lucide-react"
+import { useRouter } from "next/navigation"
+import { getExams, getBoard } from "@/lib/api/admin"
 
 interface ParticipantEvaluationContentProps {
   entryCode: string
-  participantName: string;   // ✅ 새로 추가
+  participantName?: string   // 선택적 — URL query 또는 board에서 로드
   participantId: string
   onBack?: () => void;
 }
@@ -221,8 +223,44 @@ function downloadCSV() {
   URL.revokeObjectURL(url)
 }
 
-export function ParticipantEvaluationContent({ entryCode, participantId, onBack, }: ParticipantEvaluationContentProps) {
+export function ParticipantEvaluationContent({ entryCode, participantName: participantNameProp, participantId, onBack }: ParticipantEvaluationContentProps) {
+  const router = useRouter()
   const [toasts, setToasts] = useState<ToastItem[]>([])
+
+  // 실제 참가자 정보 (board에서 로드)
+  const [boardParticipantName, setBoardParticipantName] = useState<string | null>(null)
+  const [tokenUsed, setTokenUsed] = useState<number | null>(null)
+  const [submitted, setSubmitted] = useState<boolean | null>(null)
+  const [isLoadingBoard, setIsLoadingBoard] = useState(true)
+
+  useEffect(() => {
+    async function loadParticipantFromBoard() {
+      setIsLoadingBoard(true)
+      try {
+        const exams = await getExams()
+        const matched = exams.find((e) => e.entryCode === entryCode)
+        if (!matched) {
+          setIsLoadingBoard(false)
+          return
+        }
+        const board = await getBoard(matched.id)
+        const entry = board.find((p) => p.examParticipantId.toString() === participantId)
+        if (entry) {
+          setBoardParticipantName(entry.name)
+          setTokenUsed(entry.tokenUsed)
+          setSubmitted(entry.submitted)
+        }
+      } catch (e) {
+        console.error("Failed to load participant from board", e)
+      } finally {
+        setIsLoadingBoard(false)
+      }
+    }
+    loadParticipantFromBoard()
+  }, [entryCode, participantId])
+
+  // 이름 우선순위: prop > board > fallback
+  const displayName = participantNameProp || boardParticipantName || participantData.name
 
   const showToast = (title: string, description: string) => {
     const id = crypto.randomUUID()
@@ -287,34 +325,28 @@ export function ParticipantEvaluationContent({ entryCode, participantId, onBack,
               <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#E0EDFF]">
                 <User className="h-5 w-5 text-[#3B82F6]" strokeWidth={1.5} />
               </div>
-              <span className="text-base font-semibold text-[#1A1A1A]">{participantData.name}</span>
+              <span className="text-base font-semibold text-[#1A1A1A]">
+                {isLoadingBoard ? "..." : displayName}
+              </span>
             </div>
           </div>
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
             <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">입장 코드</span>
-            <p className="mt-3 text-lg font-semibold text-[#1A1A1A]">{participantData.entryCode}</p>
+            <p className="mt-3 text-lg font-semibold text-[#1A1A1A]">{entryCode}</p>
           </div>
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">평균 점수</span>
-            <p className="mt-3 text-lg font-semibold text-[#1A1A1A]">{participantData.avgScore}%</p>
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">토큰 사용량</span>
+            <p className="mt-3 text-lg font-semibold text-[#1A1A1A]">
+              {isLoadingBoard ? "..." : tokenUsed !== null ? tokenUsed.toLocaleString() : "–"}
+            </p>
           </div>
         </div>
 
         {/* Summary Cards - Row 2 */}
         <div className="mb-6 grid grid-cols-3 gap-4">
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">시험 일시 및 소요 시간</span>
-            <p className="mt-3 text-base font-semibold text-[#1A1A1A]">
-              {(() => {
-                const dateParts = participantData.testDate.split("-")
-                const year = dateParts[0]
-                const month = parseInt(dateParts[1], 10)
-                const day = parseInt(dateParts[2], 10)
-                const durationMatch = participantData.duration.match(/(\d+)\s*minutes?/i)
-                const minutes = durationMatch ? durationMatch[1] : participantData.duration
-                return `${year}년 ${month}월 ${day}일 · ${minutes}분`
-              })()}
-            </p>
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">참가자 ID</span>
+            <p className="mt-3 text-base font-semibold text-[#1A1A1A]">{participantId}</p>
           </div>
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
             <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">성과 수준</span>
@@ -325,7 +357,13 @@ export function ParticipantEvaluationContent({ entryCode, participantId, onBack,
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
             <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">제출 상태</span>
             <div className="mt-3">
-              <StatusBadge status={participantData.status} />
+              {isLoadingBoard ? (
+                <span className="text-sm text-[#6B7280]">...</span>
+              ) : submitted !== null ? (
+                <StatusBadge status={submitted ? "Submitted" : "In Progress"} />
+              ) : (
+                <StatusBadge status={participantData.status} />
+              )}
             </div>
           </div>
         </div>

--- a/components/participant-list-content.tsx
+++ b/components/participant-list-content.tsx
@@ -1,85 +1,23 @@
 "use client"
 
-import { useState, useMemo } from "react"
+import { useState, useEffect, useMemo } from "react"
 import Link from "next/link"
-import { usePathname } from "next/navigation";
 import { ArrowLeft, Eye, ChevronLeft, ChevronRight } from "lucide-react"
+import { getExams, getBoard, ExamineeBoardEntry } from "@/lib/api/admin"
 
 type TrendLevel = "High" | "Average" | "Low"
 
 interface ParticipantDetail {
   id: string
   name: string
-  avgScore: number
+  tokenUsed: number
+  tokenLimit: number
+  submitted: boolean
   trend: TrendLevel
 }
 
 interface ParticipantListContentProps {
   entryCode: string
-}
-
-const sampleParticipants: ParticipantDetail[] = [
-  { id: "1", name: "Alice Johnson", avgScore: 92, trend: "High" },
-  { id: "2", name: "Bob Smith", avgScore: 84, trend: "Average" },
-  { id: "3", name: "Carol Davis", avgScore: 70, trend: "Low" },
-  { id: "4", name: "David Lee", avgScore: 88, trend: "High" },
-  { id: "5", name: "Emma Wilson", avgScore: 91, trend: "High" },
-  { id: "6", name: "Frank Brown", avgScore: 76, trend: "Average" },
-  { id: "7", name: "Grace Kim", avgScore: 68, trend: "Low" },
-  { id: "8", name: "Henry Chen", avgScore: 85, trend: "Average" },
-  { id: "9", name: "Ivy Martinez", avgScore: 94, trend: "High" },
-  { id: "10", name: "Jack Thompson", avgScore: 72, trend: "Low" },
-  { id: "11", name: "Karen White", avgScore: 89, trend: "High" },
-  { id: "12", name: "Leo Garcia", avgScore: 78, trend: "Average" },
-  { id: "13", name: "Mia Robinson", avgScore: 65, trend: "Low" },
-  { id: "14", name: "Nathan Clark", avgScore: 90, trend: "High" },
-  { id: "15", name: "Olivia Hall", avgScore: 82, trend: "Average" },
-  { id: "16", name: "Peter Young", avgScore: 71, trend: "Low" },
-  { id: "17", name: "Quinn Adams", avgScore: 87, trend: "High" },
-  { id: "18", name: "Rachel King", avgScore: 79, trend: "Average" },
-  { id: "19", name: "Sam Wright", avgScore: 67, trend: "Low" },
-  { id: "20", name: "Tina Scott", avgScore: 93, trend: "High" },
-  { id: "21", name: "Uma Patel", avgScore: 81, trend: "Average" },
-  { id: "22", name: "Victor Lopez", avgScore: 69, trend: "Low" },
-  { id: "23", name: "Wendy Hill", avgScore: 86, trend: "High" },
-  { id: "24", name: "Xavier Moore", avgScore: 77, trend: "Average" },
-  { id: "25", name: "Yuki Tanaka", avgScore: 64, trend: "Low" },
-  { id: "26", name: "Zara Nelson", avgScore: 95, trend: "High" },
-  { id: "27", name: "Aaron Baker", avgScore: 80, trend: "Average" },
-  { id: "28", name: "Bella Carter", avgScore: 66, trend: "Low" },
-  { id: "29", name: "Chris Evans", avgScore: 91, trend: "High" },
-  { id: "30", name: "Diana Foster", avgScore: 83, trend: "Average" },
-  { id: "31", name: "Eric Green", avgScore: 73, trend: "Low" },
-  { id: "32", name: "Fiona Hughes", avgScore: 88, trend: "High" },
-  { id: "33", name: "George Irving", avgScore: 75, trend: "Average" },
-  { id: "34", name: "Hannah James", avgScore: 62, trend: "Low" },
-  { id: "35", name: "Ian Kelly", avgScore: 90, trend: "High" },
-  { id: "36", name: "Julia Lewis", avgScore: 84, trend: "Average" },
-  { id: "37", name: "Kevin Morgan", avgScore: 70, trend: "Low" },
-  { id: "38", name: "Luna Nash", avgScore: 92, trend: "High" },
-  { id: "39", name: "Mark Owen", avgScore: 78, trend: "Average" },
-  { id: "40", name: "Nina Price", avgScore: 68, trend: "Low" },
-  { id: "41", name: "Oscar Quinn", avgScore: 89, trend: "High" },
-  { id: "42", name: "Paula Reed", avgScore: 81, trend: "Average" },
-  { id: "43", name: "Quentin Stone", avgScore: 63, trend: "Low" },
-  { id: "44", name: "Rosa Turner", avgScore: 94, trend: "High" },
-  { id: "45", name: "Steve Underwood", avgScore: 76, trend: "Average" },
-  { id: "46", name: "Tara Vance", avgScore: 69, trend: "Low" },
-  { id: "47", name: "Ulysses Ward", avgScore: 87, trend: "High" },
-  { id: "48", name: "Vera Xavier", avgScore: 82, trend: "Average" },
-  { id: "49", name: "Will York", avgScore: 71, trend: "Low" },
-  { id: "50", name: "Xena Zhang", avgScore: 96, trend: "High" },
-  { id: "51", name: "Yosef Ali", avgScore: 79, trend: "Average" },
-  { id: "52", name: "Zoe Brooks", avgScore: 65, trend: "Low" },
-  { id: "53", name: "Adam Cole", avgScore: 91, trend: "High" },
-  { id: "54", name: "Beth Davis", avgScore: 85, trend: "Average" },
-]
-
-// Summary data - in real app this would be fetched based on entryCode
-const summaryData = {
-  entryCode: "AIV-2024-001",
-  totalParticipants: 54,
-  completed: 54,
 }
 
 function TrendBadge({ trend }: { trend: TrendLevel }) {
@@ -88,59 +26,88 @@ function TrendBadge({ trend }: { trend: TrendLevel }) {
     Average: "bg-[#FEF3C7] text-[#D97706]",
     Low: "bg-[#FEE2E2] text-[#DC2626]",
   }
-
   const trendText: Record<TrendLevel, string> = {
-    High: "높음",
-    Average: "보통",
-    Low: "낮음",
+    High: "완료",
+    Average: "진행 중",
+    Low: "미시작",
   }
-
   return <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${styles[trend]}`}>{trendText[trend]}</span>
 }
 
+function getTrend(entry: ExamineeBoardEntry): TrendLevel {
+  if (entry.submitted) return "High"
+  if (entry.state === "ENTRANCE") return "Average"
+  return "Low"
+}
+
 export function ParticipantListContent({ entryCode }: ParticipantListContentProps) {
-  // Use the passed entryCode or fallback to sample data
-  const pathname = usePathname();
-
-  // URL (/admin/results/AIV-2024-001) 에서 마지막 세그먼트를 추출
-  const displayEntryCode = useMemo(() => {
-    if (!pathname) {
-      return entryCode || summaryData.entryCode;
-    }
-
-    const segments = pathname.split("/");
-    const fromPath = decodeURIComponent(segments[segments.length - 1] || "");
-
-    // 1순위: props로 받은 entryCode
-    // 2순위: URL에서 파싱한 값
-    // 3순위: 없으면 샘플 데이터/기본값
-    return entryCode || fromPath || summaryData.entryCode;
-  }, [pathname, entryCode]);
+  const [examId, setExamId] = useState<number | null>(null)
+  const [examTitle, setExamTitle] = useState<string>("")
+  const [participants, setParticipants] = useState<ParticipantDetail[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   const pageSize = 10
   const [page, setPage] = useState(1)
 
-  const totalParticipants = sampleParticipants.length
-  const totalPages = Math.ceil(totalParticipants / pageSize)
+  // entryCode → examId 변환 후 board 조회
+  useEffect(() => {
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        // 1) 시험 목록에서 entryCode에 매핑된 examId 찾기
+        const exams = await getExams()
+        const matched = exams.find((e) => e.entryCode === entryCode)
+        if (!matched) {
+          // entryCode로 직접 매핑이 안 될 때 — 첫 번째 시험 또는 에러
+          setError("해당 입장 코드에 대한 시험을 찾을 수 없습니다.")
+          setIsLoading(false)
+          return
+        }
+
+        setExamId(matched.id)
+        setExamTitle(matched.title)
+
+        // 2) board 조회
+        const board = await getBoard(matched.id)
+        const mapped: ParticipantDetail[] = board.map((p) => ({
+          id: p.examParticipantId.toString(),
+          name: p.name,
+          tokenUsed: p.tokenUsed,
+          tokenLimit: p.tokenLimit,
+          submitted: p.submitted,
+          trend: getTrend(p),
+        }))
+        setParticipants(mapped)
+        setPage(1)
+      } catch (e) {
+        console.error("Failed to load participant list", e)
+        setError("참가자 목록을 불러오는 데 실패했습니다.")
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    load()
+  }, [entryCode])
+
+  const totalParticipants = participants.length
+  const totalPages = Math.max(1, Math.ceil(totalParticipants / pageSize))
   const startIndex = (page - 1) * pageSize
   const endIndex = startIndex + pageSize
-  const pageParticipants = sampleParticipants.slice(startIndex, endIndex)
+  const pageParticipants = participants.slice(startIndex, endIndex)
+  const completedCount = useMemo(() => participants.filter((p) => p.submitted).length, [participants])
 
-  const handlePrevPage = () => {
-    if (page > 1) setPage(page - 1)
-  }
-
-  const handleNextPage = () => {
-    if (page < totalPages) setPage(page + 1)
-  }
+  const handlePrevPage = () => setPage((p) => Math.max(1, p - 1))
+  const handleNextPage = () => setPage((p) => Math.min(totalPages, p + 1))
 
   return (
     <div className="flex h-full flex-1 flex-col">
       {/* Top Header Bar */}
       <header className="flex h-[88px] shrink-0 items-center border-b border-[#E5E5E5] bg-white px-8">
         <div>
-          <h1 className="text-2xl font-semibold text-[#1A1A1A]">참가자 목록 (입장 코드 요약)</h1>
-          <p className="text-sm text-[#6B7280]">해당 입장 코드의 참가자 점수 및 성과를 확인합니다.</p>
+          <h1 className="text-2xl font-semibold text-[#1A1A1A]">참가자 목록</h1>
+          <p className="text-sm text-[#6B7280]">해당 입장 코드의 참가자 현황을 확인합니다.</p>
         </div>
       </header>
 
@@ -160,75 +127,99 @@ export function ParticipantListContent({ entryCode }: ParticipantListContentProp
         {/* Summary Card */}
         <div className="mb-6 shrink-0 rounded-xl border border-[#E5E5E5] bg-white px-12 py-6 shadow-sm">
           <div className="flex items-center gap-16">
-            {/* Entry Code */}
             <div className="flex flex-col gap-1">
               <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">입장 코드</span>
-              <span className="text-lg font-semibold text-[#1A1A1A]">{displayEntryCode}</span>
+              <span className="text-lg font-semibold text-[#1A1A1A]">{entryCode}</span>
             </div>
-
-            {/* Total Participants */}
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">시험명</span>
+              <span className="text-lg font-semibold text-[#1A1A1A]">{examTitle || "–"}</span>
+            </div>
             <div className="flex flex-col gap-1">
               <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">총 참가자 수</span>
-              <span className="text-lg font-semibold text-[#1A1A1A]">{summaryData.totalParticipants}</span>
+              <span className="text-lg font-semibold text-[#1A1A1A]">
+                {isLoading ? "..." : totalParticipants}
+              </span>
             </div>
-
-            {/* Completed */}
             <div className="flex flex-col gap-1">
               <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">완료 인원</span>
-              <span className="text-lg font-semibold text-[#1A1A1A]">{summaryData.completed}</span>
+              <span className="text-lg font-semibold text-[#1A1A1A]">
+                {isLoading ? "..." : completedCount}
+              </span>
             </div>
           </div>
         </div>
 
-        {/* Participant Table Container - Restructured for pagination inside card */}
+        {/* Error State */}
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+            <p className="text-sm text-red-600">{error}</p>
+          </div>
+        )}
+
+        {/* Participant Table Container */}
         <div className="flex flex-1 flex-col overflow-hidden rounded-xl border border-[#E5E5E5] bg-white shadow-sm">
           {/* Table Header */}
           <div className="grid shrink-0 grid-cols-[2fr_1fr_1fr_1fr] gap-4 border-b border-[#E5E5E5] bg-[#F9FAFB] px-12 py-3">
             <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">참가자</span>
-            <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">평균 점수</span>
-            <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">성과 수준</span>
+            <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">토큰 사용량</span>
+            <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">제출 상태</span>
             <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">상세 보기</span>
           </div>
 
-          {/* Table Body - Uses pageParticipants instead of full array */}
+          {/* Table Body */}
           <div className="flex-1 overflow-y-auto px-12">
-            {pageParticipants.map((participant, index) => (
-              <div
-                key={participant.id}
-                className={`grid grid-cols-[2fr_1fr_1fr_1fr] items-center gap-4 py-4 ${
-                  index !== pageParticipants.length - 1 ? "border-b border-[#E5E5E5]" : ""
-                }`}
-              >
-                <span className="text-sm font-medium text-[#1A1A1A]">{participant.name}</span>
-                <span className="text-center text-sm font-medium text-[#1A1A1A]">{participant.avgScore}%</span>
-                <div className="flex justify-center">
-                  <TrendBadge trend={participant.trend} />
-                </div>
-                <div className="flex justify-center">
-                  <Link
-                    href={{
-                      // 참가자 상세 페이지 경로: /admin/results/[entryCode]/[participantId]
-                      pathname: `/admin/results/${encodeURIComponent(displayEntryCode)}/${encodeURIComponent(participant.id)}`,
-                      // 여기에 우리가 넘기고 싶은 값들 추가
-                      query: {
-                        entryCode: displayEntryCode,       // 상단 카드에 보여줄 Entry Code
-                        participantName: participant.name, // 상단 카드에 보여줄 이름
-                        from: "results",                   // 기존에 쓰던 from 값 유지하고 싶으면 같이 전달
-                      },
-                    }}
-                    className="inline-flex items-center gap-1.5 rounded-md border-[#3B82F6] bg-white px-3 py-1.5 text-sm text-[#3B82F6] hover:bg-[#EFF6FF]"
-                  >
-                    <Eye className="h-3.5 w-3.5" strokeWidth={1.5} />
-                    상세 보기
-                  </Link>
-                </div>
+            {isLoading ? (
+              <div className="flex items-center justify-center py-16">
+                <p className="text-sm text-[#6B7280]">불러오는 중...</p>
               </div>
-            ))}
+            ) : pageParticipants.length === 0 ? (
+              <div className="flex items-center justify-center py-16">
+                <p className="text-sm text-[#6B7280]">참가자가 없습니다.</p>
+              </div>
+            ) : (
+              pageParticipants.map((participant, index) => (
+                <div
+                  key={participant.id}
+                  className={`grid grid-cols-[2fr_1fr_1fr_1fr] items-center gap-4 py-4 ${
+                    index !== pageParticipants.length - 1 ? "border-b border-[#E5E5E5]" : ""
+                  }`}
+                >
+                  <span className="text-sm font-medium text-[#1A1A1A]">{participant.name}</span>
+                  <span className="text-center text-sm font-medium text-[#1A1A1A]">
+                    {participant.tokenUsed.toLocaleString()}
+                    {participant.tokenLimit > 0 && (
+                      <span className="ml-1 text-xs text-[#9CA3AF]">/ {participant.tokenLimit.toLocaleString()}</span>
+                    )}
+                  </span>
+                  <div className="flex justify-center">
+                    <TrendBadge trend={participant.trend} />
+                  </div>
+                  <div className="flex justify-center">
+                    <Link
+                      href={{
+                        pathname: `/admin/results/${encodeURIComponent(entryCode)}/${encodeURIComponent(participant.id)}`,
+                        query: {
+                          entryCode,
+                          participantName: participant.name,
+                          from: "results",
+                        },
+                      }}
+                      className="inline-flex items-center gap-1.5 rounded-md border-[#3B82F6] bg-white px-3 py-1.5 text-sm text-[#3B82F6] hover:bg-[#EFF6FF]"
+                    >
+                      <Eye className="h-3.5 w-3.5" strokeWidth={1.5} />
+                      상세 보기
+                    </Link>
+                  </div>
+                </div>
+              ))
+            )}
           </div>
 
           <div className="flex shrink-0 items-center justify-between border-t border-[#E5E5E5] bg-white px-12 py-3">
             <p className="text-sm text-[#6B7280]">
-              총 {totalParticipants}명 중 {startIndex + 1}–{Math.min(endIndex, totalParticipants)}명 표시
+              총 {totalParticipants}명 중{" "}
+              {totalParticipants > 0 ? `${startIndex + 1}–${Math.min(endIndex, totalParticipants)}` : "0"}명 표시
             </p>
             <div className="flex items-center gap-2">
               <button

--- a/components/problem-section.tsx
+++ b/components/problem-section.tsx
@@ -1,37 +1,52 @@
-export function ProblemSection() {
+"use client"
+
+import { useState, useEffect } from "react"
+import { getAssignment, AssignmentResponse } from "@/lib/api/exams"
+
+interface ProblemSectionProps {
+  examId: number
+}
+
+export function ProblemSection({ examId }: ProblemSectionProps) {
+  const [assignment, setAssignment] = useState<AssignmentResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    getAssignment(examId)
+      .then(setAssignment)
+      .catch(() => {/* 로드 실패 시 null 유지 */})
+      .finally(() => setLoading(false))
+  }, [examId])
+
+  const problem = assignment?.problem
+
   return (
     <div className="bg-white rounded-xl border border-[#D0D0D0] p-6 flex-shrink-0">
-      <h2 className="text-lg font-semibold text-[#1F2937] mb-4">문제 1. 외판원 순회</h2>
+      <h2 className="text-lg font-semibold text-[#1F2937] mb-4">
+        {loading ? "문제 로딩 중..." : problem ? `문제. ${problem.title}` : "문제를 불러올 수 없습니다."}
+      </h2>
 
-      <div className="text-[#4B5563] text-sm leading-relaxed mb-6">
-        <p className="mb-3">
-          1번부터 N번까지 번호가 매겨진 도시들이 있고, 각 도시 쌍 사이의 이동 비용이 주어집니다. 한 도시에서 출발하여 모든 도시를 정확히 한 번씩 방문한 뒤, 다시 출발 도시로 돌아오는 외판원 순회 경로 중 최소 비용을 구하는 프로그램을 작성하세요.
-        </p>
-        <p className="mb-3">
-          이동할 수 없는 경우 비용이 0으로 주어지며, 항상 적어도 하나 이상의 완전한 순회가 존재하는 입력만 주어집니다.
-        </p>
-        <p>
-          <span className="font-medium text-[#1F2937]">제약 조건:</span> 2 ≤ N ≤ 16 이며, 이동 비용은 0 또는 1,000,000 이하의 양의 정수입니다. W[i][j] = 0이면 i에서 j로 이동할 수 없음을 의미합니다.
-        </p>
-      </div>
+      {problem && (
+        <>
+          <div className="text-[#4B5563] text-sm leading-relaxed mb-6 whitespace-pre-wrap">
+            {problem.contentMd}
+          </div>
 
-      <div className="grid grid-cols-2 gap-4">
-        {/* Input Example */}
-        <div className="bg-[#F9FAFB] rounded-lg border border-[#E5E7EB] p-4">
-          <h3 className="text-sm font-medium text-[#1F2937] mb-2">입력 예시</h3>
-          <code className="text-sm font-mono text-[#2563EB] bg-[#EFF6FF] px-2 py-1 rounded whitespace-pre">{`4
-0 10 15 20
-5 0 9 10
-6 13 0 12
-8 8 9 0`}</code>
-        </div>
-
-        {/* Output Example */}
-        <div className="bg-[#F9FAFB] rounded-lg border border-[#E5E7EB] p-4">
-          <h3 className="text-sm font-medium text-[#1F2937] mb-2">출력 예시</h3>
-          <code className="text-sm font-mono text-[#059669] bg-[#ECFDF5] px-2 py-1 rounded">35</code>
-        </div>
-      </div>
+          <div className="flex gap-2 flex-wrap">
+            {problem.tags.map((tag) => (
+              <span
+                key={tag}
+                className="text-xs px-2 py-0.5 rounded-full bg-[#EFF6FF] text-[#2563EB] border border-[#BFDBFE]"
+              >
+                {tag}
+              </span>
+            ))}
+            <span className="text-xs px-2 py-0.5 rounded-full bg-[#F3F4F6] text-[#6B7280] border border-[#E5E7EB]">
+              {problem.difficulty}
+            </span>
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -18,8 +18,8 @@ import { Button } from "@/components/ui/button"
 import { logoutAdmin } from "@/lib/api/admin"
 
 interface SidebarProps {
-  activeItem: string
-  onItemClick: (item: string) => void
+  activeItem?: string
+  onItemClick?: (item: string) => void
 }
 
 interface MenuItem {

--- a/components/test-session-details-content.tsx
+++ b/components/test-session-details-content.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import Link from "next/link";
+import { getBoard } from "@/lib/api/admin";
 
 // Participant type
 type Participant = {
@@ -41,26 +42,20 @@ export default function TestSessionDetailsContent({ session, onBack }: TestSessi
   const fetchParticipants = async () => {
     setIsLoading(true);
     try {
-      const token = localStorage.getItem('admin_access_token');
-      const response = await fetch(`/api/admin/board?examId=${session.id}`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        }
-      });
-      const data = await response.json();
-
-      if (data.code === 'COMMON200' && data.result) {
-        const mapped: Participant[] = data.result.map((p: any) => ({
-          id: p.examParticipantId,
-          name: p.name,
-          phoneNumber: p.phoneMasked,
-          connectionStatus: p.state === 'ENTRANCE' ? "Connected" : "Pending",
-          submissionStatus: p.submitted ? "Submitted" : (p.state === 'ENTRANCE' ? "In Progress" : "Not Started"),
-          tokenUsage: p.tokenUsed || 0
-        }));
-        setParticipants(mapped);
-      }
+      const board = await getBoard(session.id);
+      const mapped: Participant[] = board.map((p) => ({
+        id: p.examParticipantId,
+        name: p.name,
+        phoneNumber: p.phoneMasked,
+        connectionStatus: p.state === "ENTRANCE" ? "Connected" : "Pending",
+        submissionStatus: p.submitted
+          ? "Submitted"
+          : p.state === "ENTRANCE"
+          ? "In Progress"
+          : "Not Started",
+        tokenUsage: p.tokenUsed || 0,
+      }));
+      setParticipants(mapped);
     } catch (error) {
       console.error("Failed to fetch participants:", error);
     } finally {

--- a/components/test-sessions-content.tsx
+++ b/components/test-sessions-content.tsx
@@ -20,7 +20,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { useRouter } from "next/navigation";
 
-interface TestSession {
+export interface TestSession {
   id: number
   sessionId: string     // BE의 title을 sessionId로 매핑 (필요시)
   createdBy: string

--- a/components/user-test-screen.tsx
+++ b/components/user-test-screen.tsx
@@ -13,15 +13,56 @@ import { useExamSessionStore } from "@/lib/stores/exam-session-store";
 import { getExamState, ExamState, GetExamStateResponse } from "@/lib/api/exams";
 import { RemainingTimer } from "@/components/remaining-timer";
 import { useExamSocket, ExamStateEvent } from "@/hooks/use-exam-socket";
+import { streamScoringResult, FinalScoreEvent, SubmissionStatus } from "@/lib/api/submissions";
+import { getChatHistory } from "@/lib/api/chat";
+
+// ─── 채점 결과 표시용 타입 ────────────────────────────────────────────────────
+
+interface ScoringResult {
+  status: SubmissionStatus;
+  score: {
+    prompt: number | null;
+    perf: number | null;
+    correctness: number | null;
+    total: number | null;
+  } | null;
+  passRate: number | null;
+}
+
+const SCORING_STATUS_LABEL: Record<SubmissionStatus, string> = {
+  PENDING:               "채점 대기 중",
+  JUDGING:               "채점 중…",
+  ACCEPTED:              "✅ 정답",
+  WRONG_ANSWER:          "❌ 오답",
+  TIME_LIMIT_EXCEEDED:   "⏱ 시간 초과",
+  MEMORY_LIMIT_EXCEEDED: "💾 메모리 초과",
+  RUNTIME_ERROR:         "🔥 런타임 오류",
+  COMPILE_ERROR:         "🔨 컴파일 오류",
+  SYSTEM_ERROR:          "⚠️ 시스템 오류",
+}
+
+const SCORING_STATUS_COLOR: Record<SubmissionStatus, string> = {
+  PENDING:               "text-[#6B7280]",
+  JUDGING:               "text-[#2563EB]",
+  ACCEPTED:              "text-[#059669]",
+  WRONG_ANSWER:          "text-[#DC2626]",
+  TIME_LIMIT_EXCEEDED:   "text-[#D97706]",
+  MEMORY_LIMIT_EXCEEDED: "text-[#D97706]",
+  RUNTIME_ERROR:         "text-[#DC2626]",
+  COMPILE_ERROR:         "text-[#DC2626]",
+  SYSTEM_ERROR:          "text-[#6B7280]",
+}
+
+// ─── 컴포넌트 ─────────────────────────────────────────────────────────────────
 
 export default function UserTestScreen() {
   const router = useRouter();
   const examId = useExamSessionStore((state) => state.examId);
   const participantId = useExamSessionStore((state) => state.participantId);
 
-  // 모달 2개 상태
-  const [showTimeOverModal, setShowTimeOverModal] = useState(false);   // "시험 시간 종료 시 모달"
-  const [showFinishedModal, setShowFinishedModal] = useState(false);   // "시험 종료 완료 공지 모달"
+  // 모달 상태
+  const [showTimeOverModal, setShowTimeOverModal] = useState(false);
+  const [showFinishedModal, setShowFinishedModal] = useState(false);
 
   // 시험 종료 감지 상태
   const [isExamEnded, setIsExamEnded] = useState(false);
@@ -29,20 +70,45 @@ export default function UserTestScreen() {
   const [examState, setExamState] = useState<ExamState | null>(null);
   const [examStateData, setExamStateData] = useState<GetExamStateResponse | null>(null);
 
-  // 토큰 사용량 상태 관리
+  // 토큰 사용량 상태 관리 (초기 로드 포함)
   const [usedTokens, setUsedTokens] = useState<number>(0);
-  const maxTokens = 20000; // TODO: 나중에 API로 가져오도록 확장 가능
+  const maxTokens = 20000;
+
+  // 채점 결과 상태
+  const [scoringResult, setScoringResult] = useState<ScoringResult | null>(null);
+  const [isScoring, setIsScoring] = useState(false);
+  const [caseResultCount, setCaseResultCount] = useState(0);
+
+  // SSE cleanup ref
+  const sseCleanupRef = useRef<(() => void) | null>(null);
+
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
+  const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false)
+
+  // ── 초기 토큰 사용량 로드 (getChatHistory.totalTokens) ──────────────────────
+  useEffect(() => {
+    if (!examId || !participantId) return;
+
+    getChatHistory(examId, participantId)
+      .then((history) => {
+        if (history && history.totalTokens > 0) {
+          setUsedTokens(history.totalTokens);
+        }
+      })
+      .catch((err) => {
+        // 히스토리 없음(404)은 정상 — 0 유지
+        if (process.env.NODE_ENV === 'development') {
+          console.warn("[UserTestScreen] getChatHistory 초기 로드 실패:", err);
+        }
+      });
+  }, [examId, participantId]);
 
   // 토큰 업데이트 핸들러: delta(증가량)를 받아서 누적
   const handleTokensUpdate = (delta: number) => {
     setUsedTokens((prev) => prev + delta);
   };
 
-  const [isSidebarOpen, setIsSidebarOpen] = useState(false)
-  const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false)
-
-  // WebSocket 시험 상태 이벤트 핸들러
-  // REST 폴링(5초)과 병행하여 관리자의 시작/종료/연장을 실시간으로 수신
+  // ── WebSocket 시험 상태 이벤트 핸들러 ───────────────────────────────────────
   const handleExamStateEvent = (event: ExamStateEvent) => {
     if (process.env.NODE_ENV === 'development') {
       console.log('[UserTestScreen] WS exam state event:', event);
@@ -64,15 +130,62 @@ export default function UserTestScreen() {
 
   useExamSocket(examId, handleExamStateEvent);
 
-  const handleTimeExpired = () => {
-    // 이미 모달이 떠있으면 다시 열지 않기 위한 가드 (선택사항)
-    if (showTimeOverModal || showFinishedModal || showEndModal) return;
+  // ── SSE 채점 결과 스트리밍 ───────────────────────────────────────────────────
+  /**
+   * CodeEditorSection의 onSubmitted 콜백.
+   * submissionId를 받아 SSE 구독을 시작한다.
+   * 이전 구독이 있으면 먼저 취소한다.
+   */
+  const handleCodeSubmitted = (submissionId: number) => {
+    // 이전 SSE 연결 취소
+    sseCleanupRef.current?.();
 
-    // "시험 시간 종료 시 모달" 열기
+    setIsScoring(true);
+    setCaseResultCount(0);
+    setScoringResult({ status: "PENDING", score: null, passRate: null });
+
+    const cancel = streamScoringResult(submissionId, {
+      onCaseResult: () => {
+        setCaseResultCount((n) => n + 1);
+        setScoringResult((prev) => prev ? { ...prev, status: "JUDGING" } : prev);
+      },
+      onFinalScore: (event: FinalScoreEvent) => {
+        setScoringResult({
+          status: event.status,
+          score: event.score ?? null,
+          passRate: event.tc?.passRateWeighted ?? null,
+        });
+        setIsScoring(false);
+      },
+      onError: (err) => {
+        if (process.env.NODE_ENV === 'development') {
+          console.error("[UserTestScreen] SSE 오류:", err);
+        }
+        setScoringResult((prev) => prev ? { ...prev, status: "SYSTEM_ERROR" } : prev);
+        setIsScoring(false);
+      },
+      onComplete: () => {
+        setIsScoring(false);
+      },
+    });
+
+    sseCleanupRef.current = cancel;
+  };
+
+  // 컴포넌트 언마운트 시 SSE 취소
+  useEffect(() => {
+    return () => {
+      sseCleanupRef.current?.();
+    };
+  }, []);
+
+  // ── 시간 만료 핸들러 ─────────────────────────────────────────────────────────
+  const handleTimeExpired = () => {
+    if (showTimeOverModal || showFinishedModal || showEndModal) return;
     setShowTimeOverModal(true);
   };
 
-  // 시험 상태 폴링 (관리자가 종료했는지 감지)
+  // ── 시험 상태 폴링 ───────────────────────────────────────────────────────────
   useEffect(() => {
     if (!examId) return;
 
@@ -86,21 +199,16 @@ export default function UserTestScreen() {
         setExamState(res.state);
         setExamStateData(res);
 
-        // 시험이 종료된 상태(ENDED)로 변경되었고, 아직 종료 모달을 보여주지 않았다면
         if (res.state === "ENDED" && !isExamEnded && !showEndModal) {
           setIsExamEnded(true);
           setShowEndModal(true);
         }
       } catch (err) {
         console.error("[UserTestScreen] getExamState error:", err);
-        // 에러가 발생해도 기존 상태 유지
       }
     };
 
-    // 컴포넌트 마운트 시 즉시 한 번 체크
     checkExamState();
-
-    // 그 이후에는 5초마다 상태를 폴링
     const intervalId = setInterval(checkExamState, 5000);
 
     return () => {
@@ -109,13 +217,9 @@ export default function UserTestScreen() {
     };
   }, [examId, isExamEnded, showEndModal]);
 
-
-  // 홈으로 이동하는 핸들러
   const handleGoHome = () => {
-    // 사용자 로그인/입장 화면으로 이동
     router.push("/");
   };
-
 
   return (
     <div className="min-h-screen bg-[#F5F5F5]">
@@ -130,8 +234,8 @@ export default function UserTestScreen() {
             <Clock className="w-5 h-5 text-[#2563EB]" />
             <span className="text-lg font-medium text-[#1F2937]">남은 시간:</span>
             {examStateData?.endsAt ? (
-              <RemainingTimer 
-                endAt={examStateData.endsAt} 
+              <RemainingTimer
+                endAt={examStateData.endsAt}
                 onTimeOver={handleTimeExpired}
               />
             ) : (
@@ -144,7 +248,7 @@ export default function UserTestScreen() {
             <div className="flex items-center gap-2 text-[#4B5563]">
               <Coins className="w-4 h-4" />
               <span className="text-sm font-medium">토큰:</span>
-              <span className="font-mono text-[#1F2937] font-semibold">{usedTokens} / {maxTokens}</span>
+              <span className="font-mono text-[#1F2937] font-semibold">{usedTokens.toLocaleString()} / {maxTokens.toLocaleString()}</span>
             </div>
             {!isExamEnded && (
               <Button
@@ -157,6 +261,38 @@ export default function UserTestScreen() {
             )}
           </div>
         </div>
+
+        {/* 채점 결과 배너 */}
+        {scoringResult && (
+          <div
+            className={`flex items-center justify-between px-6 py-2 text-sm border-t border-[#E5E7EB] bg-[#F9FAFB] ${
+              SCORING_STATUS_COLOR[scoringResult.status]
+            }`}
+          >
+            <div className="flex items-center gap-2 font-medium">
+              {isScoring && (
+                <svg className="animate-spin w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                </svg>
+              )}
+              <span>{SCORING_STATUS_LABEL[scoringResult.status]}</span>
+              {caseResultCount > 0 && isScoring && (
+                <span className="text-xs text-[#6B7280]">({caseResultCount}개 테스트케이스 처리됨)</span>
+              )}
+            </div>
+            {!isScoring && scoringResult.score?.total !== null && scoringResult.score?.total !== undefined && (
+              <div className="flex items-center gap-4 text-xs text-[#6B7280]">
+                {scoringResult.passRate !== null && (
+                  <span>통과율 {Math.round(scoringResult.passRate * 100)}%</span>
+                )}
+                <span className="font-semibold text-[#1F2937]">
+                  총점 {scoringResult.score.total}점
+                </span>
+              </div>
+            )}
+          </div>
+        )}
       </header>
 
       {/* Main Content */}
@@ -165,17 +301,21 @@ export default function UserTestScreen() {
         <main className="flex-1 p-6">
           <div className="flex flex-col gap-6">
             {/* Problem Section */}
-            <ProblemSection />
+            {examId && <ProblemSection examId={examId} />}
 
             {/* Code Editor Section */}
-            <CodeEditorSection isReadOnly={isExamEnded} />
+            <CodeEditorSection
+              isReadOnly={isExamEnded}
+              examId={examId}
+              onSubmitted={handleCodeSubmitted}
+            />
           </div>
         </main>
 
         {/* AI Assistant Sidebar */}
         {examId && participantId && (
-          <AiAssistantSidebar 
-            isOpen={isSidebarOpen} 
+          <AiAssistantSidebar
+            isOpen={isSidebarOpen}
             onToggle={() => setIsSidebarOpen(!isSidebarOpen)}
             examId={examId}
             participantId={participantId}
@@ -185,6 +325,7 @@ export default function UserTestScreen() {
         )}
       </div>
 
+      {/* 제출 확인 모달 */}
       {isSubmitModalOpen && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div className="bg-white rounded-xl shadow-lg p-8 max-w-md w-full mx-4">
@@ -201,9 +342,7 @@ export default function UserTestScreen() {
               <Button
                 className="px-8 bg-[#2563EB] hover:bg-[#1D4ED8] text-white"
                 onClick={() => {
-                  // 1) 제출 확인 모달 닫기
                   setIsSubmitModalOpen(false);
-                  // 2) 시험 종료 완료 공지 모달 열기
                   setShowFinishedModal(true);
                 }}
               >
@@ -213,16 +352,12 @@ export default function UserTestScreen() {
           </div>
         </div>
       )}
-      {/* 1) 시험 시간 종료 시 모달 */}
-      <Dialog 
-        open={showTimeOverModal} 
+
+      {/* 1) 시험 시간 종료 모달 */}
+      <Dialog
+        open={showTimeOverModal}
         onOpenChange={(open) => {
-          // 바깥쪽 클릭이나 ESC 키로 닫히는 것을 방지
-          // 오로지 모달 내부 버튼을 통해서만 닫을 수 있음
-          if (!open) {
-            // false로 변경 시도를 무시
-            return;
-          }
+          if (!open) return;
           setShowTimeOverModal(open);
         }}
       >
@@ -251,14 +386,11 @@ export default function UserTestScreen() {
         </DialogContent>
       </Dialog>
 
-      {/* 3) 관리자가 시험을 종료한 경우 모달 */}
-      <Dialog 
-        open={showEndModal} 
+      {/* 2) 관리자가 시험 종료한 경우 모달 */}
+      <Dialog
+        open={showEndModal}
         onOpenChange={(open) => {
-          // 바깥쪽 클릭이나 ESC 키로 닫히는 것을 방지
-          if (!open) {
-            return;
-          }
+          if (!open) return;
           setShowEndModal(open);
         }}
       >
@@ -282,16 +414,12 @@ export default function UserTestScreen() {
         </DialogContent>
       </Dialog>
 
-      {/* 2) 시험 종료 완료 공지 모달 */}
+      {/* 3) 시험 종료 완료 공지 모달 */}
       <Dialog open={showFinishedModal} onOpenChange={setShowFinishedModal}>
         <DialogContent className="max-w-md w-full rounded-2xl border border-gray-100 shadow-xl bg-white p-8">
-          
-          {/* 접근성용 DialogTitle (화면에는 안 보이게) */}
           <DialogTitle className="sr-only">시험이 종료되었습니다.</DialogTitle>
-          
-          <div className="flex flex-col items-center text-center space-y-5">
 
-            {/* 아이콘 + 서브텍스트 */}
+          <div className="flex flex-col items-center text-center space-y-5">
             <div className="flex flex-col items-center space-y-3">
               <div className="p-3 rounded-full bg-emerald-50">
                 <CheckCircle2 className="w-8 h-8 text-emerald-500" />
@@ -301,25 +429,21 @@ export default function UserTestScreen() {
               </span>
             </div>
 
-            {/* 타이틀 */}
             <h2 className="text-xl font-semibold text-gray-900">
               시험이 종료되었습니다.
             </h2>
 
-            {/* 설명 */}
             <p className="text-sm text-gray-500 leading-relaxed">
               수고하셨습니다! <br />
               시험이 정상적으로 종료되었습니다.
             </p>
 
-            {/* 얇은 구분선 */}
             <div className="w-full h-px bg-gray-100" />
 
-            {/* 버튼 영역 */}
             <div className="w-full flex flex-col gap-2">
               <Button
                 className="w-full rounded-lg bg-gray-900 text-white hover:bg-black"
-                onClick={() => router.push("/")}   // 기존 동작 유지
+                onClick={() => router.push("/")}
               >
                 홈 화면으로 돌아가기
               </Button>

--- a/components/user-test-screen.tsx
+++ b/components/user-test-screen.tsx
@@ -12,6 +12,7 @@ import { CheckCircle2 } from "lucide-react";
 import { useExamSessionStore } from "@/lib/stores/exam-session-store";
 import { getExamState, ExamState, GetExamStateResponse } from "@/lib/api/exams";
 import { RemainingTimer } from "@/components/remaining-timer";
+import { useExamSocket, ExamStateEvent } from "@/hooks/use-exam-socket";
 
 export default function UserTestScreen() {
   const router = useRouter();
@@ -40,6 +41,28 @@ export default function UserTestScreen() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
   const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false)
 
+  // WebSocket 시험 상태 이벤트 핸들러
+  // REST 폴링(5초)과 병행하여 관리자의 시작/종료/연장을 실시간으로 수신
+  const handleExamStateEvent = (event: ExamStateEvent) => {
+    if (process.env.NODE_ENV === 'development') {
+      console.log('[UserTestScreen] WS exam state event:', event);
+    }
+    setExamState(event.state);
+    setExamStateData({
+      examId: event.examId,
+      state: event.state,
+      startsAt: event.startsAt,
+      endsAt: event.endsAt,
+      version: event.version,
+      serverTime: event.serverTime,
+    });
+    if (event.state === 'ENDED' && !isExamEnded && !showEndModal) {
+      setIsExamEnded(true);
+      setShowEndModal(true);
+    }
+  };
+
+  useExamSocket(examId, handleExamStateEvent);
 
   const handleTimeExpired = () => {
     // 이미 모달이 떠있으면 다시 열지 않기 위한 가드 (선택사항)

--- a/hooks/use-chat-socket.tsx
+++ b/hooks/use-chat-socket.tsx
@@ -28,9 +28,15 @@ export function useChatSocket(
   const stompClientRef = useRef<Client | null>(null);
 
   useEffect(() => {
+    // STOMP CONNECT 시 JWT를 헤더로 전달해 서버 Principal(userId) 설정을 가능하게 함
+    // BE의 StompPrincipalInterceptor가 이 토큰을 파싱해 participantId를 Principal로 등록
+    // → convertAndSendToUser(participantId, "/queue/chat", response) 라우팅이 정상 동작
+    const token = typeof window !== 'undefined' ? localStorage.getItem('user_access_token') : null;
+
     const socket = new SockJS(`${API_BASE_URL}/ws`);
     const client = new Client({
       webSocketFactory: () => socket,
+      connectHeaders: token ? { Authorization: `Bearer ${token}` } : {},
       debug: (str) => {
         if (process.env.NODE_ENV === 'development') {
           console.log('[STOMP Chat] ' + str);

--- a/hooks/use-exam-socket.tsx
+++ b/hooks/use-exam-socket.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from 'react';
+import { Client } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+
+export type ExamState = 'WAITING' | 'RUNNING' | 'ENDED';
+
+export interface ExamStateEvent {
+  examId: number;
+  state: ExamState;
+  startsAt: string;
+  endsAt: string;
+  version: number;
+  serverTime: string;
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
+
+/**
+ * 시험 상태 변경 WebSocket 구독 훅
+ *
+ * BE의 StartExamUseCase / EndExamUseCase / ExtendExamUseCase가
+ * /topic/exam/{examId} 로 ExamStateEvent를 브로드캐스트할 때 수신.
+ *
+ * REST 폴링(5초)과 병행 사용하여 신뢰성을 높임:
+ * - WebSocket 이벤트: 실시간 반응 (< 100ms)
+ * - 폴링: WebSocket 단절 시 최대 5초 내 복구
+ */
+export function useExamSocket(
+  examId: number | null,
+  onExamStateChange: (event: ExamStateEvent) => void
+) {
+  const [isConnected, setIsConnected] = useState(false);
+  const stompClientRef = useRef<Client | null>(null);
+  const onExamStateChangeRef = useRef(onExamStateChange);
+
+  // 최신 콜백 참조 유지 (의존성 무한 루프 방지)
+  useEffect(() => {
+    onExamStateChangeRef.current = onExamStateChange;
+  }, [onExamStateChange]);
+
+  useEffect(() => {
+    if (!examId) return;
+
+    const token = typeof window !== 'undefined' ? localStorage.getItem('user_access_token') : null;
+
+    const socket = new SockJS(`${API_BASE_URL}/ws`);
+    const client = new Client({
+      webSocketFactory: () => socket,
+      connectHeaders: token ? { Authorization: `Bearer ${token}` } : {},
+      debug: (str) => {
+        if (process.env.NODE_ENV === 'development') {
+          console.log('[STOMP Exam] ' + str);
+        }
+      },
+      reconnectDelay: 5000,
+      heartbeatIncoming: 4000,
+      heartbeatOutgoing: 4000,
+    });
+
+    client.onConnect = () => {
+      setIsConnected(true);
+      if (process.env.NODE_ENV === 'development') {
+        console.log(`[STOMP Exam] Connected. Subscribing to /topic/exam/${examId}`);
+      }
+
+      client.subscribe(`/topic/exam/${examId}`, (message) => {
+        try {
+          const event: ExamStateEvent = JSON.parse(message.body);
+          if (process.env.NODE_ENV === 'development') {
+            console.log('[STOMP Exam] State event received:', event);
+          }
+          onExamStateChangeRef.current(event);
+        } catch (e) {
+          console.error('[STOMP Exam] Failed to parse exam state event:', e);
+        }
+      });
+    };
+
+    client.onDisconnect = () => {
+      setIsConnected(false);
+      if (process.env.NODE_ENV === 'development') {
+        console.log('[STOMP Exam] Disconnected');
+      }
+    };
+
+    client.onStompError = (frame) => {
+      console.error('[STOMP Exam] Error:', frame.headers['message']);
+    };
+
+    client.activate();
+    stompClientRef.current = client;
+
+    return () => {
+      stompClientRef.current?.deactivate();
+    };
+  }, [examId]);
+
+  return { isConnected };
+}

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -1636,3 +1636,220 @@ export async function getEntryCodes(examId: number, isActive?: boolean): Promise
   }
 }
 
+// ─── 추가 타입 정의 ────────────────────────────────────────────────────────────
+
+export interface ExamineeBoardEntry {
+  examParticipantId: number;
+  name: string;
+  phoneMasked: string;
+  state: string;
+  tokenLimit: number;
+  tokenUsed: number;
+  submitted: boolean;
+}
+
+export interface AdminMetrics {
+  concurrency: {
+    activeExaminees: number;
+    wsConnections: number;
+  };
+  queue: {
+    judgeQueueDepth: number;
+    avgWaitSec: number;
+  };
+  errors: {
+    rate1m: number;
+    last: string | null;
+  };
+}
+
+// ─── 시험 연장 ─────────────────────────────────────────────────────────────────
+
+/**
+ * 시험 시간 연장 API 호출
+ * POST /api/admin/exams/{id}/extend
+ */
+export async function extendExam(examId: number, minutes: number): Promise<void> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/exams/${examId}/extend`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: getAuthHeaders(),
+    body: JSON.stringify({ minutes }),
+    credentials: 'omit',
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new LoginFailedError(data.message || '시험 시간 연장에 실패했습니다.', response.status);
+  }
+}
+
+// ─── 입장 코드 수정·삭제 ────────────────────────────────────────────────────────
+
+/**
+ * 입장 코드 활성/비활성 변경 API 호출
+ * PATCH /api/admin/entry-codes/{code}
+ */
+export async function updateEntryCode(code: string, isActive: boolean): Promise<EntryCodeResponse> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/entry-codes/${encodeURIComponent(code)}`;
+
+  const response = await fetch(url, {
+    method: 'PATCH',
+    headers: getAuthHeaders(),
+    body: JSON.stringify({ isActive }),
+    credentials: 'omit',
+  });
+
+  const data: BaseResponse<EntryCodeResponse> = await response.json();
+  if (!response.ok || data.code !== 'COMMON200' || !data.result) {
+    throw new LoginFailedError(data.message || '입장 코드 수정에 실패했습니다.', response.status);
+  }
+  return data.result;
+}
+
+/**
+ * 입장 코드 삭제 API 호출
+ * DELETE /api/admin/entry-codes/{code}
+ */
+export async function deleteEntryCode(code: string): Promise<void> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/entry-codes/${encodeURIComponent(code)}`;
+
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: getAuthHeaders(),
+    credentials: 'omit',
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new LoginFailedError(data.message || '입장 코드 삭제에 실패했습니다.', response.status);
+  }
+}
+
+// ─── 시험 지표·보드 ────────────────────────────────────────────────────────────
+
+/**
+ * 시험 실시간 지표 조회 API 호출
+ * GET /api/admin/metrics?examId={}
+ */
+export async function getMetrics(examId: number): Promise<AdminMetrics> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/metrics?examId=${examId}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: getAuthHeaders(),
+    credentials: 'omit',
+  });
+
+  const data: BaseResponse<AdminMetrics> = await response.json();
+  if (!response.ok || data.code !== 'COMMON200' || !data.result) {
+    throw new LoginFailedError(data.message || '지표 조회에 실패했습니다.', response.status);
+  }
+  return data.result;
+}
+
+/**
+ * 시험 참가자 현황 보드 조회 API 호출
+ * GET /api/admin/board?examId={}
+ */
+export async function getBoard(examId: number): Promise<ExamineeBoardEntry[]> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/board?examId=${examId}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: getAuthHeaders(),
+    credentials: 'omit',
+  });
+
+  const data: BaseResponse<ExamineeBoardEntry[]> = await response.json();
+  if (!response.ok || data.code !== 'COMMON200') {
+    throw new LoginFailedError(data.message || '보드 조회에 실패했습니다.', response.status);
+  }
+  return data.result ?? [];
+}
+
+// ─── SSE 채점 결과 스트리밍 ────────────────────────────────────────────────────
+
+export interface ScoringEvent {
+  type: 'case_result' | 'final_score';
+  data: unknown;
+}
+
+/**
+ * 채점 결과 SSE 스트리밍 구독
+ * GET /api/admin/submissions/{submissionId}/stream
+ *
+ * @returns cleanup 함수 (구독 해제 시 호출)
+ */
+export function streamScoringResult(
+  submissionId: number,
+  onEvent: (event: ScoringEvent) => void,
+  onError?: (err: Event) => void,
+  onDone?: () => void
+): () => void {
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
+  const token = typeof window !== 'undefined' ? localStorage.getItem('admin_access_token') : null;
+
+  // SSE는 EventSource를 사용하며, 커스텀 헤더 지원이 없으므로 쿼리 파라미터로 토큰 전달
+  // 서버 측에서 쿼리 파라미터 토큰을 허용해야 함. 불가 시 fetch + ReadableStream으로 대체
+  const url = `${apiBaseUrl}/api/admin/submissions/${submissionId}/stream${token ? `?token=${encodeURIComponent(token)}` : ''}`;
+
+  // fetch + ReadableStream 방식 (Authorization 헤더 지원)
+  let aborted = false;
+  const controller = new AbortController();
+
+  fetch(url.replace(/\?token=.*/, ''), {
+    headers: {
+      Authorization: token ? `Bearer ${token}` : '',
+      Accept: 'text/event-stream',
+    },
+    signal: controller.signal,
+  }).then(async (response) => {
+    if (!response.body) {
+      onError?.(new Event('no body'));
+      return;
+    }
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (!aborted) {
+      const { done, value } = await reader.read();
+      if (done) {
+        onDone?.();
+        break;
+      }
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (line.startsWith('data:')) {
+          try {
+            const parsed = JSON.parse(line.slice(5).trim());
+            onEvent(parsed);
+          } catch {
+            // non-JSON data line 무시
+          }
+        } else if (line === '' && buffer === '') {
+          // keep-alive 빈 라인
+        }
+      }
+    }
+  }).catch((err) => {
+    if (!aborted) {
+      onError?.(err);
+    }
+  });
+
+  return () => {
+    aborted = true;
+    controller.abort();
+  };
+}

--- a/lib/api/chat.ts
+++ b/lib/api/chat.ts
@@ -285,3 +285,56 @@ export async function updateTokenUsage(request: UpdateTokenUsageRequest): Promis
   }
 }
 
+// ─── 채팅 히스토리 ─────────────────────────────────────────────────────────────
+
+export interface ChatHistoryMessage {
+  id: number;
+  turn: number;
+  role: string;
+  content: string;
+  tokenCount: number | null;
+}
+
+export interface ChatHistoryResponse {
+  sessionId: number;
+  examId: number;
+  participantId: number;
+  totalTokens: number;
+  messages: ChatHistoryMessage[];
+}
+
+/**
+ * 채팅 히스토리 조회 API 호출
+ * GET /api/chat/history?examId={}&participantId={}
+ */
+export async function getChatHistory(
+  examId: number,
+  participantId: number
+): Promise<ChatHistoryResponse | null> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/chat/history?examId=${examId}&participantId=${participantId}`;
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: getUserAuthHeaders(),
+      credentials: 'include',
+    });
+
+    if (response.status === 404) {
+      return null; // 히스토리 없음
+    }
+
+    const data: BaseResponse<ChatHistoryResponse> = await response.json();
+    if (!response.ok || data.code !== 'COMMON200') {
+      throw new ChatError(data.message || '채팅 히스토리 조회에 실패했습니다.', response.status);
+    }
+    return data.result;
+  } catch (error) {
+    if (error instanceof ChatError) throw error;
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new NetworkError();
+    }
+    throw error;
+  }
+}

--- a/lib/api/exams.ts
+++ b/lib/api/exams.ts
@@ -18,6 +18,32 @@ function getUserAuthHeaders(): HeadersInit {
   return headers;
 }
 
+// ─── 문제 배정 응답 타입 ───────────────────────────────────────────────────────
+
+export interface AssignmentResponse {
+  problem: {
+    id: number;
+    title: string;
+    contentMd: string;
+    tags: string[];
+    difficulty: 'EASY' | 'MEDIUM' | 'HARD';
+  };
+  spec: {
+    version: number;
+    limits: {
+      timeMs: number;
+      memoryMb: number;
+    };
+    restrictions: {
+      allowedLangs: string[];
+      forbiddenApis: string[];
+    };
+    checker: {
+      type: string;
+    };
+  };
+}
+
 // BaseResponse 타입
 export interface BaseResponse<T> {
   timestamp: string;
@@ -141,3 +167,25 @@ export async function getExamState(examId: number): Promise<GetExamStateResponse
   }
 }
 
+/**
+ * 참가자에게 배정된 문제 조회 API
+ * GET /api/exams/{examId}/assignment
+ */
+export async function getAssignment(examId: number): Promise<AssignmentResponse> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/exams/${examId}/assignment`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: getUserAuthHeaders(),
+    credentials: 'include',
+  });
+
+  const data: BaseResponse<AssignmentResponse> = await response.json();
+  if (!response.ok || data.code !== 'COMMON200' || !data.result) {
+    const err: any = new Error(data.message || '문제 조회에 실패했습니다.');
+    err.status = response.status;
+    throw err;
+  }
+  return data.result;
+}

--- a/lib/api/submissions.ts
+++ b/lib/api/submissions.ts
@@ -1,0 +1,254 @@
+// Submission API 호출 함수들
+
+function getAdminAuthHeaders(): HeadersInit {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('admin_access_token') : null;
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+function getApiBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
+}
+
+function getUserAuthHeaders(): HeadersInit {
+  const token = typeof window !== 'undefined' ? localStorage.getItem('user_access_token') : null;
+  return {
+    'Content-Type': 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export interface BaseResponse<T> {
+  timestamp: string;
+  code: string;
+  message: string;
+  result: T | null;
+}
+
+// ─── 타입 정의 ────────────────────────────────────────────────────────────────
+
+export type SubmissionStatus =
+  | 'PENDING'
+  | 'JUDGING'
+  | 'ACCEPTED'
+  | 'WRONG_ANSWER'
+  | 'TIME_LIMIT_EXCEEDED'
+  | 'MEMORY_LIMIT_EXCEEDED'
+  | 'RUNTIME_ERROR'
+  | 'COMPILE_ERROR'
+  | 'SYSTEM_ERROR';
+
+export interface SubmitRequest {
+  lang: string;  // "python" | "java" | "cpp" | "javascript"
+  code: string;
+}
+
+export interface SubmitResponse {
+  submissionId: number;
+  status: SubmissionStatus;
+}
+
+export interface SubmissionDetailResponse {
+  id: number;
+  status: SubmissionStatus;
+  lang: string;
+  metrics: {
+    timeMsMedian: number | null;
+    memKbPeak: number | null;
+    loc: number | null;
+  } | null;
+  tc: {
+    passRateWeighted: number | null;
+    groups: Array<{
+      name: string;
+      pass: number;
+      total: number;
+      weight: number;
+    }>;
+  } | null;
+  score: {
+    prompt: number | null;
+    perf: number | null;
+    correctness: number | null;
+    total: number | null;
+  } | null;
+}
+
+// ─── API 함수 ────────────────────────────────────────────────────────────────
+
+/**
+ * 코드 제출 API 호출
+ * POST /api/exams/{examId}/submissions
+ * HTTP 202 Accepted 반환 (비동기 채점)
+ */
+export async function submitCode(examId: number, request: SubmitRequest): Promise<SubmitResponse> {
+  const url = `${getApiBaseUrl()}/api/exams/${examId}/submissions`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: getUserAuthHeaders(),
+    body: JSON.stringify(request),
+    credentials: 'include',
+  });
+
+  // 202 Accepted도 성공으로 처리
+  if (!response.ok && response.status !== 202) {
+    const data = await response.json().catch(() => ({}));
+    const err: any = new Error((data as any).message || '코드 제출에 실패했습니다.');
+    err.status = response.status;
+    throw err;
+  }
+
+  const data: BaseResponse<SubmitResponse> = await response.json();
+  if (!data.result) {
+    throw new Error('제출 응답 데이터가 없습니다.');
+  }
+  return data.result;
+}
+
+/**
+ * 제출 상세 조회 API 호출
+ * GET /api/submissions/{submissionId}
+ */
+export async function getSubmission(submissionId: number): Promise<SubmissionDetailResponse> {
+  const url = `${getApiBaseUrl()}/api/submissions/${submissionId}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: getUserAuthHeaders(),
+    credentials: 'include',
+  });
+
+  const data: BaseResponse<SubmissionDetailResponse> = await response.json();
+  if (!response.ok || data.code !== 'COMMON200' || !data.result) {
+    const err: any = new Error(data.message || '제출 내역 조회에 실패했습니다.');
+    err.status = response.status;
+    throw err;
+  }
+  return data.result;
+}
+
+// ─── SSE 채점 결과 스트리밍 (Admin 전용) ────────────────────────────────────────
+
+export interface CaseResultEvent {
+  testCaseId: number;
+  pass: boolean;
+  timeMs: number | null;
+  memKb: number | null;
+}
+
+export interface FinalScoreEvent {
+  submissionId: number;
+  status: SubmissionStatus;
+  score: {
+    prompt: number | null;
+    perf: number | null;
+    correctness: number | null;
+    total: number | null;
+  } | null;
+  tc: {
+    passRateWeighted: number | null;
+    groups: Array<{ name: string; pass: number; total: number; weight: number }>;
+  } | null;
+  metrics: {
+    timeMsMedian: number | null;
+    memKbPeak: number | null;
+    loc: number | null;
+  } | null;
+}
+
+export interface ScoringStreamCallbacks {
+  onCaseResult?: (event: CaseResultEvent) => void;
+  onFinalScore?: (event: FinalScoreEvent) => void;
+  onError?: (err: Error) => void;
+  onComplete?: () => void;
+}
+
+/**
+ * 채점 결과 SSE 스트리밍 구독 (Admin/Master 전용)
+ * GET /api/admin/submissions/{submissionId}/stream
+ *
+ * EventSource는 Authorization 헤더 미지원 → fetch + ReadableStream 사용
+ * 반환값: 구독을 취소하는 AbortController의 abort 함수
+ */
+export function streamScoringResult(
+  submissionId: number,
+  callbacks: ScoringStreamCallbacks
+): () => void {
+  const controller = new AbortController();
+  const apiBaseUrl = typeof window !== 'undefined'
+    ? (process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080')
+    : 'http://localhost:8080';
+  const url = `${apiBaseUrl}/api/admin/submissions/${submissionId}/stream`;
+  const token = typeof window !== 'undefined' ? localStorage.getItem('admin_access_token') : null;
+
+  async function connect() {
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Accept: 'text/event-stream',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        credentials: 'include',
+        signal: controller.signal,
+      });
+
+      if (!response.ok || !response.body) {
+        callbacks.onError?.(new Error(`SSE 연결 실패: ${response.status}`));
+        return;
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        let eventName = '';
+        let dataLine = '';
+
+        for (const line of lines) {
+          if (line.startsWith('event:')) {
+            eventName = line.slice(6).trim();
+          } else if (line.startsWith('data:')) {
+            dataLine = line.slice(5).trim();
+          } else if (line === '') {
+            // 이벤트 블록 종료
+            if (eventName && dataLine) {
+              try {
+                const parsed = JSON.parse(dataLine);
+                if (eventName === 'case_result') {
+                  callbacks.onCaseResult?.(parsed as CaseResultEvent);
+                } else if (eventName === 'final_score') {
+                  callbacks.onFinalScore?.(parsed as FinalScoreEvent);
+                }
+              } catch {
+                // JSON 파싱 실패 무시
+              }
+            }
+            eventName = '';
+            dataLine = '';
+          }
+        }
+      }
+
+      callbacks.onComplete?.();
+    } catch (err) {
+      if ((err as Error).name === 'AbortError') return; // 정상 취소
+      callbacks.onError?.(err instanceof Error ? err : new Error('SSE 스트림 오류'));
+    }
+  }
+
+  connect();
+  return () => controller.abort();
+}


### PR DESCRIPTION
## 배경
  백엔드에 구현된 시험/채팅/관리자 API를 프론트 화면에 연결하고, 관리자/응시자 주요 화면의 더미 데이터를 실제 데이터로 교체했습
  니다.

  ## 주요 변경
  - 관리자 화면
  - 대시보드, 통계, 세션 상세, 참가자 목록/상세를 `getExams`, `getBoard` 기반으로 실데이터 연동
  - 진행 중 시험에 대해 시험 시간 연장 기능 추가

  - 응시자 화면
  - 문제 영역을 `getAssignment`로 실제 배정 문제 표시
  - 코드 에디터에서 `submitCode` 호출로 제출 가능하도록 연결
  - 제출 후 SSE 채점 결과 스트리밍을 통해 상태/점수 배너 반영
  - AI 사이드바에서 `getChatHistory`로 이전 대화 및 누적 토큰 사용량 복원

  - API 레이어
  - `admin.ts`, `exams.ts`, `chat.ts`, `submissions.ts`에 누락된 API 클라이언트 추가

  ## 테스트/확인 포인트
  - 관리자 대시보드 진입 시 시험/참가자 수가 실제 데이터로 노출되는지
  - 시험 상세/참가자 목록/참가자 상세에서 board 기반 정보가 정상 조회되는지
  - 진행 중 시험에서 시간 연장 액션이 동작하는지
  - 응시자 화면에서 문제 조회, 코드 제출, 채점 상태 반영, 채팅 히스토리 복원이 정상 동작하는지