### PR TITLE
fix: cookie-based token, pnpm lockfile, CI/CD workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# ──────────────────────────────────────────────
+# Vibe Code Evaluator - 환경 변수 설정 예시
+# 실제 값은 .env.local 또는 Vercel 프로젝트 설정에서 등록하세요.
+# ──────────────────────────────────────────────
+
+# 백엔드 API 서버 URL (필수)
+# Vercel: 프로젝트 Settings > Environment Variables 에 등록
+# 로컬: .env.local 파일 생성 후 아래 값 입력
+NEXT_PUBLIC_API_BASE_URL=https://your-backend-domain.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm tsc --noEmit
+        env:
+          NEXT_PUBLIC_API_BASE_URL: https://placeholder.example.com
+
+      - name: Build
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_API_BASE_URL: https://placeholder.example.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to Vercel
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_API_BASE_URL: ${{ secrets.NEXT_PUBLIC_API_BASE_URL }}
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: --prod

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ Thumbs.db
 
 # CLAUDE
 .claude/
+
+.env.local

--- a/components/login-card.tsx
+++ b/components/login-card.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation"
 import { adminLogin, LoginFailedError, NetworkError } from "@/lib/api/admin"
 import { enterExam, AuthError } from "@/lib/api/auth"
 import { isMasterAdmin, saveAuthInfo } from "@/lib/auth/utils"
+import { setCookie } from "@/lib/auth/cookie-utils"
 import { useExamSessionStore } from "@/lib/stores/exam-session-store"
 
 type TabType = "user" | "admin"
@@ -62,9 +63,9 @@ export default function LoginCard() {
         setSession(examId, participantId, response.session?.tokenLimit);
       }
 
-      // accessToken 저장 (필요한 경우)
-      if (response.accessToken && typeof window !== 'undefined') {
-        localStorage.setItem('user_access_token', response.accessToken);
+      // accessToken 저장
+      if (response.accessToken) {
+        setCookie('user_access_token', response.accessToken);
       }
 
       // ✅ API 성공 시에만 대기 화면으로 이동

--- a/components/problems-content.tsx
+++ b/components/problems-content.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useMemo, useEffect } from "react"
+import { getCookie } from "@/lib/auth/cookie-utils"
 import { Search, ChevronDown, ChevronLeft, ChevronRight } from "lucide-react"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Switch } from "@/components/ui/switch"
@@ -36,7 +37,7 @@ export function ProblemsContent() {
   const fetchProblems = async () => {
     setIsLoading(true);
     try {
-      const token = localStorage.getItem('admin_access_token');
+      const token = getCookie('admin_access_token');
       const response = await fetch('/api/admin/problems', {
         headers: {
           'Authorization': `Bearer ${token}`,

--- a/components/results-content.tsx
+++ b/components/results-content.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { getCookie } from "@/lib/auth/cookie-utils"
 import Link from "next/link"
 import { Search, Download, Eye, X, CheckCircle, ChevronLeft, ChevronRight } from "lucide-react"
 
@@ -49,7 +50,7 @@ export function ResultsContent() {
   const fetchResults = async () => {
     setIsLoading(true);
     try {
-      const token = localStorage.getItem('admin_access_token');
+      const token = getCookie('admin_access_token');
       const response = await fetch('/api/admin/exams', {
         headers: {
           'Authorization': `Bearer ${token}`,

--- a/components/test-sessions-content.tsx
+++ b/components/test-sessions-content.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { getCookie } from "@/lib/auth/cookie-utils"
 import { Eye, Trash2, MoreHorizontal, ChevronLeft, ChevronRight } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -62,7 +63,7 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
   const fetchExams = async () => {
     setIsLoading(true);
     try {
-      const token = localStorage.getItem('admin_access_token');
+      const token = getCookie('admin_access_token');
       const response = await fetch('/api/admin/exams', {
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -93,7 +94,7 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
   const fetchParticipants = async (examId: number) => {
     setIsParticipantsLoading(true);
     try {
-      const token = localStorage.getItem('admin_access_token');
+      const token = getCookie('admin_access_token');
       const response = await fetch(`/api/admin/board?examId=${examId}`, {
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -147,7 +148,7 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
     if (!selectedSession) return
     
     try {
-      const token = localStorage.getItem('admin_access_token');
+      const token = getCookie('admin_access_token');
       const response = await fetch(`/api/admin/exams/${selectedSession.id}`, {
         method: 'DELETE',
         headers: {

--- a/hooks/use-chat-socket.tsx
+++ b/hooks/use-chat-socket.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
+import { getCookie } from '@/lib/auth/cookie-utils';
 
 interface Message {
   id: number;
@@ -43,7 +44,7 @@ export function useChatSocket(
     // STOMP CONNECT 시 JWT를 헤더로 전달해 서버 Principal(userId) 설정을 가능하게 함
     // BE의 StompPrincipalInterceptor가 이 토큰을 파싱해 participantId를 Principal로 등록
     // → convertAndSendToUser(participantId, "/queue/chat", response) 라우팅이 정상 동작
-    const token = typeof window !== 'undefined' ? localStorage.getItem('user_access_token') : null;
+    const token = getCookie('user_access_token');
 
     // 만료된 토큰으로 연결 시 Principal이 설정되지 않아 convertAndSendToUser가 무음 실패함
     if (!token || isTokenExpired(token)) {

--- a/hooks/use-exam-socket.tsx
+++ b/hooks/use-exam-socket.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
+import { getCookie } from '@/lib/auth/cookie-utils';
 
 export type ExamState = 'WAITING' | 'RUNNING' | 'ENDED';
 
@@ -41,7 +42,7 @@ export function useExamSocket(
   useEffect(() => {
     if (!examId) return;
 
-    const token = typeof window !== 'undefined' ? localStorage.getItem('user_access_token') : null;
+    const token = getCookie('user_access_token');
 
     const socket = new SockJS(`${API_BASE_URL}/ws`);
     const client = new Client({

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -1,4 +1,5 @@
 // Admin API 호출 함수들
+import { getCookie, removeCookie } from '../auth/cookie-utils';
 
 // 커스텀 에러 클래스: 로그인 실패와 네트워크 에러를 구분
 export class LoginFailedError extends Error {
@@ -28,7 +29,7 @@ function getApiBaseUrl(): string {
 
 // Authorization 헤더 가져오기
 function getAuthHeaders(): HeadersInit {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('admin_access_token') : null;
+  const token = getCookie('admin_access_token');
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
   };
@@ -665,9 +666,7 @@ export async function logoutAdmin(): Promise<void> {
     }
   } finally {
     // 항상 프론트엔드 세션 정리
-    if (typeof window !== 'undefined') {
-      localStorage.removeItem('admin_access_token');
-    }
+    removeCookie('admin_access_token');
   }
 }
 
@@ -1794,7 +1793,7 @@ export function streamScoringResult(
   onDone?: () => void
 ): () => void {
   const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
-  const token = typeof window !== 'undefined' ? localStorage.getItem('admin_access_token') : null;
+  const token = getCookie('admin_access_token');
 
   // SSE는 EventSource를 사용하며, 커스텀 헤더 지원이 없으므로 쿼리 파라미터로 토큰 전달
   // 서버 측에서 쿼리 파라미터 토큰을 허용해야 함. 불가 시 fetch + ReadableStream으로 대체

--- a/lib/api/chat.ts
+++ b/lib/api/chat.ts
@@ -1,4 +1,5 @@
 // Chat API 호출 함수들
+import { getCookie } from '../auth/cookie-utils';
 
 // 커스텀 에러 클래스
 export class ChatError extends Error {
@@ -28,7 +29,7 @@ function getApiBaseUrl(): string {
 
 // Authorization 헤더 가져오기 (사용자 토큰)
 function getUserAuthHeaders(): HeadersInit {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('user_access_token') : null;
+  const token = getCookie('user_access_token');
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
   };

--- a/lib/api/exams.ts
+++ b/lib/api/exams.ts
@@ -1,4 +1,5 @@
 // Exam API 호출 함수들
+import { getCookie } from '../auth/cookie-utils';
 
 // 클라이언트 컴포넌트에서 환경 변수 접근을 위한 헬퍼 함수
 function getApiBaseUrl(): string {
@@ -8,7 +9,7 @@ function getApiBaseUrl(): string {
 
 // Authorization 헤더 가져오기 (사용자 토큰)
 function getUserAuthHeaders(): HeadersInit {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('user_access_token') : null;
+  const token = getCookie('user_access_token');
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
   };

--- a/lib/api/submissions.ts
+++ b/lib/api/submissions.ts
@@ -1,7 +1,8 @@
 // Submission API 호출 함수들
+import { getCookie } from '../auth/cookie-utils';
 
 function getAdminAuthHeaders(): HeadersInit {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('admin_access_token') : null;
+  const token = getCookie('admin_access_token');
   return {
     'Content-Type': 'application/json',
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
@@ -13,7 +14,7 @@ function getApiBaseUrl(): string {
 }
 
 function getUserAuthHeaders(): HeadersInit {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('user_access_token') : null;
+  const token = getCookie('user_access_token');
   return {
     'Content-Type': 'application/json',
     ...(token ? { Authorization: `Bearer ${token}` } : {}),
@@ -178,11 +179,9 @@ export function streamScoringResult(
   callbacks: ScoringStreamCallbacks
 ): () => void {
   const controller = new AbortController();
-  const apiBaseUrl = typeof window !== 'undefined'
-    ? (process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080')
-    : 'http://localhost:8080';
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
   const url = `${apiBaseUrl}/api/admin/submissions/${submissionId}/stream`;
-  const token = typeof window !== 'undefined' ? localStorage.getItem('admin_access_token') : null;
+  const token = getCookie('admin_access_token');
 
   async function connect() {
     try {

--- a/lib/auth/cookie-utils.ts
+++ b/lib/auth/cookie-utils.ts
@@ -1,0 +1,43 @@
+/**
+ * 토큰 쿠키 관리 유틸리티
+ *
+ * localStorage 대신 쿠키를 사용합니다.
+ * - Secure: HTTPS 환경에서만 전송
+ * - SameSite=Strict: CSRF 방지
+ *
+ * 주의: 완전한 XSS 보호를 위해서는 백엔드에서 HttpOnly 쿠키로 직접 Set-Cookie 해야 합니다.
+ */
+
+const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+// 쿠키 만료 기간 (7일)
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+
+function buildCookieString(name: string, value: string): string {
+  let cookie = `${encodeURIComponent(name)}=${encodeURIComponent(value)}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Strict`;
+  if (IS_PRODUCTION) {
+    cookie += '; Secure';
+  }
+  return cookie;
+}
+
+export function setCookie(name: string, value: string): void {
+  if (typeof document === 'undefined') return;
+  document.cookie = buildCookieString(name, value);
+}
+
+export function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  const key = encodeURIComponent(name) + '=';
+  const cookies = document.cookie.split('; ');
+  for (const cookie of cookies) {
+    if (cookie.startsWith(key)) {
+      return decodeURIComponent(cookie.slice(key.length));
+    }
+  }
+  return null;
+}
+
+export function removeCookie(name: string): void {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${encodeURIComponent(name)}=; path=/; max-age=0; SameSite=Strict`;
+}

--- a/lib/auth/utils.ts
+++ b/lib/auth/utils.ts
@@ -1,4 +1,5 @@
 // 인증 관련 유틸리티 함수들
+import { setCookie, getCookie, removeCookie } from './cookie-utils';
 
 // 마스터 관리자 번호 상수
 export const MASTER_ADMIN_NUMBER = "MASTER-0001";
@@ -36,7 +37,7 @@ export function isSystemMasterAdmin(admin: { adminNumber?: string | null }): boo
 }
 
 /**
- * 인증 정보를 localStorage에 저장
+ * 인증 정보를 쿠키에 저장
  */
 export function saveAuthInfo(
   accessToken: string,
@@ -44,20 +45,18 @@ export function saveAuthInfo(
   role?: string,
   email?: string
 ): void {
-  if (typeof window === 'undefined') return;
-  
-  localStorage.setItem('admin_access_token', accessToken);
-  localStorage.setItem('admin_number', adminNumber);
+  setCookie('admin_access_token', accessToken);
+  setCookie('admin_number', adminNumber);
   if (role) {
-    localStorage.setItem('admin_role', role);
+    setCookie('admin_role', role);
   }
   if (email) {
-    localStorage.setItem('admin_email', email);
+    setCookie('admin_email', email);
   }
 }
 
 /**
- * localStorage에서 인증 정보 가져오기
+ * 쿠키에서 인증 정보 가져오기
  */
 export function getAuthInfo(): {
   accessToken: string | null;
@@ -65,33 +64,22 @@ export function getAuthInfo(): {
   role: string | null;
   email: string | null;
 } {
-  if (typeof window === 'undefined') {
-    return {
-      accessToken: null,
-      adminNumber: null,
-      role: null,
-      email: null,
-    };
-  }
-  
   return {
-    accessToken: localStorage.getItem('admin_access_token'),
-    adminNumber: localStorage.getItem('admin_number'),
-    role: localStorage.getItem('admin_role'),
-    email: localStorage.getItem('admin_email'),
+    accessToken: getCookie('admin_access_token'),
+    adminNumber: getCookie('admin_number'),
+    role: getCookie('admin_role'),
+    email: getCookie('admin_email'),
   };
 }
 
 /**
- * localStorage에서 인증 정보 삭제
+ * 쿠키에서 인증 정보 삭제
  */
 export function clearAuthInfo(): void {
-  if (typeof window === 'undefined') return;
-  
-  localStorage.removeItem('admin_access_token');
-  localStorage.removeItem('admin_number');
-  localStorage.removeItem('admin_role');
-  localStorage.removeItem('admin_email');
+  removeCookie('admin_access_token');
+  removeCookie('admin_number');
+  removeCookie('admin_role');
+  removeCookie('admin_email');
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.1.6
         version: 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@stomp/stompjs':
+        specifier: ^7.3.0
+        version: 7.3.0
       '@vercel/analytics':
         specifier: latest
         version: 1.5.0(next@16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
@@ -143,6 +146,9 @@ importers:
       recharts:
         specifier: 2.15.4
         version: 2.15.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      sockjs-client:
+        specifier: ^1.6.1
+        version: 1.6.1
       sonner:
         specifier: ^1.7.4
         version: 1.7.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -174,6 +180,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.7)
+      '@types/sockjs-client':
+        specifier: ^1.5.4
+        version: 1.5.4
       postcss:
         specifier: ^8.5
         version: 8.5.6
@@ -253,89 +262,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -396,24 +421,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.0.7':
     resolution: {integrity: sha512-+ksWNrZrthisXuo9gd1XnjHRowCbMtl/YgMpbRvFeDEqEBd523YHPWpBuDjomod88U8Xliw5DHhekBC3EOOd9g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.0.7':
     resolution: {integrity: sha512-4WtJU5cRDxpEE44Ana2Xro1284hnyVpBb62lIpU5k85D8xXxatT+rXxBgPkc7C1XwkZMWpK5rXLXTh9PFipWsA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.0.7':
     resolution: {integrity: sha512-HYlhqIP6kBPXalW2dbMTSuB4+8fe+j9juyxwfMwCe9kQPPeiyFn7NMjNfoFOfJ2eXkeQsoUGXg+O2SE3m4Qg2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.0.7':
     resolution: {integrity: sha512-EviG+43iOoBRZg9deGauXExjRphhuYmIOJ12b9sAPy0eQ6iwcPxfED2asb/s2/yiLYOdm37kPaiZu8uXSYPs0Q==}
@@ -1083,6 +1112,9 @@ packages:
   '@radix-ui/rect@1.1.0':
     resolution: {integrity: sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==}
 
+  '@stomp/stompjs@7.3.0':
+    resolution: {integrity: sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1124,24 +1156,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     resolution: {integrity: sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     resolution: {integrity: sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     resolution: {integrity: sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
@@ -1211,6 +1247,9 @@ packages:
 
   '@types/react@19.2.7':
     resolution: {integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==}
+
+  '@types/sockjs-client@1.5.4':
+    resolution: {integrity: sha512-zk+uFZeWyvJ5ZFkLIwoGA/DfJ+pYzcZ8eH4H/EILCm2OBZyHH6Hkdna1/UWL/CFruh5wj6ES7g75SvUB0VsH5w==}
 
   '@vercel/analytics@1.5.0':
     resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
@@ -1330,6 +1369,14 @@ packages:
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
+  debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
@@ -1370,9 +1417,17 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  eventsource@2.0.2:
+    resolution: {integrity: sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==}
+    engines: {node: '>=12.0.0'}
+
   fast-equals@5.3.3:
     resolution: {integrity: sha512-/boTcHZeIAQ2r/tL11voclBHDeP9WPxLt+tyAbVSyyXuUFyh0Tne7gJZTqGbxnvj79TjLdCXLOY7UIPhyG5MTw==}
     engines: {node: '>=6.0.0'}
+
+  faye-websocket@0.11.4:
+    resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
+    engines: {node: '>=0.8.0'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -1383,6 +1438,12 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
   input-otp@1.4.1:
     resolution: {integrity: sha512-+yvpmKYKHi9jIGngxagY9oWiiblPB7+nEO75F2l2o4vs+6vpPZZmUl4tBNYuTCvQjhvEIbdNeJu70bhfYP2nbw==}
@@ -1436,24 +1497,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -1485,6 +1550,9 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -1545,6 +1613,9 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   react-day-picker@9.8.0:
     resolution: {integrity: sha512-E0yhhg7R+pdgbl/2toTb0xBhsEAtmAx1l7qjIWYfcxOy8w4rTSVfbtBoSzVVhPwKP/5E9iL38LivzoE3AQDhCQ==}
@@ -1631,6 +1702,12 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -1642,6 +1719,10 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  sockjs-client@1.6.1:
+    resolution: {integrity: sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==}
+    engines: {node: '>=12'}
 
   sonner@1.7.4:
     resolution: {integrity: sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==}
@@ -1704,6 +1785,9 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
@@ -1737,6 +1821,14 @@ packages:
 
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
+  websocket-driver@0.7.4:
+    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+    engines: {node: '>=0.8.0'}
+
+  websocket-extensions@0.1.4:
+    resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
+    engines: {node: '>=0.8.0'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -2627,6 +2719,8 @@ snapshots:
 
   '@radix-ui/rect@1.1.0': {}
 
+  '@stomp/stompjs@7.3.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -2736,6 +2830,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/sockjs-client@1.5.4': {}
+
   '@vercel/analytics@1.5.0(next@16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
     optionalDependencies:
       next: 16.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -2831,6 +2927,10 @@ snapshots:
 
   date-fns@4.1.0: {}
 
+  debug@3.2.7:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js-light@2.5.1: {}
 
   detect-libc@2.1.2: {}
@@ -2865,13 +2965,23 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  eventsource@2.0.2: {}
+
   fast-equals@5.3.3: {}
+
+  faye-websocket@0.11.4:
+    dependencies:
+      websocket-driver: 0.7.4
 
   fraction.js@5.3.4: {}
 
   get-nonce@1.0.1: {}
 
   graceful-fs@4.2.11: {}
+
+  http-parser-js@0.5.10: {}
+
+  inherits@2.0.4: {}
 
   input-otp@1.4.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
@@ -2947,6 +3057,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  ms@2.1.3: {}
+
   nanoid@3.3.11: {}
 
   next-themes@0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
@@ -3004,6 +3116,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  querystringify@2.2.0: {}
 
   react-day-picker@9.8.0(react@19.2.1):
     dependencies:
@@ -3093,6 +3207,10 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
+  requires-port@1.0.0: {}
+
+  safe-buffer@5.2.1: {}
+
   scheduler@0.27.0: {}
 
   semver@7.7.3:
@@ -3129,6 +3247,16 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
     optional: true
+
+  sockjs-client@1.6.1:
+    dependencies:
+      debug: 3.2.7
+      eventsource: 2.0.2
+      faye-websocket: 0.11.4
+      inherits: 2.0.4
+      url-parse: 1.5.10
+    transitivePeerDependencies:
+      - supports-color
 
   sonner@1.7.4(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
@@ -3167,6 +3295,11 @@ snapshots:
       browserslist: 4.28.0
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   use-callback-ref@1.3.3(@types/react@19.2.7)(react@19.2.1):
     dependencies:
@@ -3212,6 +3345,14 @@ snapshots:
       d3-shape: 3.2.0
       d3-time: 3.1.0
       d3-timer: 3.0.1
+
+  websocket-driver@0.7.4:
+    dependencies:
+      http-parser-js: 0.5.10
+      safe-buffer: 5.2.1
+      websocket-extensions: 0.1.4
+
+  websocket-extensions@0.1.4: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

- **pnpm lockfile 재생성**: `@stomp/stompjs`, `sockjs-client`, `@types/sockjs-client` 추가 후 lockfile 미갱신으로 인한 Vercel frozen-lockfile 빌드 오류 수정
- **토큰 관리 localStorage → Cookie 전환**: `admin_access_token`, `user_access_token` 등 모든 JWT 토큰 저장소를 `SameSite=Strict; Secure` 쿠키로 이전
- **CI/CD 파이프라인 구성**: GitHub Actions CI(타입체크+빌드), CD(Vercel 자동 배포) 워크플로우 추가
- **환경변수 하드코딩 제거**: `submissions.ts` SSR 구간의 `http://localhost:8080` 하드코딩 제거

## Test plan

- [ ] 로컬에서 관리자 로그인 후 쿠키(`admin_access_token`)에 토큰 저장 확인
- [ ] 로컬에서 사용자 시험 입장 후 쿠키(`user_access_token`)에 토큰 저장 확인
- [ ] 로그아웃 시 쿠키 삭제 확인
- [ ] GitHub Actions CI 워크플로우 통과 확인
- [ ] Vercel 배포 성공 확인