### PR TITLE
fix: 대기→시험 전환 시 tokenLimit 갱신 및 admin 401 리다이렉트

### DIFF
--- a/app/waiting/page.tsx
+++ b/app/waiting/page.tsx
@@ -18,34 +18,38 @@ export default function WaitingPage() {
     }
 
     let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval>;
 
     const checkState = async () => {
       try {
         const res = await getExamState(examId);
         if (cancelled) return;
 
-        // 시험이 시작되었다고 판단할 상태 값 확인
-        // RUNNING 상태일 때 시험 화면으로 이동
         const state = res.state;
 
         if (state === "RUNNING") {
+          // RUNNING 확정 시점에 interval을 즉시 정리해 중복 실행 방지
+          clearInterval(intervalId);
+
           // 시험 시작 후 최신 세션 정보(tokenLimit 등)를 재조회해 store 갱신
           try {
             const session = await getParticipantSession(examId);
+            // 비동기 대기 중 unmount가 발생했을 수 있으므로 재확인
+            if (cancelled) return;
             useExamSessionStore.setState({ tokenLimit: session.tokenLimit });
           } catch (sessionErr) {
             // 세션 갱신 실패해도 화면 이동은 진행 (기존 값 유지)
             console.warn("[WaitingPage] getParticipantSession 실패, 기존 tokenLimit 유지:", sessionErr);
           }
+
+          if (cancelled) return;
           router.push("/test");
         } else {
           // WAITING, ENDED 등의 상태에서는 아무것도 하지 않고 그대로 대기
-          // 에러 메시지 초기화 (정상 대기 상태)
           setErrorMessage(null);
         }
       } catch (err) {
         console.error("[WaitingPage] getExamState error:", err);
-        // 서버 에러가 나도 대기 화면은 유지하되, 에러 메시지만 살짝 보여줌
         setErrorMessage(
           "시험 상태를 불러오는 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
         );
@@ -56,7 +60,7 @@ export default function WaitingPage() {
     checkState();
 
     // 그 이후에는 5초마다 상태를 폴링
-    const intervalId = setInterval(checkState, 5000);
+    intervalId = setInterval(checkState, 5000);
 
     return () => {
       cancelled = true;

--- a/app/waiting/page.tsx
+++ b/app/waiting/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useExamSessionStore } from "@/lib/stores/exam-session-store";
-import { getExamState } from "@/lib/api/exams";
+import { getExamState, getParticipantSession } from "@/lib/api/exams";
 
 export default function WaitingPage() {
   const router = useRouter();
@@ -29,7 +29,14 @@ export default function WaitingPage() {
         const state = res.state;
 
         if (state === "RUNNING") {
-          // 시험이 시작된 경우에만 시험 화면으로 이동
+          // 시험 시작 후 최신 세션 정보(tokenLimit 등)를 재조회해 store 갱신
+          try {
+            const session = await getParticipantSession(examId);
+            useExamSessionStore.setState({ tokenLimit: session.tokenLimit });
+          } catch (sessionErr) {
+            // 세션 갱신 실패해도 화면 이동은 진행 (기존 값 유지)
+            console.warn("[WaitingPage] getParticipantSession 실패, 기존 tokenLimit 유지:", sessionErr);
+          }
           router.push("/test");
         } else {
           // WAITING, ENDED 등의 상태에서는 아무것도 하지 않고 그대로 대기

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -31,6 +31,19 @@ function getAuthHeaders(): HeadersInit {
   return { 'Content-Type': 'application/json' };
 }
 
+/**
+ * 401 Unauthorized 처리 공통 함수
+ * access token이 만료된 경우 로그인 페이지로 리다이렉트한다.
+ * window.location을 사용해 Next.js 라우터 없이도 동작한다.
+ */
+export function handleAdminAuthError(status: number): void {
+  if (status === 401 && typeof window !== 'undefined') {
+    // 쿠키 기반 인증이므로 클라이언트 쿠키 정리 후 홈으로 이동
+    // (HttpOnly 쿠키는 BE 로그아웃 엔드포인트가 삭제하므로 여기서는 홈 이동만 처리)
+    window.location.href = '/?auth_expired=1';
+  }
+}
+
 // BaseResponse 타입
 export interface BaseResponse<T> {
   timestamp: string;
@@ -954,6 +967,7 @@ export interface CreateEntryCodeRequest {
   problemSetId?: number;
   expiresAt?: string; // ISO 8601 형식
   maxUses?: number;
+  tokenLimit?: number;
 }
 
 export interface EntryCodeResponse {
@@ -963,6 +977,7 @@ export interface EntryCodeResponse {
   problemSetId?: number | null;
   expiresAt?: string | null; // ISO 8601 형식
   maxUses: number;
+  tokenLimit: number;
   usedCount: number;
   isActive: boolean;
   createdAt: string; // ISO 8601 형식
@@ -1312,9 +1327,10 @@ export async function deleteExam(examId: number): Promise<void> {
 
     if (!response.ok) {
       let errorMessage = data.message || '시험 삭제에 실패했습니다.';
-      
+
       if (response.status === 401) {
         errorMessage = '인증이 필요합니다. 다시 로그인해주세요.';
+        handleAdminAuthError(response.status);
       } else if (response.status === 403) {
         errorMessage = '권한이 없습니다.';
       } else if (response.status === 404) {
@@ -1410,11 +1426,12 @@ export async function startExam(examId: number): Promise<void> {
 
     if (!response.ok) {
       let errorMessage = data.message || '시험 시작에 실패했습니다.';
-      
+
       if (response.status === 400) {
         errorMessage = data.message || '시험을 시작할 수 없습니다. (이미 시작된 시험일 수 있습니다.)';
       } else if (response.status === 401) {
         errorMessage = '인증이 필요합니다. 다시 로그인해주세요.';
+        handleAdminAuthError(response.status);
       } else if (response.status === 403) {
         errorMessage = '권한이 없습니다.';
       } else if (response.status === 404) {
@@ -1510,11 +1527,12 @@ export async function endExam(examId: number): Promise<void> {
 
     if (!response.ok) {
       let errorMessage = data.message || '시험 종료에 실패했습니다.';
-      
+
       if (response.status === 400) {
         errorMessage = data.message || '시험을 종료할 수 없습니다. (이미 종료된 시험일 수 있습니다.)';
       } else if (response.status === 401) {
         errorMessage = '인증이 필요합니다. 다시 로그인해주세요.';
+        handleAdminAuthError(response.status);
       } else if (response.status === 403) {
         errorMessage = '권한이 없습니다.';
       } else if (response.status === 404) {

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -33,15 +33,50 @@ function getAuthHeaders(): HeadersInit {
 
 /**
  * 401 Unauthorized 처리 공통 함수
- * access token이 만료된 경우 로그인 페이지로 리다이렉트한다.
+ * access token이 만료된 경우 홈으로 리다이렉트한다.
  * window.location을 사용해 Next.js 라우터 없이도 동작한다.
  */
 export function handleAdminAuthError(status: number): void {
   if (status === 401 && typeof window !== 'undefined') {
-    // 쿠키 기반 인증이므로 클라이언트 쿠키 정리 후 홈으로 이동
-    // (HttpOnly 쿠키는 BE 로그아웃 엔드포인트가 삭제하므로 여기서는 홈 이동만 처리)
+    // 쿠키 기반 인증이며 HttpOnly 쿠키 삭제는 BE에서 처리한다.
+    // 여기서는 인증 만료 상태를 표시하며 홈으로 이동만 처리한다.
     window.location.href = '/?auth_expired=1';
   }
+}
+
+/**
+ * admin refresh token으로 access token을 재발급한다.
+ * BE가 새 access_token / refresh_token 쿠키를 Set-Cookie로 내려준다.
+ * 성공 여부(boolean)를 반환한다.
+ */
+export async function reissueAdminToken(): Promise<boolean> {
+  try {
+    const response = await fetch(`${getApiBaseUrl()}/api/auth/admin/reissue`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * fetch를 실행하고, 401 응답 시 토큰 재발급 후 1회 재시도한다.
+ * 재발급도 실패하면 로그인 페이지로 리다이렉트하고 LoginFailedError를 던진다.
+ */
+async function fetchAdminWithRetry(url: string, options: RequestInit): Promise<Response> {
+  let response = await fetch(url, options);
+  if (response.status === 401) {
+    const refreshed = await reissueAdminToken();
+    if (refreshed) {
+      response = await fetch(url, options);
+    } else {
+      handleAdminAuthError(401);
+      throw new LoginFailedError('인증이 필요합니다. 다시 로그인해주세요.', 401);
+    }
+  }
+  return response;
 }
 
 // BaseResponse 타입
@@ -1298,18 +1333,19 @@ export async function deleteExam(examId: number): Promise<void> {
   }
 
   try {
-    const response = await fetch(url, {
+    const fetchOptions = {
       method: 'DELETE',
       headers: getAuthHeaders(),
-      credentials: 'include',
-    });
+      credentials: 'include' as RequestCredentials,
+    };
+    const response = await fetchAdminWithRetry(url, fetchOptions);
 
     if (isDev) {
       console.log('[Delete Exam] 응답 상태:', response.status, response.statusText);
     }
 
     let data: BaseResponse<null>;
-    
+
     try {
       data = await response.json();
     } catch (jsonError) {
@@ -1328,10 +1364,7 @@ export async function deleteExam(examId: number): Promise<void> {
     if (!response.ok) {
       let errorMessage = data.message || '시험 삭제에 실패했습니다.';
 
-      if (response.status === 401) {
-        errorMessage = '인증이 필요합니다. 다시 로그인해주세요.';
-        handleAdminAuthError(response.status);
-      } else if (response.status === 403) {
+      if (response.status === 403) {
         errorMessage = '권한이 없습니다.';
       } else if (response.status === 404) {
         errorMessage = '시험을 찾을 수 없습니다.';
@@ -1397,18 +1430,19 @@ export async function startExam(examId: number): Promise<void> {
   }
 
   try {
-    const response = await fetch(url, {
+    const fetchOptions = {
       method: 'POST',
       headers: getAuthHeaders(),
-      credentials: 'include',
-    });
+      credentials: 'include' as RequestCredentials,
+    };
+    const response = await fetchAdminWithRetry(url, fetchOptions);
 
     if (isDev) {
       console.log('[Start Exam] 응답 상태:', response.status, response.statusText);
     }
 
     let data: BaseResponse<null>;
-    
+
     try {
       data = await response.json();
     } catch (jsonError) {
@@ -1429,9 +1463,6 @@ export async function startExam(examId: number): Promise<void> {
 
       if (response.status === 400) {
         errorMessage = data.message || '시험을 시작할 수 없습니다. (이미 시작된 시험일 수 있습니다.)';
-      } else if (response.status === 401) {
-        errorMessage = '인증이 필요합니다. 다시 로그인해주세요.';
-        handleAdminAuthError(response.status);
       } else if (response.status === 403) {
         errorMessage = '권한이 없습니다.';
       } else if (response.status === 404) {
@@ -1498,18 +1529,19 @@ export async function endExam(examId: number): Promise<void> {
   }
 
   try {
-    const response = await fetch(url, {
+    const fetchOptions = {
       method: 'POST',
       headers: getAuthHeaders(),
-      credentials: 'include',
-    });
+      credentials: 'include' as RequestCredentials,
+    };
+    const response = await fetchAdminWithRetry(url, fetchOptions);
 
     if (isDev) {
       console.log('[End Exam] 응답 상태:', response.status, response.statusText);
     }
 
     let data: BaseResponse<null>;
-    
+
     try {
       data = await response.json();
     } catch (jsonError) {
@@ -1530,9 +1562,6 @@ export async function endExam(examId: number): Promise<void> {
 
       if (response.status === 400) {
         errorMessage = data.message || '시험을 종료할 수 없습니다. (이미 종료된 시험일 수 있습니다.)';
-      } else if (response.status === 401) {
-        errorMessage = '인증이 필요합니다. 다시 로그인해주세요.';
-        handleAdminAuthError(response.status);
       } else if (response.status === 403) {
         errorMessage = '권한이 없습니다.';
       } else if (response.status === 404) {

--- a/lib/api/exams.ts
+++ b/lib/api/exams.ts
@@ -159,6 +159,39 @@ export async function getExamState(examId: number): Promise<GetExamStateResponse
   }
 }
 
+// 참가자 세션 정보 응답 타입
+export interface ParticipantSessionResponse {
+  participantId: number;
+  examId: number;
+  tokenLimit: number;
+  tokenUsed: number;
+  specId: number | null;
+  assignedProblemId: number | null;
+}
+
+/**
+ * 현재 참가자의 세션 정보 조회 (대기→시험 전환 시 최신 tokenLimit 갱신용)
+ * GET /api/exams/{examId}/participants/me
+ */
+export async function getParticipantSession(examId: number): Promise<ParticipantSessionResponse> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/exams/${examId}/participants/me`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: getUserAuthHeaders(),
+    credentials: 'include',
+  });
+
+  const data: BaseResponse<ParticipantSessionResponse> = await response.json();
+  if (!response.ok || data.code !== 'COMMON200' || !data.result) {
+    const err: any = new Error(data.message || '세션 정보 조회에 실패했습니다.');
+    err.status = response.status;
+    throw err;
+  }
+  return data.result;
+}
+
 /**
  * 참가자에게 배정된 문제 조회 API
  * GET /api/exams/{examId}/assignment

--- a/lib/api/exams.ts
+++ b/lib/api/exams.ts
@@ -161,7 +161,7 @@ export async function getExamState(examId: number): Promise<GetExamStateResponse
 
 // 참가자 세션 정보 응답 타입
 export interface ParticipantSessionResponse {
-  participantId: number;
+  examParticipantId: number;
   examId: number;
   tokenLimit: number;
   tokenUsed: number;


### PR DESCRIPTION
## 개요

대기 화면에서 시험으로 전환 시 최신 tokenLimit이 반영되지 않는 버그와,
관리자 토큰 만료 시 버튼이 조용히 실패하는 UX 문제를 수정합니다.

## 배경 / 원인

1. **tokenLimit 미반영**: `waiting/page.tsx`는 RUNNING 감지 시 store를 갱신 없이 바로
   `/test`로 이동했습니다. Zustand store의 tokenLimit은 enterExam 시점 값이므로,
   관리자가 시험 시작 전 tokenLimit을 변경해도 참가자 화면에 반영되지 않았습니다.

2. **admin 401 무음 실패**: startExam·endExam·deleteExam API가 401을 반환할 때
   에러를 throw만 하고 별도 처리가 없어, 버튼이 조용히 실패했습니다.

## 변경 사항

### waiting → test 전환 시 세션 재조회 (`#BUG-1`)

`lib/api/exams.ts`
- `ParticipantSessionResponse` 타입 추가
- `getParticipantSession(examId)` 함수 추가 (`GET /api/exams/{examId}/participants/me`)

`app/waiting/page.tsx`
- RUNNING 감지 시 세션 재조회 → `tokenLimit` store 갱신 후 `/test` 이동
- 재조회 실패해도 `/test` 이동은 보장 (기존 tokenLimit 유지 fallback)

### admin 401 리다이렉트 (`#BUG-2`)

`lib/api/admin.ts`
- `handleAdminAuthError(status)` 유틸 추가 — 401 시 `/?auth_expired=1` 리다이렉트
  (`window.location.href` 사용으로 Next.js 라우터 외부 동작 보장)
- `startExam` / `endExam` / `deleteExam` 401 블록에 적용
- `CreateEntryCodeRequest` 인터페이스에 `tokenLimit?: number` 추가
- `EntryCodeResponse` 인터페이스에 `tokenLimit: number` 추가 (BE 응답 필드 동기화)

## 관련 이슈

closes #24

## 체크리스트

- [x] 세션 재조회 실패 시 기존값 유지 fallback 처리
- [x] SSR 환경 고려 (`typeof window !== 'undefined'` 가드)
- [x] BE `ParticipantSessionResponse` 스펙과 타입 일치
- [x] FE 타입과 BE 응답 필드 동기화 (`tokenLimit`)