### PR TITLE
fix: persist exam session on refresh

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import UserTestScreen from "@/components/user-test-screen"
+import { ExamSessionPersistGate } from "@/components/exam-session-persist-gate"
 
 export default function TestPage() {
-  return <UserTestScreen />
+  return (
+    <ExamSessionPersistGate>
+      <UserTestScreen />
+    </ExamSessionPersistGate>
+  )
 }

--- a/app/waiting/page.tsx
+++ b/app/waiting/page.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useExamSessionStore } from "@/lib/stores/exam-session-store";
 import { getExamState, getParticipantSession } from "@/lib/api/exams";
+import { ExamSessionPersistGate } from "@/components/exam-session-persist-gate";
 
-export default function WaitingPage() {
+function WaitingPageInner() {
   const router = useRouter();
   const examId = useExamSessionStore((state: { examId: number | null }) => state.examId);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -92,5 +93,13 @@ export default function WaitingPage() {
         </div>
       </main>
     </div>
+  );
+}
+
+export default function WaitingPage() {
+  return (
+    <ExamSessionPersistGate>
+      <WaitingPageInner />
+    </ExamSessionPersistGate>
   );
 }

--- a/components/exam-session-persist-gate.tsx
+++ b/components/exam-session-persist-gate.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { useLayoutEffect, useState, type ReactNode } from "react"
+import { useExamSessionStore } from "@/lib/stores/exam-session-store"
+
+/**
+ * 시험 세션 zustand persist(skipHydration) 복구가 끝난 뒤에만 자식을 렌더링합니다.
+ * 새로고침 직후 examId 등이 잠깐 null인 상태로 API/타이머가 돌지 않도록 합니다.
+ */
+export function ExamSessionPersistGate({ children }: { children: ReactNode }) {
+  const [ready, setReady] = useState(false)
+
+  useLayoutEffect(() => {
+    if (useExamSessionStore.persist.hasHydrated()) {
+      setReady(true)
+      return
+    }
+    void Promise.resolve(useExamSessionStore.persist.rehydrate())
+      .then(() => setReady(true))
+      .catch(() => setReady(true))
+  }, [])
+
+  if (!ready) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#F5F5F5] text-sm text-[#6B7280]">
+        시험 정보를 불러오는 중…
+      </div>
+    )
+  }
+
+  return <>{children}</>
+}

--- a/components/user-test-screen.tsx
+++ b/components/user-test-screen.tsx
@@ -10,7 +10,7 @@ import { AiAssistantSidebar } from "@/components/ai-assistant-sidebar"
 import { useRouter } from "next/navigation";
 import { CheckCircle2 } from "lucide-react";
 import { useExamSessionStore } from "@/lib/stores/exam-session-store";
-import { getExamState, ExamState, GetExamStateResponse } from "@/lib/api/exams";
+import { getExamState, getParticipantSession, ExamState, GetExamStateResponse } from "@/lib/api/exams";
 import { RemainingTimer } from "@/components/remaining-timer";
 import { useExamSocket, ExamStateEvent } from "@/hooks/use-exam-socket";
 import { streamScoringResult, FinalScoreEvent, SubmissionStatus } from "@/lib/api/submissions";
@@ -85,6 +85,18 @@ export default function UserTestScreen() {
 
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
   const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false)
+
+  // ── 새로고침 후에도 서버 기준 세션(토큰 한도 등) 동기화 ───────────────────────
+  useEffect(() => {
+    if (!examId) return;
+    getParticipantSession(examId)
+      .then((session) => {
+        useExamSessionStore.setState({ tokenLimit: session.tokenLimit });
+      })
+      .catch(() => {
+        // 쿠키 만료·세션 없음 등은 기존 persist 값 유지
+      });
+  }, [examId]);
 
   // ── 초기 토큰 사용량 로드 (getChatHistory.totalTokens) ──────────────────────
   useEffect(() => {
@@ -222,6 +234,19 @@ export default function UserTestScreen() {
   const handleGoHome = () => {
     router.push("/");
   };
+
+  if (!examId || !participantId) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-[#F5F5F5] p-6">
+        <p className="max-w-md text-center text-sm text-[#6B7280]">
+          저장된 시험 세션이 없습니다. 시험에 다시 입장해 주세요.
+        </p>
+        <Button type="button" className="bg-[#2563EB] hover:bg-[#1D4ED8] text-white" onClick={() => router.push("/")}>
+          입장 화면으로
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-[#F5F5F5]">

--- a/lib/stores/exam-session-store.ts
+++ b/lib/stores/exam-session-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 
 interface ExamSessionState {
   examId: number | null;
@@ -10,13 +11,58 @@ interface ExamSessionState {
   clearSession: () => void;
 }
 
-export const useExamSessionStore = create<ExamSessionState>((set) => ({
-  examId: null,
-  participantId: null,
-  tokenLimit: 20000,
-  accessToken: null,
-  setSession: (examId, participantId, tokenLimit = 20000) => set({ examId, participantId, tokenLimit }),
-  setAccessToken: (token) => set({ accessToken: token }),
-  clearSession: () => set({ examId: null, participantId: null, tokenLimit: 20000, accessToken: null }),
-}));
+/** SSR·프리렌더 시 `sessionStorage` 미존재 — no-op 스토리지로 동일 API 유지 */
+const noopStorage = (): Storage => {
+  const memory = new Map<string, string>();
+  return {
+    get length() {
+      return memory.size;
+    },
+    clear: () => memory.clear(),
+    getItem: (key: string) => memory.get(key) ?? null,
+    key: (index: number) => Array.from(memory.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      memory.set(key, value);
+    },
+  };
+};
 
+const sessionStorageOrNoop = (): Storage =>
+  typeof window !== "undefined" ? window.sessionStorage : noopStorage();
+
+export const useExamSessionStore = create<ExamSessionState>()(
+  persist(
+    (set) => ({
+      examId: null,
+      participantId: null,
+      tokenLimit: 20000,
+      accessToken: null,
+      setSession: (examId, participantId, tokenLimit = 20000) =>
+        set({ examId, participantId, tokenLimit }),
+      setAccessToken: (token) => set({ accessToken: token }),
+      clearSession: () => {
+        set({ examId: null, participantId: null, tokenLimit: 20000, accessToken: null });
+        try {
+          useExamSessionStore.persist.clearStorage();
+        } catch {
+          /* no-op */
+        }
+      },
+    }),
+    {
+      name: "vibecode-exam-session",
+      storage: createJSONStorage(sessionStorageOrNoop),
+      partialize: (state) => ({
+        examId: state.examId,
+        participantId: state.participantId,
+        tokenLimit: state.tokenLimit,
+        accessToken: state.accessToken,
+      }),
+      /** Next SSR과 클라이언트 sessionStorage 복구 시점을 맞추기 위해 수동 rehydrate 사용 */
+      skipHydration: true,
+    },
+  ),
+);


### PR DESCRIPTION
## 개요
시험 화면에서 새로고침 시 시험 상태가 초기화되는 문제를 수정했습니다.

## 문제
- 새로고침 시 examId / participantId 초기화
- 타이머가 00:00:00으로 표시됨
- 문제 영역 및 AI 어시스턴트 버튼이 사라짐

## 원인
- Zustand store가 메모리 기반이라 새로고침 시 상태 유지 불가

## 수정 내용
- exam-session-store에 sessionStorage persist 적용
- hydration 완료 이후에만 렌더링하도록 처리
- test / waiting 페이지에 persist gate 적용
- participant session 기반 tokenLimit 재동기화

## 결과
- 새로고침 시 코드 에디터 내용을 제외한 시험 상태 정상 복구

## TODO
- 새로고침 시 코드 에디터 내용 복구 기능은 추후 보완 예정