### PR TITLE
fix: restore exam session after refresh

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -1,7 +1,66 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import UserTestScreen from "@/components/user-test-screen"
+import { useExamSessionStore } from "@/lib/stores/exam-session-store";
+import { getActiveSession } from "@/lib/api/exams";
 
 export default function TestPage() {
+  const router = useRouter();
+  const [isRestoring, setIsRestoring] = useState(true);
+  const [restoreError, setRestoreError] = useState<string | null>(null);
+  const examId = useExamSessionStore((state) => state.examId);
+  const participantId = useExamSessionStore((state) => state.participantId);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const restoreSession = async () => {
+      try {
+        const activeSession = await getActiveSession();
+        if (cancelled) return;
+
+        if (!activeSession) {
+          setRestoreError("활성 시험 세션이 없습니다. 다시 입장해주세요.");
+          setTimeout(() => router.replace("/"), 1200);
+          return;
+        }
+
+        useExamSessionStore.setState({
+          examId: activeSession.examId,
+          participantId: activeSession.examParticipantId,
+          tokenLimit: activeSession.tokenLimit,
+        });
+      } catch (error) {
+        if (cancelled) return;
+        console.error("[TestPage] active session restore failed:", error);
+        setRestoreError("세션 복구에 실패했습니다. 다시 입장해주세요.");
+        setTimeout(() => router.replace("/"), 1200);
+      } finally {
+        if (!cancelled) {
+          setIsRestoring(false);
+        }
+      }
+    };
+
+    restoreSession();
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  if (isRestoring || !examId || !participantId) {
+    return (
+      <div className="min-h-screen w-full bg-[#F5F5F5] flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-base font-medium text-[#1F2937]">
+            {restoreError ?? "시험 세션을 복구하는 중입니다..."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return <UserTestScreen />
 }

--- a/components/entry-codes-content.tsx
+++ b/components/entry-codes-content.tsx
@@ -49,6 +49,22 @@ const getExamStateLabel = (state: string): string => {
   }
 }
 
+// 백엔드 응답의 다양한 필드명(entryCode/accessCode/code/inviteCode)에서 입장 코드를 추출
+const pickEntryCode = (source: unknown): string | undefined => {
+  if (!source || typeof source !== "object") return undefined
+
+  const record = source as Record<string, unknown>
+  const candidates = ["entryCode", "accessCode", "code", "inviteCode"]
+  for (const key of candidates) {
+    const value = record[key]
+    if (typeof value === "string" && value.trim()) {
+      return value
+    }
+  }
+
+  return undefined
+}
+
 export function EntryCodesContent() {
 
   // 시험 생성 모달 상태
@@ -120,14 +136,14 @@ export function EntryCodesContent() {
             const activeEntryCode = entryCodes.find((ec) => ec.isActive) || entryCodes[0]
             return {
               ...exam,
-              entryCode: activeEntryCode?.code || undefined,
+              entryCode: activeEntryCode?.code || pickEntryCode(exam),
             }
           } catch (entryCodeError) {
             // 입장 코드 조회 실패 시 해당 시험의 입장 코드는 undefined로 유지
             console.warn(`Failed to fetch entry codes for exam ${exam.id}:`, entryCodeError)
             return {
               ...exam,
-              entryCode: undefined,
+              entryCode: pickEntryCode(exam),
             }
           }
         })
@@ -211,14 +227,32 @@ export function EntryCodesContent() {
     setIsSubmitting(true)
     try {
       const createdExam = await createExam(payload)
-      console.log("Exam created:", createdExam)
+      const responseEntryCode = pickEntryCode(createdExam)
+      let createdExamWithEntryCode: Exam = {
+        ...createdExam,
+        entryCode: responseEntryCode,
+      }
+
+      // 생성 직후 entry-codes API에서 실제 활성 코드를 한번 더 조회해 반영
+      try {
+        const createdExamEntryCodes = await getEntryCodes(createdExam.id)
+        const activeEntryCode = createdExamEntryCodes.find((ec) => ec.isActive) || createdExamEntryCodes[0]
+        createdExamWithEntryCode = {
+          ...createdExam,
+          entryCode: activeEntryCode?.code || responseEntryCode,
+        }
+      } catch (entryCodeError) {
+        console.warn(`Failed to fetch entry codes right after exam creation (examId=${createdExam.id}):`, entryCodeError)
+      }
+
+      console.log("Exam created:", createdExamWithEntryCode)
 
       // 시험 목록에 새로 생성된 시험 추가
       setExams((prev) => {
         if (prev === null) {
-          return [createdExam]
+          return [createdExamWithEntryCode]
         }
-        return [createdExam, ...prev]
+        return [createdExamWithEntryCode, ...prev]
       })
 
       // 모달 닫기
@@ -232,7 +266,7 @@ export function EntryCodesContent() {
       // 성공 토스트 표시
       toast({
         title: "시험 생성 성공",
-        description: `"${createdExam.title}" 시험이 성공적으로 생성되었습니다.`,
+        description: `"${createdExamWithEntryCode.title}" 시험이 성공적으로 생성되었습니다.`,
       })
     } catch (error) {
       console.error("Failed to create exam", error)

--- a/hooks/use-chat-socket.tsx
+++ b/hooks/use-chat-socket.tsx
@@ -21,16 +21,6 @@ interface SendMessageResponse {
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
 
-/** JWT 만료 여부 확인 (클라이언트 사이드) */
-function isTokenExpired(token: string): boolean {
-  try {
-    const payload = JSON.parse(atob(token.split('.')[1]));
-    return payload.exp * 1000 < Date.now();
-  } catch {
-    return true;
-  }
-}
-
 export function useChatSocket(
   examId: number,
   participantId: number,
@@ -39,7 +29,7 @@ export function useChatSocket(
 ) {
   const [isConnected, setIsConnected] = useState(false);
   const stompClientRef = useRef<Client | null>(null);
-  // 셀렉터로 구독: accessToken 변경 시 effect 재실행 → 로그인 후 소켓 연결 보장
+  // accessToken은 있으면 Authorization 헤더로 전달하고, 없으면 쿠키 기반 인증으로 연결
   const accessToken = useExamSessionStore((state) => state.accessToken);
 
   // 콜백을 ref로 관리: 최신 함수 참조를 유지하면서 STOMP 재연결을 방지
@@ -49,17 +39,7 @@ export function useChatSocket(
   useEffect(() => { onErrorRef.current = onError; }, [onError]);
 
   useEffect(() => {
-    // STOMP CONNECT 시 JWT를 헤더로 전달해 서버 Principal(userId) 설정을 가능하게 함
-    // BE의 StompPrincipalInterceptor가 이 토큰을 파싱해 participantId를 Principal로 등록
-    // → convertAndSendToUser(participantId, "/queue/chat", response) 라우팅이 정상 동작
     const token = accessToken;
-
-    // 만료된 토큰으로 연결 시 Principal이 설정되지 않아 convertAndSendToUser가 무음 실패함
-    if (!token || isTokenExpired(token)) {
-      console.warn('[STOMP Chat] JWT 토큰이 없거나 만료됨 - 재로그인 필요');
-      onErrorRef.current?.('세션이 만료되었습니다. 다시 로그인해주세요.');
-      return;
-    }
 
     const socket = new SockJS(`${API_BASE_URL}/ws`);
     const client = new Client({

--- a/lib/api/exams.ts
+++ b/lib/api/exams.ts
@@ -169,6 +169,63 @@ export interface ParticipantSessionResponse {
   assignedProblemId: number | null;
 }
 
+// 활성 시험 세션 복구 응답 타입
+export interface ActiveSessionResponse {
+  examId: number;
+  examParticipantId: number;
+  assignedProblemId: number | null;
+  specId: number | null;
+  examState: ExamState;
+  startsAt: string;
+  endsAt: string;
+  serverTime: string;
+  tokenLimit: number;
+  tokenUsed: number;
+}
+
+/**
+ * 현재 로그인한 참가자의 활성 시험 세션 조회
+ * GET /api/exams/active-session
+ */
+export async function getActiveSession(): Promise<ActiveSessionResponse | null> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/exams/active-session`;
+  const isDev = process.env.NODE_ENV === 'development';
+
+  if (isDev) {
+    console.log('[Get Active Session] API 호출:', url);
+  }
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: getUserAuthHeaders(),
+    credentials: 'include',
+  });
+
+  let data: BaseResponse<ActiveSessionResponse>;
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error('활성 세션 응답을 파싱할 수 없습니다.');
+  }
+
+  if (!response.ok) {
+    // 활성 세션이 없는 경우(null)로 처리
+    if (response.status === 404 || data.code === 'EXAM404_5') {
+      return null;
+    }
+    const err: any = new Error(data.message || '활성 세션 조회에 실패했습니다.');
+    err.status = response.status;
+    throw err;
+  }
+
+  if (data.code !== 'COMMON200' || !data.result) {
+    return null;
+  }
+
+  return data.result;
+}
+
 /**
  * 현재 참가자의 세션 정보 조회 (대기→시험 전환 시 최신 tokenLimit 갱신용)
  * GET /api/exams/{examId}/participants/me


### PR DESCRIPTION
## 변경 내용

* 시험 화면(`/test`) 새로고침 시 active-session API 기반 세션 복구 로직 추가
* 새로고침 후 examId / participantId / tokenLimit 상태 복구
* WebSocket(STOMP) 연결 시 token 의존 완화 및 쿠키 기반 연결 대응
* 시험 생성 직후 entry code 표시 보강
* entryCode/accessCode/code/inviteCode 필드 별칭 대응 추가

## 해결한 문제

* 시험 화면 새로고침 시 세션이 끊기고 복구되지 않던 문제
* 시험 생성 직후 "입장 코드 없음"으로 표시되던 문제

## 테스트 내용

* 시험 생성 후 entry code 정상 표시 확인
* `/test` 진입 후 새로고침 시 세션 정상 복구 확인
* 새로고침 후 시험 화면 및 WebSocket 연결 정상 동작 확인
