### PR TITLE
fix: add retry handling for active-session and assignment APIs

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -15,6 +15,18 @@ export default function TestPage() {
 
   useEffect(() => {
     let cancelled = false;
+    let redirectTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const scheduleRedirect = () => {
+      if (redirectTimeoutId !== undefined) {
+        clearTimeout(redirectTimeoutId);
+      }
+      redirectTimeoutId = setTimeout(() => {
+        if (!cancelled) {
+          router.replace("/");
+        }
+      }, 1200);
+    };
 
     const restoreSession = async () => {
       const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
@@ -24,6 +36,8 @@ export default function TestPage() {
       // 이 경우 즉시 entry로 튕기지 말고 짧게 재시도 후 실패 시에만 리다이렉트한다.
       const maxAttempts = 6; // 총 5~6초 내 재시도
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        if (cancelled) return;
+
         try {
           const currentExamId = useExamSessionStore.getState().examId;
           const activeSession = currentExamId
@@ -42,17 +56,18 @@ export default function TestPage() {
 
           if (attempt === maxAttempts) {
             setRestoreError("활성 시험 세션이 없습니다. 다시 입장해주세요.");
-            setTimeout(() => router.replace("/"), 1200);
+            scheduleRedirect();
             return;
           }
 
           await sleep(300 + attempt * 250);
+          if (cancelled) return;
         } catch (error: any) {
           if (cancelled) return;
           // 인증 실패(쿠키 누락/만료)는 재시도해도 의미 없으므로 즉시 리다이렉트
           if (error?.status === 401) {
             setRestoreError("인증이 필요합니다. 다시 입장해주세요.");
-            setTimeout(() => router.replace("/"), 1200);
+            scheduleRedirect();
             return;
           }
 
@@ -60,11 +75,12 @@ export default function TestPage() {
 
           if (attempt === maxAttempts) {
             setRestoreError("세션 복구에 실패했습니다. 다시 입장해주세요.");
-            setTimeout(() => router.replace("/"), 1200);
+            scheduleRedirect();
             return;
           }
 
           await sleep(300 + attempt * 250);
+          if (cancelled) return;
         }
       }
     };
@@ -74,6 +90,9 @@ export default function TestPage() {
     });
     return () => {
       cancelled = true;
+      if (redirectTimeoutId !== undefined) {
+        clearTimeout(redirectTimeoutId);
+      }
     };
   }, [router]);
 

--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import UserTestScreen from "@/components/user-test-screen"
 import { useExamSessionStore } from "@/lib/stores/exam-session-store";
-import { getActiveSession } from "@/lib/api/exams";
+import { getActiveSession, getActiveSessionByExam } from "@/lib/api/exams";
 
 export default function TestPage() {
   const router = useRouter();
@@ -17,34 +17,61 @@ export default function TestPage() {
     let cancelled = false;
 
     const restoreSession = async () => {
-      try {
-        const activeSession = await getActiveSession();
-        if (cancelled) return;
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-        if (!activeSession) {
-          setRestoreError("활성 시험 세션이 없습니다. 다시 입장해주세요.");
-          setTimeout(() => router.replace("/"), 1200);
-          return;
-        }
+      // 시험 시작 직후(관리자 start 직후)에는 서버가 아직 "RUNNING/active-session"으로
+      // 판단되기 전에 FE가 먼저 조회할 수 있어 404(NO_ACTIVE_SESSION)가 일시적으로 발생할 수 있다.
+      // 이 경우 즉시 entry로 튕기지 말고 짧게 재시도 후 실패 시에만 리다이렉트한다.
+      const maxAttempts = 6; // 총 5~6초 내 재시도
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          const currentExamId = useExamSessionStore.getState().examId;
+          const activeSession = currentExamId
+            ? await getActiveSessionByExam(currentExamId)
+            : await getActiveSession();
+          if (cancelled) return;
 
-        useExamSessionStore.setState({
-          examId: activeSession.examId,
-          participantId: activeSession.examParticipantId,
-          tokenLimit: activeSession.tokenLimit,
-        });
-      } catch (error) {
-        if (cancelled) return;
-        console.error("[TestPage] active session restore failed:", error);
-        setRestoreError("세션 복구에 실패했습니다. 다시 입장해주세요.");
-        setTimeout(() => router.replace("/"), 1200);
-      } finally {
-        if (!cancelled) {
-          setIsRestoring(false);
+          if (activeSession) {
+            useExamSessionStore.setState({
+              examId: activeSession.examId,
+              participantId: activeSession.examParticipantId,
+              tokenLimit: activeSession.tokenLimit,
+            });
+            return;
+          }
+
+          if (attempt === maxAttempts) {
+            setRestoreError("활성 시험 세션이 없습니다. 다시 입장해주세요.");
+            setTimeout(() => router.replace("/"), 1200);
+            return;
+          }
+
+          await sleep(300 + attempt * 250);
+        } catch (error: any) {
+          if (cancelled) return;
+          // 인증 실패(쿠키 누락/만료)는 재시도해도 의미 없으므로 즉시 리다이렉트
+          if (error?.status === 401) {
+            setRestoreError("인증이 필요합니다. 다시 입장해주세요.");
+            setTimeout(() => router.replace("/"), 1200);
+            return;
+          }
+
+          console.error("[TestPage] active session restore failed:", error);
+
+          if (attempt === maxAttempts) {
+            setRestoreError("세션 복구에 실패했습니다. 다시 입장해주세요.");
+            setTimeout(() => router.replace("/"), 1200);
+            return;
+          }
+
+          await sleep(300 + attempt * 250);
         }
       }
     };
 
-    restoreSession();
+    void restoreSession().finally(() => {
+      if (!cancelled) setIsRestoring(false);
+    });
     return () => {
       cancelled = true;
     };

--- a/components/problem-section.tsx
+++ b/components/problem-section.tsx
@@ -10,16 +10,66 @@ interface ProblemSectionProps {
 export function ProblemSection({ examId }: ProblemSectionProps) {
   const [assignment, setAssignment] = useState<AssignmentResponse | null>(null)
   const [loading, setLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
-    getAssignment(examId)
-      .then(setAssignment)
-      .catch((err) => {
-        if (process.env.NODE_ENV === "development") {
-          console.warn("[ProblemSection] getAssignment failed:", err)
+    let cancelled = false
+
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+    const isRetryableNoAssignment = (err: any) => {
+      const status = err?.status
+      const code = err?.code
+      const msg = String(err?.apiMessage || err?.message || "")
+      return status === 400 && (code === "PROBLEM005" || msg.includes("배정된 문제가 없습니다"))
+    }
+
+    const load = async () => {
+      setLoading(true)
+      setErrorMessage(null)
+
+      const maxAttempts = 6
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          const res = await getAssignment(examId)
+          if (cancelled) return
+          setAssignment(res)
+          setLoading(false)
+          return
+        } catch (err: any) {
+          if (cancelled) return
+
+          // 인증 실패는 재시도 대신 별도 안내(자동 리다이렉트 금지)
+          if (err?.status === 401) {
+            setAssignment(null)
+            setErrorMessage("인증이 필요합니다. 다시 입장해주세요.")
+            setLoading(false)
+            return
+          }
+
+          // 배정 지연(PROBLEM005)만 짧게 재시도
+          if (isRetryableNoAssignment(err) && attempt < maxAttempts) {
+            if (process.env.NODE_ENV === "development") {
+              console.warn(`[ProblemSection] assignment not ready (attempt ${attempt}/${maxAttempts}), retrying...`, err)
+            }
+            await sleep(1000)
+            continue
+          }
+
+          if (process.env.NODE_ENV === "development") {
+            console.warn("[ProblemSection] getAssignment failed:", err)
+          }
+          setAssignment(null)
+          setErrorMessage("문제를 불러올 수 없습니다.")
+          setLoading(false)
+          return
         }
-      })
-      .finally(() => setLoading(false))
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
   }, [examId])
 
   const problem = assignment?.problem
@@ -27,7 +77,11 @@ export function ProblemSection({ examId }: ProblemSectionProps) {
   return (
     <div className="bg-white rounded-xl border border-[#D0D0D0] p-6 flex-shrink-0">
       <h2 className="text-lg font-semibold text-[#1F2937] mb-4">
-        {loading ? "문제 로딩 중..." : problem ? `문제. ${problem.title}` : "문제를 불러올 수 없습니다."}
+        {loading
+          ? "문제 배정을 확인하는 중입니다..."
+          : problem
+            ? `문제. ${problem.title}`
+            : (errorMessage ?? "문제를 불러올 수 없습니다.")}
       </h2>
 
       {problem && (

--- a/components/problem-section.tsx
+++ b/components/problem-section.tsx
@@ -20,7 +20,11 @@ export function ProblemSection({ examId }: ProblemSectionProps) {
       const status = err?.status
       const code = err?.code
       const msg = String(err?.apiMessage || err?.message || "")
-      return status === 400 && (code === "PROBLEM005" || msg.includes("배정된 문제가 없습니다"))
+      return (
+        status === 400 ||
+        code === "PROBLEM005" ||
+        msg.includes("배정된 문제가 없습니다")
+      )
     }
 
     const load = async () => {
@@ -52,6 +56,7 @@ export function ProblemSection({ examId }: ProblemSectionProps) {
               console.warn(`[ProblemSection] assignment not ready (attempt ${attempt}/${maxAttempts}), retrying...`, err)
             }
             await sleep(1000)
+            if (cancelled) return
             continue
           }
 

--- a/lib/api/exams.ts
+++ b/lib/api/exams.ts
@@ -240,23 +240,37 @@ export async function getActiveSessionByExam(examId: number): Promise<ActiveSess
     credentials: 'include',
   });
 
-  let data: BaseResponse<ActiveSessionResponse>;
-  try {
-    data = await response.json();
-  } catch {
-    throw new Error('활성 세션 응답을 파싱할 수 없습니다.');
+  if (response.status === 404) {
+    return null;
+  }
+
+  let data: BaseResponse<ActiveSessionResponse> | undefined;
+  const text = await response.text();
+  if (text) {
+    try {
+      data = JSON.parse(text) as BaseResponse<ActiveSessionResponse>;
+    } catch {
+      if (!response.ok) {
+        const err: any = new Error('활성 세션 응답을 파싱할 수 없습니다.');
+        err.status = response.status;
+        throw err;
+      }
+      throw new Error('활성 세션 응답을 파싱할 수 없습니다.');
+    }
   }
 
   if (!response.ok) {
-    if (response.status === 404 || data.code === 'EXAM404_5') {
+    if (data?.code === 'EXAM404_5') {
       return null;
     }
-    const err: any = new Error(data.message || '활성 세션 조회에 실패했습니다.');
+    const err: any = new Error(data?.message || '활성 세션 조회에 실패했습니다.');
     err.status = response.status;
+    err.code = data?.code;
+    err.apiMessage = data?.message;
     throw err;
   }
 
-  if (data.code !== 'COMMON200' || !data.result) {
+  if (!data || data.code !== 'COMMON200' || !data.result) {
     return null;
   }
 
@@ -300,8 +314,22 @@ export async function getAssignment(examId: number): Promise<AssignmentResponse>
     credentials: 'include',
   });
 
-  const data: BaseResponse<AssignmentResponse> = await response.json();
-  if (!response.ok || data.code !== 'COMMON200' || !data.result) {
+  let data: BaseResponse<AssignmentResponse> | undefined;
+  const text = await response.text();
+  if (text) {
+    try {
+      data = JSON.parse(text) as BaseResponse<AssignmentResponse>;
+    } catch {
+      if (!response.ok) {
+        const err: any = new Error('문제 조회 응답을 파싱할 수 없습니다.');
+        err.status = response.status;
+        throw err;
+      }
+      throw new Error('문제 조회 응답을 파싱할 수 없습니다.');
+    }
+  }
+
+  if (!response.ok || !data || data.code !== 'COMMON200' || !data.result) {
     const err: any = new Error(data?.message || '문제 조회에 실패했습니다.');
     err.status = response.status;
     err.code = data?.code;

--- a/lib/api/exams.ts
+++ b/lib/api/exams.ts
@@ -227,6 +227,43 @@ export async function getActiveSession(): Promise<ActiveSessionResponse | null> 
 }
 
 /**
+ * 특정 시험(examId) 기준 활성 시험 세션 조회
+ * GET /api/exams/{examId}/active-session
+ */
+export async function getActiveSessionByExam(examId: number): Promise<ActiveSessionResponse | null> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/exams/${examId}/active-session`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: getUserAuthHeaders(),
+    credentials: 'include',
+  });
+
+  let data: BaseResponse<ActiveSessionResponse>;
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error('활성 세션 응답을 파싱할 수 없습니다.');
+  }
+
+  if (!response.ok) {
+    if (response.status === 404 || data.code === 'EXAM404_5') {
+      return null;
+    }
+    const err: any = new Error(data.message || '활성 세션 조회에 실패했습니다.');
+    err.status = response.status;
+    throw err;
+  }
+
+  if (data.code !== 'COMMON200' || !data.result) {
+    return null;
+  }
+
+  return data.result;
+}
+
+/**
  * 현재 참가자의 세션 정보 조회 (대기→시험 전환 시 최신 tokenLimit 갱신용)
  * GET /api/exams/{examId}/participants/me
  */
@@ -265,8 +302,10 @@ export async function getAssignment(examId: number): Promise<AssignmentResponse>
 
   const data: BaseResponse<AssignmentResponse> = await response.json();
   if (!response.ok || data.code !== 'COMMON200' || !data.result) {
-    const err: any = new Error(data.message || '문제 조회에 실패했습니다.');
+    const err: any = new Error(data?.message || '문제 조회에 실패했습니다.');
     err.status = response.status;
+    err.code = data?.code;
+    err.apiMessage = data?.message;
     throw err;
   }
   return data.result;


### PR DESCRIPTION
## 수정 내용 요약

* `active-session` 세션 복구 과정에 retry/backoff 처리 추가
* 문제 배정이 지연되는 경우 `assignment` API 재시도 처리 추가
* 시험 시작 직후 세션 복구 과정의 loading/error 처리 안정화

## 상세 내용

### `/test` 세션 복구

* `active-session`이 일시적으로 404를 반환하더라도 즉시 entry 화면으로 redirect하지 않도록 수정
* 일정 횟수 동안 `active-session` 재시도 수행
* store에 examId가 존재할 경우 exam 기준 active-session endpoint 우선 사용

### `assignment` 처리

* 아래 조건일 경우 assignment API 재시도 수행

  * `400`
  * `PROBLEM005`
  * `"배정된 문제가 없습니다."`
* 재시도 중에는 loading 상태 유지
* 문제 배정이 잠시 지연되는 경우 즉시 실패 UI가 표시되지 않도록 수정

### 에러 처리 개선

* API 에러 metadata(`status`, `code`, `message`) 보존
* 세션 복구 중 불필요한 redirect 방지
* 화면이 갑자기 전환되는 대신 안정적인 loading/failure 상태 표시

## 참고 사항

* 이후 추가 테스트 결과, 기존 이슈의 근본 원인 중 하나는 같은 브라우저 환경에서 admin/user `access_token` 쿠키가 충돌하는 구조임을 확인했습니다.
* 본 PR은 해당 구조적 문제 자체를 해결하기보다는, 시험 시작 직후 FE 세션 복구 및 상태 전환 과정의 안정화를 목적으로 합니다.
