### PR TITLE
Feature/admin result api integration

### DIFF
--- a/app/admin/results/[entryCode]/[participantId]/page.tsx
+++ b/app/admin/results/[entryCode]/[participantId]/page.tsx
@@ -16,6 +16,7 @@ export default function ParticipantEvaluationPage() {
   const searchParams = useSearchParams();
   const from = searchParams.get("from");
   const sessionId = searchParams.get("sessionId");
+  const participantName = searchParams.get("participantName") ?? undefined;
 
   const decodedEntryCode = decodeURIComponent(entryCode);
 
@@ -36,12 +37,11 @@ export default function ParticipantEvaluationPage() {
 };
 
   return (
-    <main className="mt-[0px] min-h-[calc(100vh-80px)] overflow-y-auto py-6 px-8">
-      <ParticipantEvaluationContent
-        entryCode={decodedEntryCode}
-        participantId={String(participantId)}
-        onBack={handleBack}
-      />
-    </main>
+    <ParticipantEvaluationContent
+      entryCode={decodedEntryCode}
+      participantId={String(participantId)}
+      participantName={participantName}
+      onBack={handleBack}
+    />
   );
 }

--- a/app/admin/results/[entryCode]/page.tsx
+++ b/app/admin/results/[entryCode]/page.tsx
@@ -1,24 +1,18 @@
 // app/admin/results/[entryCode]/page.tsx
+// Next.js 15+ / 16: 동적 라우트의 params는 Promise — 반드시 await 후 사용
 
 import { ParticipantListContent } from "@/components/participant-list-content";
 
 type ResultParticipantsPageProps = {
-  params: {
-    entryCode: string;
-  };
+  params: Promise<{ entryCode: string }>;
 };
 
-// ⚠️ 맨 위에 "use client" 가 있었다면 삭제해주세요.
-// 이 파일은 서버 컴포넌트로 두는게 편합니다.
-
-export default function ResultParticipantsPage({
+export default async function ResultParticipantsPage({
   params,
 }: ResultParticipantsPageProps) {
-  // Next.js 동적 세그먼트에서 받은 값
-  const rawEntryCode = params?.entryCode ?? "";
-
-  // 혹시 인코딩 되어 있을 수 있으니 decode
-  const decodedEntryCode = decodeURIComponent(rawEntryCode);
+  const { entryCode: rawEntryCode } = await params;
+  const safe = rawEntryCode ?? "";
+  const decodedEntryCode = decodeURIComponent(safe);
 
   return <ParticipantListContent entryCode={decodedEntryCode} />;
 }

--- a/app/admin/results/[entryCode]/page.tsx
+++ b/app/admin/results/[entryCode]/page.tsx
@@ -12,7 +12,13 @@ export default async function ResultParticipantsPage({
 }: ResultParticipantsPageProps) {
   const { entryCode: rawEntryCode } = await params;
   const safe = rawEntryCode ?? "";
-  const decodedEntryCode = decodeURIComponent(safe);
+  let decodedEntryCode = safe;
+
+  try {
+    decodedEntryCode = decodeURIComponent(safe);
+  } catch {
+    decodedEntryCode = safe;
+  }
 
   return <ParticipantListContent entryCode={decodedEntryCode} />;
 }

--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -32,9 +32,11 @@ export default function TestPage() {
           if (cancelled) return;
 
           if (activeSession) {
+            const current = useExamSessionStore.getState();
             useExamSessionStore.setState({
               examId: activeSession.examId,
-              participantId: activeSession.examParticipantId,
+              participantId: activeSession.participantId ?? current.participantId,
+              examParticipantId: activeSession.examParticipantId,
               tokenLimit: activeSession.tokenLimit,
             });
             return;

--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import UserTestScreen from "@/components/user-test-screen"
 import { useExamSessionStore } from "@/lib/stores/exam-session-store";
-import { getActiveSession } from "@/lib/api/exams";
+import { getActiveSession, getActiveSessionByExam } from "@/lib/api/exams";
 
 export default function TestPage() {
   const router = useRouter();
@@ -17,34 +17,61 @@ export default function TestPage() {
     let cancelled = false;
 
     const restoreSession = async () => {
-      try {
-        const activeSession = await getActiveSession();
-        if (cancelled) return;
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-        if (!activeSession) {
-          setRestoreError("활성 시험 세션이 없습니다. 다시 입장해주세요.");
-          setTimeout(() => router.replace("/"), 1200);
-          return;
-        }
+      // 시험 시작 직후(관리자 start 직후)에는 서버가 아직 "RUNNING/active-session"으로
+      // 판단되기 전에 FE가 먼저 조회할 수 있어 404(NO_ACTIVE_SESSION)가 일시적으로 발생할 수 있다.
+      // 이 경우 즉시 entry로 튕기지 말고 짧게 재시도 후 실패 시에만 리다이렉트한다.
+      const maxAttempts = 6; // 총 5~6초 내 재시도
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          const currentExamId = useExamSessionStore.getState().examId;
+          const activeSession = currentExamId
+            ? await getActiveSessionByExam(currentExamId)
+            : await getActiveSession();
+          if (cancelled) return;
 
-        useExamSessionStore.setState({
-          examId: activeSession.examId,
-          participantId: activeSession.examParticipantId,
-          tokenLimit: activeSession.tokenLimit,
-        });
-      } catch (error) {
-        if (cancelled) return;
-        console.error("[TestPage] active session restore failed:", error);
-        setRestoreError("세션 복구에 실패했습니다. 다시 입장해주세요.");
-        setTimeout(() => router.replace("/"), 1200);
-      } finally {
-        if (!cancelled) {
-          setIsRestoring(false);
+          if (activeSession) {
+            useExamSessionStore.setState({
+              examId: activeSession.examId,
+              participantId: activeSession.examParticipantId,
+              tokenLimit: activeSession.tokenLimit,
+            });
+            return;
+          }
+
+          if (attempt === maxAttempts) {
+            setRestoreError("활성 시험 세션이 없습니다. 다시 입장해주세요.");
+            setTimeout(() => router.replace("/"), 1200);
+            return;
+          }
+
+          await sleep(300 + attempt * 250);
+        } catch (error: any) {
+          if (cancelled) return;
+          // 인증 실패(쿠키 누락/만료)는 재시도해도 의미 없으므로 즉시 리다이렉트
+          if (error?.status === 401) {
+            setRestoreError("인증이 필요합니다. 다시 입장해주세요.");
+            setTimeout(() => router.replace("/"), 1200);
+            return;
+          }
+
+          console.error("[TestPage] active session restore failed:", error);
+
+          if (attempt === maxAttempts) {
+            setRestoreError("세션 복구에 실패했습니다. 다시 입장해주세요.");
+            setTimeout(() => router.replace("/"), 1200);
+            return;
+          }
+
+          await sleep(300 + attempt * 250);
         }
       }
     };
 
-    restoreSession();
+    void restoreSession().finally(() => {
+      if (!cancelled) setIsRestoring(false);
+    });
     return () => {
       cancelled = true;
     };

--- a/components/analytics-content.tsx
+++ b/components/analytics-content.tsx
@@ -34,11 +34,15 @@ function mapBoardToParticipant(entry: ExamineeBoardEntry, examTitle: string): Pa
   const tokenRatio =
     entry.tokenLimit > 0 ? Math.min(100, Math.round((entry.tokenUsed / entry.tokenLimit) * 100)) : 0
 
+  const total =
+    entry.totalScore != null && entry.totalScore !== undefined ? Number(entry.totalScore) : null
+  const avgScore = total != null && !Number.isNaN(total) ? total : 0
+
   return {
     id: entry.examParticipantId.toString(),
     name: entry.name,
     entryCode: examTitle,
-    avgScore: 0, // 채점 API 미연동 — 채점 완료 후 집계 예정
+    avgScore,
     status: submitted ? "완료" : "진행 중",
     trend: "보통",
     sparklineData: [0, tokenRatio], // 토큰 사용 추이

--- a/components/analytics-content.tsx
+++ b/components/analytics-content.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useEffect } from "react"
 import Link from "next/link"
 import { Download, TrendingUp, TrendingDown, Minus, ChevronDown, X, CheckCircle } from "lucide-react"
 import { getExams, getBoard, Exam, ExamineeBoardEntry } from "@/lib/api/admin"
+import { adminParticipantEvaluationHref } from "@/lib/paths/admin-participant-evaluation"
 
 type Trend = "높음" | "보통" | "낮음"
 type Status = "완료" | "진행 중"
@@ -150,10 +151,12 @@ function ParticipantCard({ participant }: { participant: Participant }) {
 
       <div className="mt-4 flex justify-end">
         <Link
-          href={{
-            pathname: `/admin/results/${encodeURIComponent(participant.entryCode)}/${participant.id}`,
-            query: { from: "analytics" },
-          }}
+          href={adminParticipantEvaluationHref({
+            resultsSegment: participant.entryCode,
+            participantId: participant.id,
+            from: "analytics",
+            participantName: participant.name,
+          })}
           className="text-sm font-medium text-[#3B82F6] transition-colors hover:text-[#2563EB]"
         >
           상세 보기 →

--- a/components/code-editor-section.tsx
+++ b/components/code-editor-section.tsx
@@ -184,7 +184,7 @@ export const CodeEditorSection = forwardRef<CodeEditorSectionHandle, CodeEditorS
       {/* Editor Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-[#E5E7EB]">
         <span className="text-sm font-medium text-[#1F2937]">Code Editor</span>
-        <div className="flex items-center gap-3">
+        <div className="flex shrink-0 items-center">
           <Select value={language} onValueChange={handleLanguageChange} disabled={isReadOnly}>
             <SelectTrigger className="w-[140px] h-8 text-sm">
               <SelectValue />
@@ -196,18 +196,6 @@ export const CodeEditorSection = forwardRef<CodeEditorSectionHandle, CodeEditorS
               <SelectItem value="javascript">JavaScript</SelectItem>
             </SelectContent>
           </Select>
-
-          {/* 제출 버튼 — isReadOnly일 때 숨김 */}
-          {!isReadOnly && examId && (
-            <button
-              type="button"
-              onClick={() => void handleSubmit()}
-              disabled={isSubmitting}
-              className="h-8 px-4 text-sm font-medium rounded-md bg-[#2563EB] text-white hover:bg-[#1D4ED8] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            >
-              {isSubmitting ? "제출 중…" : "코드 제출"}
-            </button>
-          )}
         </div>
       </div>
 

--- a/components/code-editor-section.tsx
+++ b/components/code-editor-section.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react"
 
-import { useState, useRef } from "react"
+import { useState, useRef, useCallback, useImperativeHandle, forwardRef } from "react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { submitCode, SubmissionStatus } from "@/lib/api/submissions"
 
@@ -77,11 +77,20 @@ interface CodeEditorSectionProps {
   onSubmitted?: (submissionId: number) => void;
 }
 
-export function CodeEditorSection({
+/** 부모(헤더 제출 확인 모달 등)에서 POST 제출을 트리거할 때 사용 */
+export type CodeEditorSectionHandle = {
+  /** POST /api/exams/{examId}/submissions — 성공 시 true */
+  submit: () => Promise<boolean>;
+};
+
+export const CodeEditorSection = forwardRef<CodeEditorSectionHandle, CodeEditorSectionProps>(function CodeEditorSection(
+  {
   isReadOnly = false,
   examId,
   onSubmitted,
-}: CodeEditorSectionProps) {
+}: CodeEditorSectionProps,
+  ref
+) {
   const [language, setLanguage] = useState("python")
   const [languageCodes, setLanguageCodes] = useState<Record<string, string>>({
     python: defaultCodeTemplates.python,
@@ -128,15 +137,15 @@ export function CodeEditorSection({
     }
   };
 
-  /** 코드 제출 핸들러 */
-  const handleSubmit = async () => {
+  /** 코드 제출 — 에디터 버튼·부모 ref 동시 사용 */
+  const handleSubmit = useCallback(async (): Promise<boolean> => {
     if (!examId) {
       setSubmitError("시험 정보가 없습니다.")
-      return
+      return false
     }
     if (!code.trim()) {
       setSubmitError("코드를 작성해주세요.")
-      return
+      return false
     }
 
     setIsSubmitting(true)
@@ -147,13 +156,23 @@ export function CodeEditorSection({
       const result = await submitCode(examId, { lang: language, code })
       setSubmitStatus(result.status)
       onSubmitted?.(result.submissionId)
+      return true
     } catch (err: any) {
       setSubmitError(err.message || "코드 제출에 실패했습니다.")
       setSubmitStatus(null)
+      return false
     } finally {
       setIsSubmitting(false)
     }
-  }
+  }, [examId, language, code, onSubmitted])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      submit: () => handleSubmit(),
+    }),
+    [handleSubmit]
+  )
 
   const MIN_LINES = 15;
   const actualLineCount = code.split("\n").length || 1;
@@ -181,7 +200,8 @@ export function CodeEditorSection({
           {/* 제출 버튼 — isReadOnly일 때 숨김 */}
           {!isReadOnly && examId && (
             <button
-              onClick={handleSubmit}
+              type="button"
+              onClick={() => void handleSubmit()}
               disabled={isSubmitting}
               className="h-8 px-4 text-sm font-medium rounded-md bg-[#2563EB] text-white hover:bg-[#1D4ED8] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
@@ -257,4 +277,4 @@ export function CodeEditorSection({
       </div>
     </div>
   )
-}
+})

--- a/components/dashboard-content.tsx
+++ b/components/dashboard-content.tsx
@@ -107,13 +107,13 @@ export function DashboardContent() {
               <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-green-50">
                 <CheckCircle className="h-5 w-5 text-green-500" />
               </div>
-              <span className="text-sm font-medium text-gray-500">평가 완료 수</span>
+              <span className="text-sm font-medium text-gray-500">코드 제출 완료 수</span>
             </div>
             <p className="mt-6 text-4xl font-bold text-gray-900">{displayValue(completedCount)}</p>
             <p className="mt-1 text-xs text-gray-400">
               {!isLoading && totalParticipants !== null && totalParticipants > 0
-                ? `완료율 ${Math.round(((completedCount ?? 0) / totalParticipants) * 100)}%`
-                : "코드 제출 기준"}
+                ? `제출률 ${Math.round(((completedCount ?? 0) / totalParticipants) * 100)}%`
+                : "submissions 테이블 기준"}
             </p>
           </div>
 

--- a/components/login-card.tsx
+++ b/components/login-card.tsx
@@ -62,6 +62,7 @@ export default function LoginCard() {
         useExamSessionStore.setState({
           examId,
           participantId,
+          examParticipantId: response.session?.examParticipantId ?? null,
           tokenLimit: response.session?.tokenLimit ?? 20000,
           accessToken: response.accessToken,
         });

--- a/components/participant-evaluation-content.tsx
+++ b/components/participant-evaluation-content.tsx
@@ -12,6 +12,9 @@ import {
   type ExamineeBoardEntry,
   type AdminSubmissionDetailResponse,
 } from "@/lib/api/admin"
+import { resolveBoardPerformanceLevel } from "@/lib/performance-level"
+import { ParticipantEvaluationTestSummary } from "@/components/participant-evaluation-test-summary"
+import { ParticipantEvaluationRubricReport } from "@/components/participant-evaluation-rubric-report"
 
 interface ParticipantEvaluationContentProps {
   entryCode: string
@@ -49,25 +52,9 @@ function findExamByResultsSegment(exams: Exam[], segment: string) {
   return undefined
 }
 
-function trendFromBoard(entry: ExamineeBoardEntry | null): "High" | "Average" | "Low" {
-  if (!entry) return "Low"
-  if (entry.submitted) return "High"
-  if (entry.state === "ENTRANCE") return "Average"
-  return "Low"
-}
-
-function TrendBadge({ trend }: { trend: "High" | "Average" | "Low" }) {
-  const badgeStyles: Record<string, string> = {
-    High: "bg-[#DCFCE7] text-[#16A34A]",
-    Average: "bg-[#FEF3C7] text-[#D97706]",
-    Low: "bg-[#FEE2E2] text-[#DC2626]",
-  }
-  const trendText: Record<string, string> = {
-    High: "높음",
-    Average: "보통",
-    Low: "낮음",
-  }
-  return <span className={"rounded-full px-3 py-1 text-xs font-medium " + badgeStyles[trend]}>{trendText[trend]}</span>
+function PerformanceLevelBadge({ totalScore }: { totalScore: number | null | undefined }) {
+  const { label, badgeClass } = resolveBoardPerformanceLevel(totalScore)
+  return <span className={"rounded-full px-3 py-1 text-xs font-medium " + badgeClass}>{label}</span>
 }
 
 function LanguageBadge({ language }: { language: string }) {
@@ -77,16 +64,6 @@ function LanguageBadge({ language }: { language: string }) {
 function formatScore(n: number | null | undefined): string {
   if (n === null || n === undefined || Number.isNaN(Number(n))) return "–"
   return `${Number(n).toFixed(1)}`
-}
-
-function formatRubricDisplay(raw: string): string {
-  const trimmed = raw.trim()
-  if (!trimmed) return ""
-  try {
-    return JSON.stringify(JSON.parse(trimmed), null, 2)
-  } catch {
-    return trimmed
-  }
 }
 
 export function ParticipantEvaluationContent({
@@ -186,8 +163,6 @@ export function ParticipantEvaluationContent({
     return formatBoardSubmissionLabelKo(boardEntry)
   }, [boardEntry])
 
-  const trend = useMemo(() => trendFromBoard(boardEntry), [boardEntry])
-
   const scoreFromDetail = submissionDetail?.score
   /** BE는 Score 행이 없어도 0으로 채워 보냄 → 전부 0이면 ‘실제 점수 없음’으로 간주 */
   const detailScoresMeaningful =
@@ -201,6 +176,18 @@ export function ParticipantEvaluationContent({
     boardEntry?.totalScore != null &&
     !Number.isNaN(Number(boardEntry.totalScore)) &&
     !detailScoresMeaningful
+
+  const effectiveTotalScore = useMemo((): number | null => {
+    if (detailScoresMeaningful && scoreFromDetail?.total != null) {
+      const n = Number(scoreFromDetail.total)
+      return Number.isNaN(n) ? null : n
+    }
+    if (boardEntry?.totalScore != null) {
+      const n = Number(boardEntry.totalScore)
+      return Number.isNaN(n) ? null : n
+    }
+    return null
+  }, [detailScoresMeaningful, scoreFromDetail, boardEntry])
 
   const showToast = (title: string, description: string) => {
     const id = crypto.randomUUID()
@@ -262,8 +249,8 @@ export function ParticipantEvaluationContent({
         </div>
       </header>
 
-      <div className="flex-1 overflow-y-auto p-6">
-        <div className="mb-4">
+      <div className="flex min-h-0 flex-1 flex-col p-6">
+        <div className="mb-4 shrink-0">
           <button
             type="button"
             onClick={handleBackClick}
@@ -322,10 +309,22 @@ export function ParticipantEvaluationContent({
             )}
           </div>
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">성과 수준 (보드 기준)</span>
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+              성과 수준 (총점 기준)
+            </span>
             <div className="mt-3">
-              <TrendBadge trend={trend} />
+              <PerformanceLevelBadge totalScore={effectiveTotalScore} />
             </div>
+            {effectiveTotalScore != null && (
+              <p className="mt-2 text-xs text-[#6B7280]">
+                기준: 80점 이상 높음 · 50점 이상 보통 · 50점 미만 낮음
+                {detailScoresMeaningful
+                  ? " (관리자 제출 상세 API 총점)"
+                  : showBoardTotalOnly
+                    ? " (관리자 보드 총점)"
+                    : ""}
+              </p>
+            )}
           </div>
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
             <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">제출·채점 상태</span>
@@ -403,107 +402,48 @@ export function ParticipantEvaluationContent({
 
         <div className="mb-6">
           <h2 className="mb-4 text-lg font-semibold text-[#1A1A1A]">제출한 코드</h2>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="flex flex-col rounded-xl border border-[#E5E5E5] bg-white shadow-sm">
-              <div className="flex items-center justify-between border-b border-[#E5E5E5] px-5 py-3">
-                <div className="flex items-center gap-2">
-                  <Code className="h-4 w-4 text-[#6B7280]" strokeWidth={1.5} />
-                  <span className="text-sm font-medium text-[#374151]">코드</span>
-                </div>
-                <LanguageBadge language={langDisplay} />
+          <div className="flex flex-col rounded-xl border border-[#E5E5E5] bg-white shadow-sm">
+            <div className="flex items-center justify-between border-b border-[#E5E5E5] px-5 py-3">
+              <div className="flex items-center gap-2">
+                <Code className="h-4 w-4 text-[#6B7280]" strokeWidth={1.5} />
+                <span className="text-sm font-medium text-[#374151]">코드</span>
               </div>
-              <div className="max-h-[400px] flex-1 overflow-y-auto p-4">
-                {isLoadingSubmission ? (
-                  <p className="text-sm text-[#6B7280]">불러오는 중…</p>
-                ) : submissionDetail?.codeInline != null && submissionDetail.codeInline.trim() !== "" ? (
-                  <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-[#1A1A1A]">
-                    {submissionDetail.codeInline}
-                  </pre>
-                ) : submissionDetail ? (
-                  <p className="text-sm text-[#6B7280]">저장된 제출 코드가 없습니다.</p>
-                ) : (
-                  <p className="text-sm text-[#6B7280]">제출 상세를 불러오면 표시됩니다.</p>
-                )}
-              </div>
+              <LanguageBadge language={langDisplay} />
             </div>
-            <div className="flex flex-col rounded-xl border border-[#E5E5E5] bg-white shadow-sm">
-              <div className="flex items-center gap-2 border-b border-[#E5E5E5] px-5 py-3">
-                <span className="text-sm font-medium text-[#374151]">AI 피드백 (루브릭·턴 평가)</span>
-              </div>
-              <div className="max-h-[400px] flex-1 overflow-y-auto p-5">
-                {isLoadingSubmission ? (
-                  <p className="text-sm text-[#6B7280]">불러오는 중…</p>
-                ) : submissionDetail?.rubricJson != null && submissionDetail.rubricJson.trim() !== "" ? (
-                  <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-[#1A1A1A]">
-                    {formatRubricDisplay(submissionDetail.rubricJson)}
-                  </pre>
-                ) : submissionDetail ? (
-                  <p className="text-sm text-[#6B7280]">
-                    채점 루브릭 JSON(<code className="rounded bg-[#F3F4F6] px-1">scores.rubric_json</code>)이 아직 없습니다.
-                  </p>
-                ) : (
-                  <p className="text-sm text-[#6B7280]">제출 상세를 불러오면 표시됩니다.</p>
-                )}
-              </div>
+            <div className="max-h-[400px] overflow-y-auto p-4">
+              {isLoadingSubmission ? (
+                <p className="text-sm text-[#6B7280]">불러오는 중…</p>
+              ) : submissionDetail?.codeInline != null && submissionDetail.codeInline.trim() !== "" ? (
+                <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-[#1A1A1A]">
+                  {submissionDetail.codeInline}
+                </pre>
+              ) : submissionDetail ? (
+                <p className="text-sm text-[#6B7280]">저장된 제출 코드가 없습니다.</p>
+              ) : (
+                <p className="text-sm text-[#6B7280]">제출 상세를 불러오면 표시됩니다.</p>
+              )}
             </div>
           </div>
         </div>
 
         <div className="mb-6">
-          <h2 className="mb-4 text-lg font-semibold text-[#1A1A1A]">채점·테스트 요약</h2>
-          <div className="rounded-xl border border-[#E5E5E5] bg-white shadow-sm p-6">
-            {!submissionDetail && !isLoadingSubmission && (
-              <p className="text-sm text-[#6B7280]">
-                제출이 없거나 제출 상세를 불러오지 못했습니다. 개별 테스트 케이스 입·출력은 현재 API에 없습니다.
-              </p>
-            )}
-            {submissionDetail && (
-              <div className="space-y-4 text-sm">
-                <p>
-                  <span className="font-medium text-[#374151]">제출 상태(상세):</span>{" "}
-                  <span className="text-[#1A1A1A]">{submissionDetail.status}</span>
-                </p>
-                {submissionDetail.metrics && (
-                  <p className="text-[#6B7280]">
-                    시간 중앙값: {submissionDetail.metrics.timeMsMedian ?? "–"} ms · 메모리 peak:{" "}
-                    {submissionDetail.metrics.memKbPeak ?? "–"} KB · LOC: {submissionDetail.metrics.loc ?? "–"}
-                  </p>
-                )}
-                {submissionDetail.tc?.groups && submissionDetail.tc.groups.length > 0 ? (
-                  <div>
-                    <p className="mb-2 font-medium text-[#374151]">채점 그룹별 통과 (submission_runs 집계)</p>
-                    <div className="overflow-x-auto">
-                      <table className="w-full text-left text-sm">
-                        <thead>
-                          <tr className="border-b border-[#E5E5E5] text-[#6B7280]">
-                            <th className="py-2 pr-4">그룹</th>
-                            <th className="py-2 pr-4">통과</th>
-                            <th className="py-2">전체</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {submissionDetail.tc.groups.map((g, i) => (
-                            <tr key={i} className="border-b border-[#F3F4F6]">
-                              <td className="py-2 pr-4 font-mono text-xs">{String(g.name)}</td>
-                              <td className="py-2 pr-4">{g.pass}</td>
-                              <td className="py-2">{g.total}</td>
-                            </tr>
-                          ))}
-                        </tbody>
-                      </table>
-                    </div>
-                    {submissionDetail.tc.passRateWeighted != null && (
-                      <p className="mt-2 text-[#6B7280]">
-                        가중 통과율: {(Number(submissionDetail.tc.passRateWeighted) * 100).toFixed(1)}%
-                      </p>
-                    )}
-                  </div>
-                ) : (
-                  <p className="text-[#6B7280]">그룹별 채점 요약 데이터가 없습니다.</p>
-                )}
-              </div>
-            )}
+          <h2 className="mb-4 text-lg font-semibold text-[#1A1A1A]">AI 피드백 (루브릭·턴 평가)</h2>
+          <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
+            <ParticipantEvaluationRubricReport
+              rubricJson={submissionDetail?.rubricJson}
+              isLoading={isLoadingSubmission}
+            />
           </div>
+        </div>
+
+        <div className="mb-6">
+          <h2 className="mb-4 text-lg font-semibold text-[#1A1A1A]">채점·테스트 요약</h2>
+          <ParticipantEvaluationTestSummary
+            submissionId={submissionId}
+            isLoading={isLoadingSubmission}
+            detail={submissionDetail}
+            boardStatusLabel={submissionStatusLabel}
+          />
           <div className="mt-6 flex justify-end">
             <button
               type="button"

--- a/components/participant-evaluation-content.tsx
+++ b/components/participant-evaluation-content.tsx
@@ -6,11 +6,12 @@ import { useRouter } from "next/navigation"
 import {
   getExams,
   getBoard,
+  getAdminSubmissionDetail,
   formatBoardSubmissionLabelKo,
   type Exam,
   type ExamineeBoardEntry,
+  type AdminSubmissionDetailResponse,
 } from "@/lib/api/admin"
-import { getSubmission, type SubmissionDetailResponse } from "@/lib/api/submissions"
 
 interface ParticipantEvaluationContentProps {
   entryCode: string
@@ -78,6 +79,16 @@ function formatScore(n: number | null | undefined): string {
   return `${Number(n).toFixed(1)}`
 }
 
+function formatRubricDisplay(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) return ""
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2)
+  } catch {
+    return trimmed
+  }
+}
+
 export function ParticipantEvaluationContent({
   entryCode,
   participantName: participantNameProp,
@@ -92,7 +103,7 @@ export function ParticipantEvaluationContent({
   const [boardError, setBoardError] = useState<string | null>(null)
   const [isLoadingBoard, setIsLoadingBoard] = useState(true)
 
-  const [submissionDetail, setSubmissionDetail] = useState<SubmissionDetailResponse | null>(null)
+  const [submissionDetail, setSubmissionDetail] = useState<AdminSubmissionDetailResponse | null>(null)
   const [submissionDetailError, setSubmissionDetailError] = useState<string | null>(null)
   const [isLoadingSubmission, setIsLoadingSubmission] = useState(false)
 
@@ -133,20 +144,21 @@ export function ParticipantEvaluationContent({
   const submissionId = boardEntry?.submissionId ?? null
 
   useEffect(() => {
-    if (!submissionId) {
+    if (submissionId == null) {
       setSubmissionDetail(null)
       setSubmissionDetailError(null)
       return
     }
+    const submissionIdNum = submissionId
     let cancelled = false
     async function loadSubmission() {
       setIsLoadingSubmission(true)
       setSubmissionDetailError(null)
       try {
-        const detail = await getSubmission(submissionId)
+        const detail = await getAdminSubmissionDetail(submissionIdNum)
         if (!cancelled) setSubmissionDetail(detail)
       } catch (e: unknown) {
-        console.error("getSubmission failed", e)
+        console.error("getAdminSubmissionDetail failed", e)
         if (!cancelled) {
           setSubmissionDetail(null)
           setSubmissionDetailError(
@@ -210,6 +222,8 @@ export function ParticipantEvaluationContent({
       `ExamParticipantId,${participantId}`,
       `ExamId,${examId ?? ""}`,
       `SubmissionId,${submissionId ?? ""}`,
+      `HasSubmissionCode,${submissionDetail?.codeInline?.trim() ? "yes" : "no"}`,
+      `HasRubricJson,${submissionDetail?.rubricJson?.trim() ? "yes" : "no"}`,
       `BoardStatus,${submissionStatusLabel ?? ""}`,
       `PromptScore,${scoreFromDetail?.prompt ?? ""}`,
       `PerfScore,${scoreFromDetail?.perf ?? ""}`,
@@ -243,7 +257,7 @@ export function ParticipantEvaluationContent({
         <div>
           <h1 className="text-2xl font-semibold text-[#1A1A1A]">참가자 평가 상세</h1>
           <p className="text-sm text-[#6B7280]">
-            보드·제출 API에서 불러온 데이터입니다. 미제공 필드는 안내 문구로 표시됩니다.
+            보드 API와 관리자 전용 제출 상세 API에서 불러온 데이터입니다. 미제공 필드는 안내 문구로 표시됩니다.
           </p>
         </div>
       </header>
@@ -349,14 +363,14 @@ export function ParticipantEvaluationContent({
                 {detailScoresMeaningful ? formatScore(scoreFromDetail?.prompt ?? null) : "–"}
               </p>
               <p className="mt-1 text-sm font-medium text-[#374151]">프롬프트 점수</p>
-              <p className="mt-1 text-xs text-[#6B7280]">GET /api/submissions/… 의 score.prompt</p>
+              <p className="mt-1 text-xs text-[#6B7280]">관리자 제출 상세 API의 score.prompt</p>
             </div>
             <div className="rounded-xl border border-[#E5E5E5] bg-white p-6 shadow-sm">
               <p className="text-3xl font-bold text-[#1A1A1A]">
                 {detailScoresMeaningful ? formatScore(scoreFromDetail?.perf ?? null) : "–"}
               </p>
               <p className="mt-1 text-sm font-medium text-[#374151]">성능 점수</p>
-              <p className="mt-1 text-xs text-[#6B7280]">GET /api/submissions/… 의 score.perf</p>
+              <p className="mt-1 text-xs text-[#6B7280]">관리자 제출 상세 API의 score.perf</p>
             </div>
             <div className="rounded-xl border border-[#E5E5E5] bg-white p-6 shadow-sm">
               <p className="text-3xl font-bold text-[#1A1A1A]">
@@ -365,7 +379,7 @@ export function ParticipantEvaluationContent({
               <p className="mt-1 text-sm font-medium text-[#374151]">정답률 점수</p>
               <p className="mt-1 text-xs text-[#6B7280]">
                 {detailScoresMeaningful
-                  ? "상세 API score.correctness"
+                  ? "관리자 제출 상세 API score.correctness"
                   : showBoardTotalOnly
                     ? "항목별 값 없음 — 아래 총점만 보드 참고"
                     : "데이터 없음"}
@@ -374,7 +388,7 @@ export function ParticipantEvaluationContent({
           </div>
           {detailScoresMeaningful && (
             <p className="mt-3 text-center text-sm font-semibold text-[#1A1A1A]">
-              총점 {formatScore(scoreFromDetail?.total ?? null)} (상세 API)
+              총점 {formatScore(scoreFromDetail?.total ?? null)} (관리자 제출 상세 API)
             </p>
           )}
           {!detailScoresMeaningful && showBoardTotalOnly && (
@@ -399,10 +413,17 @@ export function ParticipantEvaluationContent({
                 <LanguageBadge language={langDisplay} />
               </div>
               <div className="max-h-[400px] flex-1 overflow-y-auto p-4">
-                <p className="text-sm leading-relaxed text-[#6B7280]">
-                  현재 <code className="rounded bg-[#F3F4F6] px-1">GET /api/submissions/{"{id}"}</code> 응답에
-                  제출 소스 코드 필드가 포함되어 있지 않습니다. 백엔드에 코드 필드가 추가되면 여기에 표시할 수 있습니다.
-                </p>
+                {isLoadingSubmission ? (
+                  <p className="text-sm text-[#6B7280]">불러오는 중…</p>
+                ) : submissionDetail?.codeInline != null && submissionDetail.codeInline.trim() !== "" ? (
+                  <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-[#1A1A1A]">
+                    {submissionDetail.codeInline}
+                  </pre>
+                ) : submissionDetail ? (
+                  <p className="text-sm text-[#6B7280]">저장된 제출 코드가 없습니다.</p>
+                ) : (
+                  <p className="text-sm text-[#6B7280]">제출 상세를 불러오면 표시됩니다.</p>
+                )}
               </div>
             </div>
             <div className="flex flex-col rounded-xl border border-[#E5E5E5] bg-white shadow-sm">
@@ -410,10 +431,19 @@ export function ParticipantEvaluationContent({
                 <span className="text-sm font-medium text-[#374151]">AI 피드백 (루브릭·턴 평가)</span>
               </div>
               <div className="max-h-[400px] flex-1 overflow-y-auto p-5">
-                <p className="text-sm leading-relaxed text-[#6B7280]">
-                  Spring 관리자 API에는 <code className="rounded bg-[#F3F4F6] px-1">prompt_evaluations</code> 본문이
-                  아직 노출되지 않습니다. AI 평가 텍스트는 별도 내부/분석 API가 마련되면 연결할 수 있습니다.
-                </p>
+                {isLoadingSubmission ? (
+                  <p className="text-sm text-[#6B7280]">불러오는 중…</p>
+                ) : submissionDetail?.rubricJson != null && submissionDetail.rubricJson.trim() !== "" ? (
+                  <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-[#1A1A1A]">
+                    {formatRubricDisplay(submissionDetail.rubricJson)}
+                  </pre>
+                ) : submissionDetail ? (
+                  <p className="text-sm text-[#6B7280]">
+                    채점 루브릭 JSON(<code className="rounded bg-[#F3F4F6] px-1">scores.rubric_json</code>)이 아직 없습니다.
+                  </p>
+                ) : (
+                  <p className="text-sm text-[#6B7280]">제출 상세를 불러오면 표시됩니다.</p>
+                )}
               </div>
             </div>
           </div>

--- a/components/participant-evaluation-content.tsx
+++ b/components/participant-evaluation-content.tsx
@@ -1,16 +1,23 @@
 "use client"
 
-import { useState, useEffect } from "react"
-import Link from "next/link"
+import { useState, useEffect, useMemo } from "react"
 import { ArrowLeft, User, Code, CheckCircle, X } from "lucide-react"
 import { useRouter } from "next/navigation"
-import { getExams, getBoard } from "@/lib/api/admin"
+import {
+  getExams,
+  getBoard,
+  formatBoardSubmissionLabelKo,
+  type Exam,
+  type ExamineeBoardEntry,
+} from "@/lib/api/admin"
+import { getSubmission, type SubmissionDetailResponse } from "@/lib/api/submissions"
 
 interface ParticipantEvaluationContentProps {
   entryCode: string
-  participantName?: string   // 선택적 — URL query 또는 board에서 로드
+  participantName?: string
+  /** URL 세그먼트 — 목록·보드와 동일하게 `exam_participants.id` (examParticipantId) */
   participantId: string
-  onBack?: () => void;
+  onBack?: () => void
 }
 
 interface ToastItem {
@@ -19,147 +26,33 @@ interface ToastItem {
   description: string
 }
 
-const participantData = {
-  name: "Alice Johnson",
-  entryCode: "AJ-2024-001",
-  avgScore: 92,
-  status: "Submitted" as const,
-  testDate: "2024-02-11",
-  duration: "32 minutes",
-  trend: "High" as const,
-  language: "Python",
-  promptScore: 86,
-  performanceScore: 81,
-  correctnessScore: 89,
+/**
+ * participant-list-content 와 동일 규칙 — 결과 URL 세그먼트 → 시험 매칭
+ */
+function findExamByResultsSegment(exams: Exam[], segment: string) {
+  const trimmed = segment.trim()
+  if (!trimmed) return undefined
+
+  const byEntryCode = exams.find(
+    (e) => e.entryCode != null && String(e.entryCode).length > 0 && e.entryCode === trimmed
+  )
+  if (byEntryCode) return byEntryCode
+
+  const byTitle = exams.find((e) => e.title === trimmed)
+  if (byTitle) return byTitle
+
+  if (/^\d+$/.test(trimmed)) {
+    return exams.find((e) => String(e.id) === trimmed)
+  }
+
+  return undefined
 }
 
-const dummyCode = `def solution(nums: List[int], target: int) -> List[int]:
-    seen = {}
-    for i, num in enumerate(nums):
-        complement = target - num
-        if complement in seen:
-            return [seen[complement], i]
-        seen[num] = i
-    return []
-
-def optimize_query(data: List[Dict], filters: Dict) -> List[Dict]:
-    result = data
-    for key, value in filters.items():
-        result = [item for item in result if item.get(key) == value]
-    return result
-
-class DataProcessor:
-    def __init__(self, config: Dict):
-        self.config = config
-        self.cache = {}
-    
-    def process(self, input_data: Any) -> Any:
-        cache_key = hash(str(input_data))
-        if cache_key in self.cache:
-            return self.cache[cache_key]
-        result = self._transform(input_data)
-        self.cache[cache_key] = result
-        return result`
-
-const feedbackData = {
-  strengths: [
-    "깔끔하고 읽기 쉬운 코드 구조",
-    "O(n) 시간 복잡도를 위한 해시 맵의 효율적인 사용",
-    "독스트링을 통한 좋은 문서화",
-    "코드 전반에 걸친 적절한 타입 힌트",
-  ],
-  weaknesses: [
-    "빈 입력에 대한 엣지 케이스 처리 누락",
-    "데이터 타입에 대한 입력 검증 없음",
-    "캐시 무효화 전략이 구현되지 않음",
-  ],
-  suggestions: [
-    "엣지 케이스를 위한 단위 테스트 추가",
-    "메모이제이션을 위해 functools.lru_cache 사용 고려",
-    "커스텀 예외를 사용한 적절한 오류 처리 구현",
-  ],
-  performanceNotes: [
-    "해시 맵 접근 방식이 이 문제에 최적입니다",
-    "제너레이터를 사용하면 메모리 사용량을 줄일 수 있습니다",
-    "대용량 데이터셋에 대해 지연 평가 고려",
-  ],
-}
-
-const testCaseResults = [
-  {
-    id: "1",
-    testCase: "Basic Input",
-    expected: "[0, 1]",
-    submitted: "[0, 1]",
-    result: "Passed" as const,
-    execTime: "12ms",
-    memory: "14.2 MB",
-    tokens: 128,
-  },
-  {
-    id: "2",
-    testCase: "Empty Array",
-    expected: "[]",
-    submitted: "[]",
-    result: "Passed" as const,
-    execTime: "8ms",
-    memory: "13.8 MB",
-    tokens: 64,
-  },
-  {
-    id: "3",
-    testCase: "Large Input",
-    expected: "[999, 1000]",
-    submitted: "[999, 1000]",
-    result: "Passed" as const,
-    execTime: "45ms",
-    memory: "28.4 MB",
-    tokens: 256,
-  },
-  {
-    id: "4",
-    testCase: "Negative Numbers",
-    expected: "[2, 4]",
-    submitted: "[2, 3]",
-    result: "Failed" as const,
-    execTime: "15ms",
-    memory: "14.6 MB",
-    tokens: 128,
-  },
-  {
-    id: "5",
-    testCase: "Duplicate Values",
-    expected: "[1, 3]",
-    submitted: "[1, 3]",
-    result: "Passed" as const,
-    execTime: "11ms",
-    memory: "14.1 MB",
-    tokens: 96,
-  },
-  {
-    id: "6",
-    testCase: "Single Element",
-    expected: "[]",
-    submitted: "[]",
-    result: "Passed" as const,
-    execTime: "6ms",
-    memory: "13.5 MB",
-    tokens: 48,
-  },
-]
-
-function StatusBadge({ status }: { status: "Submitted" | "In Progress" | "Not Started" }) {
-  const badgeStyles: Record<string, string> = {
-    Submitted: "bg-[#DCFCE7] text-[#16A34A]",
-    "In Progress": "bg-[#E0EDFF] text-[#3B82F6] font-semibold",
-    "Not Started": "bg-[#F3F4F6] text-[#6B7280]",
-  }
-  const statusText: Record<string, string> = {
-    Submitted: "제출됨",
-    "In Progress": "진행 중",
-    "Not Started": "시작 안 함",
-  }
-  return <span className={"rounded-full px-3 py-1 text-xs font-medium " + badgeStyles[status]}>{statusText[status]}</span>
+function trendFromBoard(entry: ExamineeBoardEntry | null): "High" | "Average" | "Low" {
+  if (!entry) return "Low"
+  if (entry.submitted) return "High"
+  if (entry.state === "ENTRANCE") return "Average"
+  return "Low"
 }
 
 function TrendBadge({ trend }: { trend: "High" | "Average" | "Low" }) {
@@ -180,87 +73,122 @@ function LanguageBadge({ language }: { language: string }) {
   return <span className="rounded-full bg-[#F3F4F6] px-3 py-1 text-xs font-medium text-[#374151]">{language}</span>
 }
 
-function TestResultBadge({ result }: { result: "Passed" | "Failed" }) {
-  const badgeStyles: Record<string, string> = {
-    Passed: "bg-[#DCFCE7] text-[#16A34A]",
-    Failed: "bg-[#FEE2E2] text-[#DC2626]",
-  }
-  const resultText: Record<string, string> = {
-    Passed: "통과",
-    Failed: "실패",
-  }
-  return <span className={"rounded-full px-2.5 py-0.5 text-xs font-medium " + badgeStyles[result]}>{resultText[result]}</span>
+function formatScore(n: number | null | undefined): string {
+  if (n === null || n === undefined || Number.isNaN(Number(n))) return "–"
+  return `${Number(n).toFixed(1)}`
 }
 
-function generateParticipantCSV(): string {
-  const header = "Metric,Value"
-  const rows = [
-    "Name," + participantData.name,
-    "Entry Code," + participantData.entryCode,
-    "Average Score," + participantData.avgScore + "%",
-    "Status," + participantData.status,
-    "Test Date," + participantData.testDate,
-    "Duration," + participantData.duration,
-    "Trend," + participantData.trend,
-    "Language," + participantData.language,
-    "Prompt Score," + participantData.promptScore + "%",
-    "Performance Score," + participantData.performanceScore + "%",
-    "Correctness Score," + participantData.correctnessScore + "%",
-  ]
-  return [header, ...rows].join("\n")
-}
-
-function downloadCSV() {
-  const csvContent = generateParticipantCSV()
-  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" })
-  const url = URL.createObjectURL(blob)
-  const link = document.createElement("a")
-  link.href = url
-  link.download = "participants.csv"
-  document.body.appendChild(link)
-  link.click()
-  document.body.removeChild(link)
-  URL.revokeObjectURL(url)
-}
-
-export function ParticipantEvaluationContent({ entryCode, participantName: participantNameProp, participantId, onBack }: ParticipantEvaluationContentProps) {
+export function ParticipantEvaluationContent({
+  entryCode,
+  participantName: participantNameProp,
+  participantId,
+  onBack,
+}: ParticipantEvaluationContentProps) {
   const router = useRouter()
   const [toasts, setToasts] = useState<ToastItem[]>([])
 
-  // 실제 참가자 정보 (board에서 로드)
-  const [boardParticipantName, setBoardParticipantName] = useState<string | null>(null)
-  const [tokenUsed, setTokenUsed] = useState<number | null>(null)
-  const [submitted, setSubmitted] = useState<boolean | null>(null)
+  const [examId, setExamId] = useState<number | null>(null)
+  const [boardEntry, setBoardEntry] = useState<ExamineeBoardEntry | null>(null)
+  const [boardError, setBoardError] = useState<string | null>(null)
   const [isLoadingBoard, setIsLoadingBoard] = useState(true)
 
+  const [submissionDetail, setSubmissionDetail] = useState<SubmissionDetailResponse | null>(null)
+  const [submissionDetailError, setSubmissionDetailError] = useState<string | null>(null)
+  const [isLoadingSubmission, setIsLoadingSubmission] = useState(false)
+
   useEffect(() => {
-    async function loadParticipantFromBoard() {
+    let cancelled = false
+    async function loadBoard() {
       setIsLoadingBoard(true)
+      setBoardError(null)
+      setBoardEntry(null)
+      setExamId(null)
       try {
         const exams = await getExams()
-        const matched = exams.find((e) => e.entryCode === entryCode)
+        const matched = findExamByResultsSegment(exams, entryCode)
         if (!matched) {
-          setIsLoadingBoard(false)
+          if (!cancelled) setBoardError("해당 입장 코드·시험명에 맞는 시험을 찾을 수 없습니다.")
           return
         }
         const board = await getBoard(matched.id)
-        const entry = board.find((p) => p.examParticipantId.toString() === participantId)
-        if (entry) {
-          setBoardParticipantName(entry.name)
-          setTokenUsed(entry.tokenUsed)
-          setSubmitted(entry.submitted)
+        const entry = board.find((p) => String(p.examParticipantId) === String(participantId))
+        if (!cancelled) {
+          setExamId(matched.id)
+          if (entry) setBoardEntry(entry)
+          else setBoardError("참가자를 보드에서 찾을 수 없습니다. (ID가 examParticipantId와 일치하는지 확인하세요)")
         }
       } catch (e) {
-        console.error("Failed to load participant from board", e)
+        console.error("Failed to load board for evaluation detail", e)
+        if (!cancelled) setBoardError("참가자·시험 정보를 불러오지 못했습니다.")
       } finally {
-        setIsLoadingBoard(false)
+        if (!cancelled) setIsLoadingBoard(false)
       }
     }
-    loadParticipantFromBoard()
+    loadBoard()
+    return () => {
+      cancelled = true
+    }
   }, [entryCode, participantId])
 
-  // 이름 우선순위: prop > board > fallback
-  const displayName = participantNameProp || boardParticipantName || participantData.name
+  const submissionId = boardEntry?.submissionId ?? null
+
+  useEffect(() => {
+    if (!submissionId) {
+      setSubmissionDetail(null)
+      setSubmissionDetailError(null)
+      return
+    }
+    let cancelled = false
+    async function loadSubmission() {
+      setIsLoadingSubmission(true)
+      setSubmissionDetailError(null)
+      try {
+        const detail = await getSubmission(submissionId)
+        if (!cancelled) setSubmissionDetail(detail)
+      } catch (e: unknown) {
+        console.error("getSubmission failed", e)
+        if (!cancelled) {
+          setSubmissionDetail(null)
+          setSubmissionDetailError(
+            e instanceof Error ? e.message : "제출 상세를 불러오지 못했습니다. (권한 또는 네트워크를 확인하세요)"
+          )
+        }
+      } finally {
+        if (!cancelled) setIsLoadingSubmission(false)
+      }
+    }
+    loadSubmission()
+    return () => {
+      cancelled = true
+    }
+  }, [submissionId])
+
+  const displayName = useMemo(() => {
+    if (participantNameProp?.trim()) return participantNameProp.trim()
+    if (boardEntry?.name) return boardEntry.name
+    return "–"
+  }, [participantNameProp, boardEntry])
+
+  const submissionStatusLabel = useMemo(() => {
+    if (!boardEntry) return null
+    return formatBoardSubmissionLabelKo(boardEntry)
+  }, [boardEntry])
+
+  const trend = useMemo(() => trendFromBoard(boardEntry), [boardEntry])
+
+  const scoreFromDetail = submissionDetail?.score
+  /** BE는 Score 행이 없어도 0으로 채워 보냄 → 전부 0이면 ‘실제 점수 없음’으로 간주 */
+  const detailScoresMeaningful =
+    scoreFromDetail &&
+    (Number(scoreFromDetail.prompt) !== 0 ||
+      Number(scoreFromDetail.perf) !== 0 ||
+      Number(scoreFromDetail.correctness) !== 0 ||
+      Number(scoreFromDetail.total) !== 0)
+
+  const showBoardTotalOnly =
+    boardEntry?.totalScore != null &&
+    !Number.isNaN(Number(boardEntry.totalScore)) &&
+    !detailScoresMeaningful
 
   const showToast = (title: string, description: string) => {
     const id = crypto.randomUUID()
@@ -275,37 +203,52 @@ export function ParticipantEvaluationContent({ entryCode, participantName: parti
   }
 
   const handleExport = () => {
-    downloadCSV()
-    showToast("Participant results exported successfully.", "File: participants.csv")
+    const header = "Field,Value"
+    const rows = [
+      `Name,${displayName}`,
+      `EntryCodeSegment,${entryCode}`,
+      `ExamParticipantId,${participantId}`,
+      `ExamId,${examId ?? ""}`,
+      `SubmissionId,${submissionId ?? ""}`,
+      `BoardStatus,${submissionStatusLabel ?? ""}`,
+      `PromptScore,${scoreFromDetail?.prompt ?? ""}`,
+      `PerfScore,${scoreFromDetail?.perf ?? ""}`,
+      `CorrectnessScore,${scoreFromDetail?.correctness ?? ""}`,
+      `TotalScore,${scoreFromDetail?.total ?? boardEntry?.totalScore ?? ""}`,
+    ]
+    const csvContent = [header, ...rows].join("\n")
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = "participant-evaluation.csv"
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+    showToast("보내기 완료", "participant-evaluation.csv")
   }
 
+  const handleBackClick = (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
+    e.preventDefault()
+    if (onBack) onBack()
+    else router.back()
+  }
 
-  const handleBackClick = (
-    e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
-  ) => {
-    e.preventDefault();
-    if (onBack) {
-      onBack();       // 🔹 page.tsx 에서 만들어준 분기 로직 실행
-    } else {
-      router.back();  // 🔹 혹시 onBack이 없을 때 기본 동작
-    }
-  };
+  const langDisplay = submissionDetail?.lang ?? "–"
 
   return (
     <div className="flex h-full flex-1 flex-col">
-      {/* Top Header Bar */}
       <header className="flex h-[88px] shrink-0 items-center border-b border-[#E5E5E5] bg-white px-8">
         <div>
           <h1 className="text-2xl font-semibold text-[#1A1A1A]">참가자 평가 상세</h1>
           <p className="text-sm text-[#6B7280]">
-            이 참가자의 평가 결과와 제출 세부 정보를 모두 확인할 수 있습니다.
+            보드·제출 API에서 불러온 데이터입니다. 미제공 필드는 안내 문구로 표시됩니다.
           </p>
         </div>
       </header>
 
-      {/* Main Content Panel - Scrollable */}
       <div className="flex-1 overflow-y-auto p-6">
-        {/* Back Link */}
         <div className="mb-4">
           <button
             type="button"
@@ -317,7 +260,12 @@ export function ParticipantEvaluationContent({ entryCode, participantName: parti
           </button>
         </div>
 
-        {/* Summary Cards - Row 1 */}
+        {boardError && (
+          <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+            {boardError}
+          </div>
+        )}
+
         <div className="mb-4 grid grid-cols-3 gap-4">
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
             <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">참가자</span>
@@ -326,71 +274,119 @@ export function ParticipantEvaluationContent({ entryCode, participantName: parti
                 <User className="h-5 w-5 text-[#3B82F6]" strokeWidth={1.5} />
               </div>
               <span className="text-base font-semibold text-[#1A1A1A]">
-                {isLoadingBoard ? "..." : displayName}
+                {isLoadingBoard ? "…" : displayName}
               </span>
             </div>
           </div>
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">입장 코드</span>
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">시험 구분 (URL)</span>
             <p className="mt-3 text-lg font-semibold text-[#1A1A1A]">{entryCode}</p>
+            {examId != null && <p className="mt-1 text-xs text-[#6B7280]">examId: {examId}</p>}
           </div>
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
             <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">토큰 사용량</span>
             <p className="mt-3 text-lg font-semibold text-[#1A1A1A]">
-              {isLoadingBoard ? "..." : tokenUsed !== null ? tokenUsed.toLocaleString() : "–"}
+              {isLoadingBoard || !boardEntry ? (
+                "…"
+              ) : (
+                <>
+                  {boardEntry.tokenUsed.toLocaleString()} / {boardEntry.tokenLimit.toLocaleString()}
+                </>
+              )}
             </p>
           </div>
         </div>
 
-        {/* Summary Cards - Row 2 */}
         <div className="mb-6 grid grid-cols-3 gap-4">
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">참가자 ID</span>
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+              응시 참가 ID (examParticipantId)
+            </span>
             <p className="mt-3 text-base font-semibold text-[#1A1A1A]">{participantId}</p>
+            {submissionId != null && (
+              <p className="mt-2 text-xs text-[#6B7280]">submissionId: {submissionId}</p>
+            )}
           </div>
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">성과 수준</span>
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">성과 수준 (보드 기준)</span>
             <div className="mt-3">
-              <TrendBadge trend={participantData.trend} />
+              <TrendBadge trend={trend} />
             </div>
           </div>
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">제출 상태</span>
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">제출·채점 상태</span>
             <div className="mt-3">
               {isLoadingBoard ? (
-                <span className="text-sm text-[#6B7280]">...</span>
-              ) : submitted !== null ? (
-                <StatusBadge status={submitted ? "Submitted" : "In Progress"} />
+                <span className="text-sm text-[#6B7280]">…</span>
+              ) : submissionStatusLabel ? (
+                <span className="rounded-full bg-[#F3F4F6] px-3 py-1 text-xs font-medium text-[#374151]">
+                  {submissionStatusLabel}
+                </span>
               ) : (
-                <StatusBadge status={participantData.status} />
+                <span className="text-sm text-[#6B7280]">–</span>
               )}
             </div>
+            {boardEntry?.submittedAt && (
+              <p className="mt-2 text-xs text-[#6B7280]">제출 시각: {boardEntry.submittedAt}</p>
+            )}
+            {boardEntry?.evaluatedAt && (
+              <p className="text-xs text-[#6B7280]">점수 갱신: {boardEntry.evaluatedAt}</p>
+            )}
           </div>
         </div>
 
-        {/* Evaluation Breakdown Section */}
         <div className="mb-6">
           <h2 className="mb-4 text-lg font-semibold text-[#1A1A1A]">평가 점수 세부 내역</h2>
+          {isLoadingSubmission && submissionId != null && (
+            <p className="mb-2 text-sm text-[#6B7280]">제출 상세를 불러오는 중…</p>
+          )}
+          {submissionDetailError && (
+            <p className="mb-2 text-sm text-red-600">{submissionDetailError}</p>
+          )}
           <div className="grid grid-cols-3 gap-4">
             <div className="rounded-xl border border-[#E5E5E5] bg-white p-6 shadow-sm">
-              <p className="text-3xl font-bold text-[#1A1A1A]">{participantData.promptScore}%</p>
+              <p className="text-3xl font-bold text-[#1A1A1A]">
+                {detailScoresMeaningful ? formatScore(scoreFromDetail?.prompt ?? null) : "–"}
+              </p>
               <p className="mt-1 text-sm font-medium text-[#374151]">프롬프트 점수</p>
-              <p className="mt-1 text-xs text-[#6B7280]">이해 및 문제 해석 능력</p>
+              <p className="mt-1 text-xs text-[#6B7280]">GET /api/submissions/… 의 score.prompt</p>
             </div>
             <div className="rounded-xl border border-[#E5E5E5] bg-white p-6 shadow-sm">
-              <p className="text-3xl font-bold text-[#1A1A1A]">{participantData.performanceScore}%</p>
+              <p className="text-3xl font-bold text-[#1A1A1A]">
+                {detailScoresMeaningful ? formatScore(scoreFromDetail?.perf ?? null) : "–"}
+              </p>
               <p className="mt-1 text-sm font-medium text-[#374151]">성능 점수</p>
-              <p className="mt-1 text-xs text-[#6B7280]">실행 효율 및 최적화</p>
+              <p className="mt-1 text-xs text-[#6B7280]">GET /api/submissions/… 의 score.perf</p>
             </div>
             <div className="rounded-xl border border-[#E5E5E5] bg-white p-6 shadow-sm">
-              <p className="text-3xl font-bold text-[#1A1A1A]">{participantData.correctnessScore}%</p>
+              <p className="text-3xl font-bold text-[#1A1A1A]">
+                {detailScoresMeaningful ? formatScore(scoreFromDetail?.correctness ?? null) : "–"}
+              </p>
               <p className="mt-1 text-sm font-medium text-[#374151]">정답률 점수</p>
-              <p className="mt-1 text-xs text-[#6B7280]">솔루션 정확도 및 테스트 결과 일치율</p>
+              <p className="mt-1 text-xs text-[#6B7280]">
+                {detailScoresMeaningful
+                  ? "상세 API score.correctness"
+                  : showBoardTotalOnly
+                    ? "항목별 값 없음 — 아래 총점만 보드 참고"
+                    : "데이터 없음"}
+              </p>
             </div>
           </div>
+          {detailScoresMeaningful && (
+            <p className="mt-3 text-center text-sm font-semibold text-[#1A1A1A]">
+              총점 {formatScore(scoreFromDetail?.total ?? null)} (상세 API)
+            </p>
+          )}
+          {!detailScoresMeaningful && showBoardTotalOnly && (
+            <p className="mt-3 text-center text-sm font-semibold text-[#1A1A1A]">
+              총점 {formatScore(Number(boardEntry!.totalScore))} (관리자 보드 — 상세 점수 행 없음)
+            </p>
+          )}
+          {!detailScoresMeaningful && !showBoardTotalOnly && !isLoadingSubmission && (
+            <p className="mt-3 text-center text-sm text-[#6B7280]">표시할 점수 데이터가 없습니다.</p>
+          )}
         </div>
 
-        {/* Submitted Code Section */}
         <div className="mb-6">
           <h2 className="mb-4 text-lg font-semibold text-[#1A1A1A]">제출한 코드</h2>
           <div className="grid grid-cols-2 gap-4">
@@ -398,120 +394,98 @@ export function ParticipantEvaluationContent({ entryCode, participantName: parti
               <div className="flex items-center justify-between border-b border-[#E5E5E5] px-5 py-3">
                 <div className="flex items-center gap-2">
                   <Code className="h-4 w-4 text-[#6B7280]" strokeWidth={1.5} />
-                  <span className="text-sm font-medium text-[#374151]">코드 구현</span>
+                  <span className="text-sm font-medium text-[#374151]">코드</span>
                 </div>
-                <LanguageBadge language={participantData.language} />
+                <LanguageBadge language={langDisplay} />
               </div>
               <div className="max-h-[400px] flex-1 overflow-y-auto p-4">
-                <pre className="text-xs leading-relaxed text-[#374151]">
-                  <code>{dummyCode}</code>
-                </pre>
+                <p className="text-sm leading-relaxed text-[#6B7280]">
+                  현재 <code className="rounded bg-[#F3F4F6] px-1">GET /api/submissions/{"{id}"}</code> 응답에
+                  제출 소스 코드 필드가 포함되어 있지 않습니다. 백엔드에 코드 필드가 추가되면 여기에 표시할 수 있습니다.
+                </p>
               </div>
             </div>
             <div className="flex flex-col rounded-xl border border-[#E5E5E5] bg-white shadow-sm">
               <div className="flex items-center gap-2 border-b border-[#E5E5E5] px-5 py-3">
-                <span className="text-sm font-medium text-[#374151]">AI 피드백 요약</span>
+                <span className="text-sm font-medium text-[#374151]">AI 피드백 (루브릭·턴 평가)</span>
               </div>
               <div className="max-h-[400px] flex-1 overflow-y-auto p-5">
-                <div className="mb-4">
-                  <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#16A34A]">강점</h4>
-                  <ul className="space-y-1">
-                    {feedbackData.strengths.map((item, index) => (
-                      <li key={index} className="text-sm text-[#374151]">
-                        • {item}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="mb-4">
-                  <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#DC2626]">약점</h4>
-                  <ul className="space-y-1">
-                    {feedbackData.weaknesses.map((item, index) => (
-                      <li key={index} className="text-sm text-[#374151]">
-                        • {item}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <div className="mb-4">
-                  <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#3B82F6]">개선 제안</h4>
-                  <ul className="space-y-1">
-                    {feedbackData.suggestions.map((item, index) => (
-                      <li key={index} className="text-sm text-[#374151]">
-                        • {item}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                <div>
-                  <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#D97706]">
-                    성능 관련 메모
-                  </h4>
-                  <ul className="space-y-1">
-                    {feedbackData.performanceNotes.map((item, index) => (
-                      <li key={index} className="text-sm text-[#374151]">
-                        • {item}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
+                <p className="text-sm leading-relaxed text-[#6B7280]">
+                  Spring 관리자 API에는 <code className="rounded bg-[#F3F4F6] px-1">prompt_evaluations</code> 본문이
+                  아직 노출되지 않습니다. AI 평가 텍스트는 별도 내부/분석 API가 마련되면 연결할 수 있습니다.
+                </p>
               </div>
             </div>
           </div>
         </div>
 
-        {/* Test Case Results Section */}
         <div className="mb-6">
-          <h2 className="mb-4 text-lg font-semibold text-[#1A1A1A]">테스트 케이스 결과</h2>
-          <div className="rounded-xl border border-[#E5E5E5] bg-white shadow-sm">
-            <div className="px-6 pt-4 pb-2">
-              <span className="text-xs font-medium uppercase tracking-wide text-slate-500">전체 테스트 케이스</span>
-            </div>
-            <div className="grid grid-cols-[1.5fr_1.5fr_1.5fr_1fr_1fr_1fr_1fr] gap-4 border-b border-[#E5E5E5] bg-[#F9FAFB] px-6 py-3">
-              <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">테스트 케이스</span>
-              <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">기대 출력값</span>
-              <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">제출된 출력값</span>
-              <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">결과</span>
-              <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
-                실행 시간
-              </span>
-              <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">메모리 사용량</span>
-              <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">토큰 수</span>
-            </div>
-            <div className="px-6">
-              {testCaseResults.map((testCase, index) => (
-                <div
-                  key={testCase.id}
-                  className={
-                    "grid grid-cols-[1.5fr_1.5fr_1.5fr_1fr_1fr_1fr_1fr] items-center gap-4 py-3 " +
-                    (index !== testCaseResults.length - 1 ? "border-b border-[#E5E5E5]" : "")
-                  }
-                >
-                  <span className="text-sm text-[#374151]">{testCase.testCase}</span>
-                  <span className="font-mono text-xs text-[#6B7280]">{testCase.expected}</span>
-                  <span className="font-mono text-xs text-[#6B7280]">{testCase.submitted}</span>
-                  <div className="flex justify-center">
-                    <TestResultBadge result={testCase.result} />
+          <h2 className="mb-4 text-lg font-semibold text-[#1A1A1A]">채점·테스트 요약</h2>
+          <div className="rounded-xl border border-[#E5E5E5] bg-white shadow-sm p-6">
+            {!submissionDetail && !isLoadingSubmission && (
+              <p className="text-sm text-[#6B7280]">
+                제출이 없거나 제출 상세를 불러오지 못했습니다. 개별 테스트 케이스 입·출력은 현재 API에 없습니다.
+              </p>
+            )}
+            {submissionDetail && (
+              <div className="space-y-4 text-sm">
+                <p>
+                  <span className="font-medium text-[#374151]">제출 상태(상세):</span>{" "}
+                  <span className="text-[#1A1A1A]">{submissionDetail.status}</span>
+                </p>
+                {submissionDetail.metrics && (
+                  <p className="text-[#6B7280]">
+                    시간 중앙값: {submissionDetail.metrics.timeMsMedian ?? "–"} ms · 메모리 peak:{" "}
+                    {submissionDetail.metrics.memKbPeak ?? "–"} KB · LOC: {submissionDetail.metrics.loc ?? "–"}
+                  </p>
+                )}
+                {submissionDetail.tc?.groups && submissionDetail.tc.groups.length > 0 ? (
+                  <div>
+                    <p className="mb-2 font-medium text-[#374151]">채점 그룹별 통과 (submission_runs 집계)</p>
+                    <div className="overflow-x-auto">
+                      <table className="w-full text-left text-sm">
+                        <thead>
+                          <tr className="border-b border-[#E5E5E5] text-[#6B7280]">
+                            <th className="py-2 pr-4">그룹</th>
+                            <th className="py-2 pr-4">통과</th>
+                            <th className="py-2">전체</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {submissionDetail.tc.groups.map((g, i) => (
+                            <tr key={i} className="border-b border-[#F3F4F6]">
+                              <td className="py-2 pr-4 font-mono text-xs">{String(g.name)}</td>
+                              <td className="py-2 pr-4">{g.pass}</td>
+                              <td className="py-2">{g.total}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                    {submissionDetail.tc.passRateWeighted != null && (
+                      <p className="mt-2 text-[#6B7280]">
+                        가중 통과율: {(Number(submissionDetail.tc.passRateWeighted) * 100).toFixed(1)}%
+                      </p>
+                    )}
                   </div>
-                  <span className="text-center text-sm text-[#6B7280]">{testCase.execTime}</span>
-                  <span className="text-center text-sm text-[#6B7280]">{testCase.memory}</span>
-                  <span className="text-center text-sm text-[#6B7280]">{testCase.tokens}</span>
-                </div>
-              ))}
-            </div>
+                ) : (
+                  <p className="text-[#6B7280]">그룹별 채점 요약 데이터가 없습니다.</p>
+                )}
+              </div>
+            )}
           </div>
           <div className="mt-6 flex justify-end">
             <button
+              type="button"
               onClick={handleExport}
               className="inline-flex items-center gap-1.5 rounded-lg bg-[#3B82F6] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#2563EB]"
             >
-              결과 내보내기 (CSV)
+              결과보내기 (CSV)
             </button>
           </div>
         </div>
       </div>
 
-      {/* Toast Notifications */}
       <div className="fixed right-6 top-6 z-50 flex flex-col gap-3">
         {toasts.map((toast) => (
           <div
@@ -526,6 +500,7 @@ export function ParticipantEvaluationContent({ entryCode, participantName: parti
               <p className="mt-0.5 text-xs text-[#6B7280]">{toast.description}</p>
             </div>
             <button
+              type="button"
               onClick={() => removeToast(toast.id)}
               className="shrink-0 rounded p-0.5 text-[#9CA3AF] transition-colors hover:bg-[#F3F4F6] hover:text-[#6B7280]"
             >

--- a/components/participant-evaluation-content.tsx
+++ b/components/participant-evaluation-content.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect, useMemo } from "react"
+import type { MouseEvent } from "react"
 import { ArrowLeft, User, Code, CheckCircle, X } from "lucide-react"
 import { useRouter } from "next/navigation"
 import {
@@ -64,6 +65,11 @@ function LanguageBadge({ language }: { language: string }) {
 function formatScore(n: number | null | undefined): string {
   if (n === null || n === undefined || Number.isNaN(Number(n))) return "–"
   return `${Number(n).toFixed(1)}`
+}
+
+const escapeCsv = (value: unknown) => {
+  const str = String(value ?? "")
+  return `"${str.replace(/"/g, '""')}"`
 }
 
 export function ParticipantEvaluationContent({
@@ -204,18 +210,18 @@ export function ParticipantEvaluationContent({
   const handleExport = () => {
     const header = "Field,Value"
     const rows = [
-      `Name,${displayName}`,
-      `EntryCodeSegment,${entryCode}`,
-      `ExamParticipantId,${participantId}`,
-      `ExamId,${examId ?? ""}`,
-      `SubmissionId,${submissionId ?? ""}`,
-      `HasSubmissionCode,${submissionDetail?.codeInline?.trim() ? "yes" : "no"}`,
-      `HasRubricJson,${submissionDetail?.rubricJson?.trim() ? "yes" : "no"}`,
-      `BoardStatus,${submissionStatusLabel ?? ""}`,
-      `PromptScore,${scoreFromDetail?.prompt ?? ""}`,
-      `PerfScore,${scoreFromDetail?.perf ?? ""}`,
-      `CorrectnessScore,${scoreFromDetail?.correctness ?? ""}`,
-      `TotalScore,${scoreFromDetail?.total ?? boardEntry?.totalScore ?? ""}`,
+      `Name,${escapeCsv(displayName)}`,
+      `EntryCodeSegment,${escapeCsv(entryCode)}`,
+      `ExamParticipantId,${escapeCsv(participantId)}`,
+      `ExamId,${escapeCsv(examId ?? "")}`,
+      `SubmissionId,${escapeCsv(submissionId ?? "")}`,
+      `HasSubmissionCode,${escapeCsv(submissionDetail?.codeInline?.trim() ? "yes" : "no")}`,
+      `HasRubricJson,${escapeCsv(submissionDetail?.rubricJson?.trim() ? "yes" : "no")}`,
+      `BoardStatus,${escapeCsv(submissionStatusLabel ?? "")}`,
+      `PromptScore,${escapeCsv(scoreFromDetail?.prompt ?? "")}`,
+      `PerfScore,${escapeCsv(scoreFromDetail?.perf ?? "")}`,
+      `CorrectnessScore,${escapeCsv(scoreFromDetail?.correctness ?? "")}`,
+      `TotalScore,${escapeCsv(scoreFromDetail?.total ?? boardEntry?.totalScore ?? "")}`,
     ]
     const csvContent = [header, ...rows].join("\n")
     const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" })
@@ -230,7 +236,7 @@ export function ParticipantEvaluationContent({
     showToast("보내기 완료", "participant-evaluation.csv")
   }
 
-  const handleBackClick = (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
+  const handleBackClick = (e: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
     e.preventDefault()
     if (onBack) onBack()
     else router.back()

--- a/components/participant-evaluation-rubric-report.tsx
+++ b/components/participant-evaluation-rubric-report.tsx
@@ -1,0 +1,655 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { ChevronDown, ChevronRight, Info } from "lucide-react"
+import {
+  parseRubricJson,
+  pickScore,
+  asString,
+  asStringArray,
+  asNumber,
+  hasPresentValue,
+  isRecord,
+  collectDebateEntries,
+  groupDebateEntriesByRound,
+  splitHolisticFlowAnalysis,
+  formatRubricJsonPretty,
+  formatWeightLabel,
+  rubricHasStructuredFields,
+  type RubricJsonRecord,
+} from "@/lib/rubric-json"
+import {
+  collectFunctionComplexityDisplayLines,
+  formatCodeQualityMetricLabel,
+} from "@/lib/code-quality-metrics-labels"
+
+export interface ParticipantEvaluationRubricReportProps {
+  rubricJson: string | null | undefined
+  isLoading?: boolean
+}
+
+function Section({
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  title: string
+  children: React.ReactNode
+  defaultOpen?: boolean
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <section className="rounded-lg border border-[#E5E5E5] bg-[#FAFAFA]">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between px-4 py-3 text-left"
+      >
+        <h3 className="text-sm font-semibold text-[#1A1A1A]">{title}</h3>
+        {open ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-[#6B7280]" />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-[#6B7280]" />
+        )}
+      </button>
+      {open && <div className="border-t border-[#E5E5E5] px-4 py-4">{children}</div>}
+    </section>
+  )
+}
+
+function MetricCell({
+  label,
+  value,
+  description,
+}: {
+  label: string
+  value: string
+  description?: string
+}) {
+  return (
+    <div className="rounded-lg border border-[#F3F4F6] bg-white px-4 py-3">
+      <div className="flex items-center gap-1">
+        <p className="text-xs font-medium text-[#6B7280]">{label}</p>
+        {description && (
+          <span
+            className="inline-flex shrink-0 text-[#9CA3AF]"
+            title={description}
+            aria-label={description}
+          >
+            <Info className="h-3.5 w-3.5" strokeWidth={1.5} aria-hidden />
+          </span>
+        )}
+      </div>
+      <p className="mt-1 text-lg font-semibold text-[#1A1A1A]">{value}</p>
+    </div>
+  )
+}
+
+function TextBlock({ text }: { text: string }) {
+  return (
+    <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-[#374151]">{text}</p>
+  )
+}
+
+function Unavailable({ label = "제공되지 않음" }: { label?: string }) {
+  return <p className="text-sm text-[#9CA3AF]">{label}</p>
+}
+
+function formatDisplayLabel(raw: string): string {
+  return raw
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function formatScoreDisplay(n: number | null): string {
+  if (n === null) return "–"
+  return Number.isInteger(n) ? String(n) : n.toFixed(1)
+}
+
+function SummarySection({ data }: { data: RubricJsonRecord }) {
+  const grade = asString(data.grade)
+  const total = pickScore(data, "total_score", "totalScore")
+  const prompt = pickScore(data, "prompt_score", "promptScore")
+  const correctness = pickScore(
+    data,
+    "correctness_score",
+    "correctnessScore",
+    "code_correctness_score",
+    "codeCorrectnessScore"
+  )
+  const performance = pickScore(
+    data,
+    "performance_score",
+    "performanceScore",
+    "code_performance_score",
+    "codePerformanceScore"
+  )
+  const holistic = pickScore(data, "holistic_flow_score", "holisticFlowScore")
+  const weights = isRecord(data.weights) ? data.weights : null
+
+  const hasAny =
+    grade ||
+    total !== null ||
+    prompt !== null ||
+    correctness !== null ||
+    performance !== null ||
+    holistic !== null ||
+    weights
+
+  if (!hasAny) return null
+
+  return (
+    <Section title="1. 최종 AI 평가 요약">
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
+        {grade && <MetricCell label="등급" value={grade} />}
+        {total !== null && <MetricCell label="총점" value={formatScoreDisplay(total)} />}
+        {prompt !== null && <MetricCell label="프롬프트 점수" value={formatScoreDisplay(prompt)} />}
+        {correctness !== null && (
+          <MetricCell label="정답률 점수" value={formatScoreDisplay(correctness)} />
+        )}
+        {performance !== null && (
+          <MetricCell label="성능 점수" value={formatScoreDisplay(performance)} />
+        )}
+        {holistic !== null && (
+          <MetricCell
+            label="Holistic Flow"
+            value={formatScoreDisplay(holistic)}
+            description="전체 대화 흐름 및 AI 활용 전략 평가"
+          />
+        )}
+      </div>
+      {weights && (
+        <div className="mt-4 rounded-lg border border-[#F3F4F6] bg-white px-4 py-3">
+          <p className="mb-2 text-xs font-medium text-[#6B7280]">가중치</p>
+          <div className="flex flex-wrap gap-4 text-sm text-[#374151]">
+            {formatWeightLabel(weights.prompt, "프롬프트") && (
+              <span>{formatWeightLabel(weights.prompt, "프롬프트")}</span>
+            )}
+            {formatWeightLabel(weights.correctness, "정답률") && (
+              <span>{formatWeightLabel(weights.correctness, "정답률")}</span>
+            )}
+            {formatWeightLabel(weights.performance, "성능") && (
+              <span>{formatWeightLabel(weights.performance, "성능")}</span>
+            )}
+          </div>
+        </div>
+      )}
+    </Section>
+  )
+}
+
+const R4_CONTEXT_SECTION_TITLE = "R4 맥락 유지"
+const R4_CONTEXT_SECTION_HINT = "대화 흐름과 문맥 유지 능력 평가"
+
+function HolisticSubsectionTitle({ title }: { title: string }) {
+  const showHint = title === R4_CONTEXT_SECTION_TITLE
+  return (
+    <div className="mb-2 flex items-center gap-1">
+      <p className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">{title}</p>
+      {showHint && (
+        <span
+          className="inline-flex shrink-0 text-[#9CA3AF]"
+          title={R4_CONTEXT_SECTION_HINT}
+          aria-label={R4_CONTEXT_SECTION_HINT}
+        >
+          <Info className="h-3.5 w-3.5" strokeWidth={1.5} aria-hidden />
+        </span>
+      )}
+    </div>
+  )
+}
+
+function HolisticSection({ data }: { data: RubricJsonRecord }) {
+  const analysis = asString(data.holistic_flow_analysis) ?? asString(data.holisticFlowAnalysis)
+  if (!analysis) return null
+
+  const sections = splitHolisticFlowAnalysis(analysis)
+
+  return (
+    <Section title="2. 종합 분석">
+      <div className="space-y-4">
+        {sections.map((sec, i) => (
+          <div key={i} className="rounded-lg border border-[#F3F4F6] bg-white p-4">
+            <HolisticSubsectionTitle title={sec.title} />
+            <TextBlock text={sec.body} />
+          </div>
+        ))}
+      </div>
+    </Section>
+  )
+}
+
+function CodeEvalReportSection({ data }: { data: RubricJsonRecord }) {
+  const report = data.code_eval_report ?? data.codeEvalReport
+  if (!isRecord(report)) return null
+
+  const fields: { key: string; label: string }[] = [
+    { key: "overall_summary", label: "종합 요약" },
+    { key: "efficiency_review", label: "효율성 리뷰" },
+    { key: "readability_review", label: "가독성 리뷰" },
+    { key: "error_handling_review", label: "예외 처리 리뷰" },
+    { key: "score_adjustment_note", label: "점수 조정 참고" },
+  ]
+
+  const items = fields
+    .map(({ key, label }) => {
+      const text = asString(report[key])
+      return text ? { label, text } : null
+    })
+    .filter((x): x is { label: string; text: string } => x != null)
+
+  if (items.length === 0) return null
+
+  return (
+    <Section title="3. 코드 평가 리포트">
+      <div className="space-y-4">
+        {items.map((item) => (
+          <div key={item.label} className="rounded-lg border border-[#F3F4F6] bg-white p-4">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+              {item.label}
+            </p>
+            <TextBlock text={item.text} />
+          </div>
+        ))}
+      </div>
+    </Section>
+  )
+}
+
+const DEBATE_AGENT_ORDER = ["strict", "advocate", "neutral"]
+
+function pickDebateBriefSummary(entry: RubricJsonRecord): string | null {
+  return (
+    asString(entry.stance) ??
+    asString(entry.summary) ??
+    asString(entry.opinion) ??
+    asString(entry.overview) ??
+    null
+  )
+}
+
+function debateAgentSortKey(entry: RubricJsonRecord): number {
+  const agent = asString(entry.agent)?.toLowerCase() ?? ""
+  const idx = DEBATE_AGENT_ORDER.indexOf(agent)
+  return idx >= 0 ? idx : 100
+}
+
+function DebateAgentBadge({ agent }: { agent: string }) {
+  const key = agent.toLowerCase()
+  const tone =
+    key === "strict"
+      ? "bg-[#FEE2E2] text-[#B91C1C]"
+      : key === "advocate"
+        ? "bg-[#DCFCE7] text-[#15803D]"
+        : key === "neutral"
+          ? "bg-[#F3F4F6] text-[#374151]"
+          : "bg-[#E0EDFF] text-[#1D4ED8]"
+  return (
+    <span className={`shrink-0 rounded px-2 py-0.5 text-xs font-semibold ${tone}`}>
+      {formatDisplayLabel(agent)}
+    </span>
+  )
+}
+
+function DebateRoundCompactRow({ entry }: { entry: RubricJsonRecord }) {
+  const agent = asString(entry.agent) ?? "–"
+  const summary = pickDebateBriefSummary(entry)
+  const suggested = asNumber(entry.suggested_score ?? entry.suggestedScore)
+
+  return (
+    <div className="flex flex-col gap-1.5 sm:flex-row sm:items-start sm:gap-3">
+      <div className="flex min-w-[5.5rem] items-center sm:pt-0.5">
+        <DebateAgentBadge agent={agent} />
+      </div>
+      <div className="min-w-0 flex-1 rounded-md border border-[#FDE68A] bg-[#FFFBEB] px-3 py-2">
+        {summary ? (
+          <p className="whitespace-pre-wrap break-words text-sm leading-snug text-[#78350F]">{summary}</p>
+        ) : (
+          <p className="text-sm text-[#9CA3AF]">제공되지 않음</p>
+        )}
+        {suggested !== null && (
+          <p className="mt-1 text-xs text-[#92400E]">제안 점수 {formatScoreDisplay(suggested)}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function DebateVerdictCard({ entry }: { entry: RubricJsonRecord }) {
+  const suggested = asNumber(entry.suggested_score ?? entry.suggestedScore)
+  const keyPoints = asStringArray(entry.key_points ?? entry.keyPoints)
+  const codeQ = asString(entry.code_quality_assessment ?? entry.codeQualityAssessment)
+  const promptQ = asString(entry.prompt_quality_assessment ?? entry.promptQualityAssessment)
+  const consensus = asString(entry.consensus_summary ?? entry.consensusSummary)
+  const holistic = asNumber(entry.holistic_flow_score ?? entry.holisticFlowScore)
+  const holisticAnalysis = asString(entry.holistic_flow_analysis ?? entry.holisticFlowAnalysis)
+  const scoreRationale = asString(entry.score_rationale ?? entry.scoreRationale)
+  const grade = asString(entry.grade)
+  const r4 = asNumber(entry.r4_context_maintenance_score ?? entry.r4ContextMaintenanceScore)
+
+  return (
+    <article className="rounded-lg border border-[#E5E5E5] bg-white p-4 shadow-sm">
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <span className="rounded-full bg-[#1E293B] px-2.5 py-0.5 text-xs font-semibold text-white">
+          Verdict
+        </span>
+        {grade && (
+          <span className="rounded-full bg-[#F3F4F6] px-2.5 py-0.5 text-xs font-medium text-[#374151]">
+            등급 {grade}
+          </span>
+        )}
+        {holistic !== null && (
+          <span className="text-xs text-[#6B7280]">Holistic {formatScoreDisplay(holistic)}</span>
+        )}
+        {r4 !== null && <span className="text-xs text-[#6B7280]">R4 {formatScoreDisplay(r4)}</span>}
+        {suggested !== null && (
+          <span className="text-xs text-[#6B7280]">제안 점수: {formatScoreDisplay(suggested)}</span>
+        )}
+      </div>
+      {consensus && (
+        <div className="mb-3">
+          <p className="mb-1 text-xs font-medium text-[#6B7280]">합의 요약</p>
+          <TextBlock text={consensus} />
+        </div>
+      )}
+      {holisticAnalysis && (
+        <div className="mb-3">
+          <p className="mb-1 text-xs font-medium text-[#6B7280]">종합 분석</p>
+          <TextBlock text={holisticAnalysis} />
+        </div>
+      )}
+      {scoreRationale && (
+        <div className="mb-3">
+          <p className="mb-1 text-xs font-medium text-[#6B7280]">점수 근거</p>
+          <TextBlock text={scoreRationale} />
+        </div>
+      )}
+      {keyPoints.length > 0 && (
+        <div className="mb-3">
+          <p className="mb-1 text-xs font-medium text-[#6B7280]">핵심 포인트</p>
+          <ul className="list-inside list-disc space-y-1 text-sm text-[#374151]">
+            {keyPoints.map((p, i) => (
+              <li key={i} className="whitespace-pre-wrap break-words">
+                {p}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {codeQ && (
+        <div className="mb-3">
+          <p className="mb-1 text-xs font-medium text-[#6B7280]">코드 품질 평가</p>
+          <TextBlock text={codeQ} />
+        </div>
+      )}
+      {promptQ && (
+        <div>
+          <p className="mb-1 text-xs font-medium text-[#6B7280]">프롬프트 품질 평가</p>
+          <TextBlock text={promptQ} />
+        </div>
+      )}
+    </article>
+  )
+}
+
+function DebateSection({ data }: { data: RubricJsonRecord }) {
+  const entries = collectDebateEntries(data)
+  if (entries.length === 0) return null
+
+  const { roundNumbers, byRound, verdicts } = groupDebateEntriesByRound(entries)
+
+  for (const list of byRound.values()) {
+    list.sort((a, b) => debateAgentSortKey(a) - debateAgentSortKey(b))
+  }
+
+  return (
+    <Section title="4. 평가관 토론 요약">
+      <div className="space-y-4">
+        {roundNumbers.map((roundNum) => {
+          const roundEntries = byRound.get(roundNum) ?? []
+          if (roundEntries.length === 0) return null
+          return (
+            <div key={roundNum} className="rounded-lg border border-[#E5E5E5] bg-white p-3 sm:p-4">
+              <p className="mb-3 text-sm font-semibold text-[#1A1A1A]">Round {roundNum}</p>
+              <div className="space-y-3">
+                {roundEntries.map((entry, i) => (
+                  <DebateRoundCompactRow
+                    key={`${roundNum}-${asString(entry.agent) ?? i}`}
+                    entry={entry}
+                  />
+                ))}
+              </div>
+            </div>
+          )
+        })}
+        {verdicts.length > 0 && (
+          <div className="space-y-3">
+            <p className="text-sm font-semibold text-[#1A1A1A]">최종 Verdict</p>
+            {verdicts.map((entry, i) => (
+              <DebateVerdictCard key={`verdict-${i}`} entry={entry} />
+            ))}
+          </div>
+        )}
+      </div>
+    </Section>
+  )
+}
+
+function TurnScoresSection({ data }: { data: RubricJsonRecord }) {
+  const raw = data.turn_scores ?? data.turnScores
+  if (!isRecord(raw) && !Array.isArray(raw)) return null
+
+  const rows: { turn: string; score: string; detail: string }[] = []
+
+  if (isRecord(raw)) {
+    for (const [turn, val] of Object.entries(raw)) {
+      if (isRecord(val)) {
+        const ts = asNumber(val.turn_score ?? val.turnScore ?? val.score)
+        const parts: string[] = []
+        if (hasPresentValue(val.intent)) parts.push(`intent: ${asString(val.intent)}`)
+        if (hasPresentValue(val.feedback)) parts.push(asString(val.feedback) ?? "")
+        rows.push({
+          turn,
+          score: ts !== null ? formatScoreDisplay(ts) : "–",
+          detail: parts.join(" · ") || "–",
+        })
+      } else {
+        const n = asNumber(val)
+        rows.push({ turn, score: n !== null ? formatScoreDisplay(n) : String(val), detail: "–" })
+      }
+    }
+  }
+
+  if (rows.length === 0) return null
+
+  rows.sort((a, b) => {
+    const na = Number(a.turn)
+    const nb = Number(b.turn)
+    if (!Number.isNaN(na) && !Number.isNaN(nb)) return na - nb
+    return a.turn.localeCompare(b.turn)
+  })
+
+  return (
+    <Section title="5. 프롬프트 턴 점수">
+      <div className="overflow-x-auto rounded-lg border border-[#E5E5E5]">
+        <table className="w-full min-w-[320px] text-left text-sm">
+          <thead className="bg-white">
+            <tr className="border-b border-[#E5E5E5] text-xs text-[#6B7280]">
+              <th className="px-4 py-2 font-medium">Turn</th>
+              <th className="px-4 py-2 font-medium">점수</th>
+              <th className="px-4 py-2 font-medium">비고</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.turn} className="border-b border-[#F3F4F6] last:border-0">
+                <td className="px-4 py-2 font-mono text-xs">{r.turn}</td>
+                <td className="px-4 py-2 font-semibold text-[#1A1A1A]">{r.score}</td>
+                <td className="px-4 py-2 text-[#6B7280]">{r.detail}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Section>
+  )
+}
+
+function QualityMetricsSection({ data }: { data: RubricJsonRecord }) {
+  const qm = data.code_quality_metrics ?? data.codeQualityMetrics
+  if (!isRecord(qm)) return null
+
+  const radon = isRecord(qm.radon_cc) ? qm.radon_cc : isRecord(qm.radonCc) ? qm.radonCc : null
+  const refRadon = isRecord(qm.reference_radon_cc)
+    ? qm.reference_radon_cc
+    : isRecord(qm.referenceRadonCc)
+      ? qm.referenceRadonCc
+      : null
+  const deltaRef = isRecord(qm.delta_cc_vs_reference)
+    ? qm.delta_cc_vs_reference
+    : isRecord(qm.deltaCcVsReference)
+      ? qm.deltaCcVsReference
+      : null
+  const deltaCc = isRecord(qm.delta_cc) ? qm.delta_cc : isRecord(qm.deltaCc) ? qm.deltaCc : null
+  const v2Radon = isRecord(qm.v2_metrics) && isRecord(qm.v2_metrics.radon_cc) ? qm.v2_metrics.radon_cc : null
+  const functionLines = collectFunctionComplexityDisplayLines(
+    qm.functions,
+    radon?.functions,
+    v2Radon?.functions
+  )
+
+  const metrics: { key: string; label: string; value: string }[] = []
+  const push = (metricKey: string, v: unknown) => {
+    const n = asNumber(v)
+    const s = asString(v)
+    const label = formatCodeQualityMetricLabel(metricKey)
+    if (n !== null) metrics.push({ key: metricKey, label, value: formatScoreDisplay(n) })
+    else if (s) metrics.push({ key: metricKey, label, value: s })
+  }
+
+  if (radon) {
+    push("radon_cc.avg_cc", radon.avg_cc ?? radon.avgCc)
+    push("radon_cc.max_cc", radon.max_cc ?? radon.maxCc)
+  }
+  if (refRadon) {
+    push("reference_radon_cc.avg_cc", refRadon.avg_cc ?? refRadon.avgCc)
+    push("reference_radon_cc.max_cc", refRadon.max_cc ?? refRadon.maxCc)
+  }
+  if (deltaRef) {
+    push("delta_cc_vs_reference.delta_cc_pct", deltaRef.delta_cc_pct ?? deltaRef.deltaCcPct)
+  }
+  if (deltaCc && !deltaRef) {
+    push("delta_cc.delta_cc_pct", deltaCc.delta_cc_pct ?? deltaCc.deltaCcPct)
+  }
+
+  if (metrics.length === 0 && functionLines.length === 0) return null
+
+  return (
+    <Section title="6. 코드 품질 메트릭">
+      {metrics.length > 0 && (
+        <div className="mb-4 grid grid-cols-2 gap-3 lg:grid-cols-3">
+          {metrics.map((m) => (
+            <MetricCell key={m.key} label={m.label} value={m.value} />
+          ))}
+        </div>
+      )}
+      {functionLines.length > 0 && (
+        <div className="rounded-lg border border-[#F3F4F6] bg-white p-4">
+          <p className="mb-2 text-xs font-medium uppercase tracking-wide text-[#6B7280]">
+            함수별 복잡도
+          </p>
+          <ul className="list-inside list-disc space-y-1 text-sm text-[#374151]">
+            {functionLines.map((fn, i) => (
+              <li key={i} className="break-words">
+                {fn}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </Section>
+  )
+}
+
+function RawJsonSection({ raw }: { raw: string }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <section className="rounded-lg border border-dashed border-[#D1D5DB] bg-white">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center justify-between px-4 py-3 text-left text-sm font-medium text-[#374151]"
+      >
+        7. 원본 JSON 보기
+        {open ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+      </button>
+      {open && (
+        <pre className="max-h-[360px] overflow-auto border-t border-[#E5E5E5] p-4 font-mono text-xs leading-relaxed whitespace-pre-wrap break-words text-[#1A1A1A]">
+          {raw}
+        </pre>
+      )}
+    </section>
+  )
+}
+
+function StructuredReport({ data, rawPretty }: { data: RubricJsonRecord; rawPretty: string }) {
+  const hasStructured = rubricHasStructuredFields(data)
+
+  return (
+    <div className="space-y-4">
+      {!hasStructured && (
+        <p className="text-sm text-[#6B7280]">
+          파싱된 루브릭 데이터에 표시할 구조화 필드가 없습니다. 아래 원본 JSON을 확인하세요.
+        </p>
+      )}
+      <SummarySection data={data} />
+      <HolisticSection data={data} />
+      <CodeEvalReportSection data={data} />
+      <DebateSection data={data} />
+      <TurnScoresSection data={data} />
+      <QualityMetricsSection data={data} />
+      <RawJsonSection raw={rawPretty} />
+    </div>
+  )
+}
+
+export function ParticipantEvaluationRubricReport({
+  rubricJson,
+  isLoading = false,
+}: ParticipantEvaluationRubricReportProps) {
+  const parsed = useMemo(() => parseRubricJson(rubricJson ?? null), [rubricJson])
+
+  if (isLoading) {
+    return <p className="text-sm text-[#6B7280]">AI 평가 리포트를 불러오는 중…</p>
+  }
+
+  if (!rubricJson?.trim()) {
+    return (
+      <p className="text-sm text-[#6B7280]">
+        채점 루브릭 JSON(<code className="rounded bg-[#F3F4F6] px-1">scores.rubric_json</code>)이
+        아직 없습니다.
+      </p>
+    )
+  }
+
+  if (!parsed) {
+    return <Unavailable />
+  }
+
+  if (!parsed.ok) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-amber-800">
+          rubricJson JSON 파싱에 실패했습니다. 원본 문자열을 표시합니다.
+          {parsed.error ? ` (${parsed.error})` : ""}
+        </p>
+        <pre className="max-h-[400px] overflow-auto whitespace-pre-wrap break-words rounded-lg border border-[#E5E5E5] bg-[#FAFAFA] p-4 font-mono text-xs text-[#1A1A1A]">
+          {parsed.raw}
+        </pre>
+      </div>
+    )
+  }
+
+  const rawPretty = formatRubricJsonPretty(parsed.data)
+  return <StructuredReport data={parsed.data} rawPretty={rawPretty} />
+}

--- a/components/participant-evaluation-rubric-report.tsx
+++ b/components/participant-evaluation-rubric-report.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useMemo, useState } from "react"
+import type { ReactNode } from "react"
 import { ChevronDown, ChevronRight, Info } from "lucide-react"
 import {
   parseRubricJson,
@@ -34,7 +35,7 @@ function Section({
   defaultOpen = false,
 }: {
   title: string
-  children: React.ReactNode
+  children: ReactNode
   defaultOpen?: boolean
 }) {
   const [open, setOpen] = useState(defaultOpen)

--- a/components/participant-evaluation-test-summary.tsx
+++ b/components/participant-evaluation-test-summary.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import type {
+  AdminSubmissionDetailResponse,
+  AdminSubmissionGroupInfo,
+  AdminSubmissionRunGroup,
+  AdminSubmissionCaseRunInfo,
+} from "@/lib/api/admin"
+
+const TC_GROUP_ORDER: AdminSubmissionRunGroup[] = ["SAMPLE", "PUBLIC", "PRIVATE"]
+
+const TC_GROUP_LABEL: Record<AdminSubmissionRunGroup, string> = {
+  SAMPLE: "샘플 (SAMPLE)",
+  PUBLIC: "공개 (PUBLIC)",
+  PRIVATE: "비공개 (PRIVATE)",
+}
+
+const TC_GROUP_WEIGHT: Record<AdminSubmissionRunGroup, number> = {
+  SAMPLE: 0.1,
+  PUBLIC: 0.3,
+  PRIVATE: 0.6,
+}
+
+const VERDICT_LABEL: Record<string, string> = {
+  AC: "정답 (AC)",
+  WA: "오답 (WA)",
+  TLE: "시간 초과 (TLE)",
+  MLE: "메모리 초과 (MLE)",
+  RE: "런타임 오류 (RE)",
+}
+
+function formatSubmissionStatusDetailKo(
+  status: AdminSubmissionDetailResponse["status"] | undefined
+): string {
+  if (!status) return "–"
+  const map: Record<AdminSubmissionDetailResponse["status"], string> = {
+    QUEUED: "대기 (QUEUED)",
+    RUNNING: "실행·채점 중 (RUNNING)",
+    DONE: "완료 (DONE)",
+    FAILED: "실패 (FAILED)",
+  }
+  return map[status] ?? status
+}
+
+function normalizeRunGroupName(name: unknown): AdminSubmissionRunGroup | null {
+  const raw =
+    typeof name === "string"
+      ? name
+      : name != null && typeof name === "object" && "name" in name
+        ? String((name as { name: unknown }).name)
+        : String(name)
+  if (raw === "SAMPLE" || raw === "PUBLIC" || raw === "PRIVATE") return raw
+  return null
+}
+
+function mergeTcGroupsForDisplay(groups: AdminSubmissionGroupInfo[] | undefined) {
+  const map = new Map<AdminSubmissionRunGroup, AdminSubmissionGroupInfo>()
+  for (const g of groups ?? []) {
+    const key = normalizeRunGroupName(g.name)
+    if (key) map.set(key, { ...g, name: key })
+  }
+  return TC_GROUP_ORDER.map((name) => {
+    const g = map.get(name)
+    return {
+      name,
+      label: TC_GROUP_LABEL[name],
+      pass: g?.pass ?? 0,
+      total: g?.total ?? 0,
+      weight: g?.weight ?? TC_GROUP_WEIGHT[name],
+    }
+  })
+}
+
+function aggregateGroupsFromRuns(runs: AdminSubmissionCaseRunInfo[]): AdminSubmissionGroupInfo[] {
+  const acc = new Map<AdminSubmissionRunGroup, { pass: number; total: number }>()
+  for (const r of runs) {
+    const cur = acc.get(r.grp) ?? { pass: 0, total: 0 }
+    cur.total += 1
+    if (r.verdict === "AC") cur.pass += 1
+    acc.set(r.grp, cur)
+  }
+  return TC_GROUP_ORDER.filter((name) => acc.has(name)).map((name) => ({
+    name,
+    pass: acc.get(name)!.pass,
+    total: acc.get(name)!.total,
+    weight: TC_GROUP_WEIGHT[name],
+  }))
+}
+
+export interface ParticipantEvaluationTestSummaryProps {
+  submissionId: number | null
+  isLoading: boolean
+  detail: AdminSubmissionDetailResponse | null
+  boardStatusLabel: string | null
+}
+
+export function ParticipantEvaluationTestSummary({
+  submissionId,
+  isLoading,
+  detail,
+  boardStatusLabel,
+}: ParticipantEvaluationTestSummaryProps) {
+  const displayGroups = (() => {
+    const fromApi = detail?.tc?.groups
+    if (fromApi && fromApi.length > 0) return mergeTcGroupsForDisplay(fromApi)
+    const runs = detail?.runs
+    if (runs && runs.length > 0) return mergeTcGroupsForDisplay(aggregateGroupsFromRuns(runs))
+    return mergeTcGroupsForDisplay([])
+  })()
+
+  const hasAnyTcData =
+    (detail?.tc?.groups?.length ?? 0) > 0 || (detail?.runs?.length ?? 0) > 0
+
+  const failedRuns = (detail?.runs ?? []).filter((r) => r.verdict !== "AC")
+
+  return (
+    <div className="rounded-xl border border-[#E5E5E5] bg-white p-6 shadow-sm">
+      {isLoading && submissionId != null && (
+        <p className="text-sm text-[#6B7280]">제출 상세·테스트 결과를 불러오는 중…</p>
+      )}
+      {!isLoading && submissionId == null && (
+        <p className="text-sm text-[#6B7280]">제출 기록이 없어 테스트 결과를 표시할 수 없습니다.</p>
+      )}
+      {!isLoading && submissionId != null && !detail && (
+        <p className="text-sm text-[#6B7280]">
+          제출 상세를 불러오지 못했습니다. 네트워크·관리자 권한을 확인하세요.
+        </p>
+      )}
+      {detail && (
+        <div className="space-y-6 text-sm">
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+            <div className="rounded-lg border border-[#F3F4F6] bg-[#FAFAFA] p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-[#6B7280]">제출 상태</p>
+              <p className="mt-2 font-semibold text-[#1A1A1A]">
+                {formatSubmissionStatusDetailKo(detail.status)}
+              </p>
+              {boardStatusLabel && (
+                <p className="mt-1 text-xs text-[#6B7280]">보드: {boardStatusLabel}</p>
+              )}
+            </div>
+            <div className="rounded-lg border border-[#F3F4F6] bg-[#FAFAFA] p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-[#6B7280]">실행 시간</p>
+              <p className="mt-2 font-semibold text-[#1A1A1A]">
+                {detail.metrics?.timeMsMedian != null ? `${detail.metrics.timeMsMedian} ms` : "–"}
+              </p>
+              <p className="mt-1 text-xs text-[#6B7280]">중앙값 (submission_runs)</p>
+            </div>
+            <div className="rounded-lg border border-[#F3F4F6] bg-[#FAFAFA] p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-[#6B7280]">메모리</p>
+              <p className="mt-2 font-semibold text-[#1A1A1A]">
+                {detail.metrics?.memKbPeak != null ? `${detail.metrics.memKbPeak} KB` : "–"}
+              </p>
+              <p className="mt-1 text-xs text-[#6B7280]">peak (submission_runs)</p>
+            </div>
+            <div className="rounded-lg border border-[#F3F4F6] bg-[#FAFAFA] p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-[#6B7280]">코드 LOC</p>
+              <p className="mt-2 font-semibold text-[#1A1A1A]">
+                {detail.metrics?.loc != null ? detail.metrics.loc : "–"}
+              </p>
+              <p className="mt-1 text-xs text-[#6B7280]">submissions.code_loc</p>
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-3 font-medium text-[#374151]">테스트 그룹별 결과</p>
+            {hasAnyTcData ? (
+              <>
+                <div className="overflow-x-auto rounded-lg border border-[#E5E5E5]">
+                  <table className="w-full min-w-[480px] text-left text-sm">
+                    <thead className="bg-[#FAFAFA]">
+                      <tr className="border-b border-[#E5E5E5] text-xs text-[#6B7280]">
+                        <th className="px-4 py-3 font-medium">그룹</th>
+                        <th className="px-4 py-3 font-medium">통과 / 전체</th>
+                        <th className="px-4 py-3 font-medium">통과율</th>
+                        <th className="px-4 py-3 font-medium">가중치</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {displayGroups.map((g) => {
+                        const rate = g.total > 0 ? (g.pass / g.total) * 100 : 0
+                        return (
+                          <tr key={g.name} className="border-b border-[#F3F4F6] last:border-0">
+                            <td className="px-4 py-3 text-[#1A1A1A]">{g.label}</td>
+                            <td className="px-4 py-3 font-mono text-[#1A1A1A]">
+                              {g.pass} / {g.total}
+                            </td>
+                            <td className="px-4 py-3 text-[#374151]">
+                              {g.total > 0 ? `${rate.toFixed(0)}%` : "–"}
+                            </td>
+                            <td className="px-4 py-3 text-[#6B7280]">{(g.weight * 100).toFixed(0)}%</td>
+                          </tr>
+                        )
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+                {detail.tc?.passRateWeighted != null && (
+                  <p className="mt-2 text-xs text-[#6B7280]">
+                    가중 통과율 (API): {(Number(detail.tc.passRateWeighted) * 100).toFixed(1)}%
+                  </p>
+                )}
+              </>
+            ) : (
+              <p className="rounded-lg border border-dashed border-[#E5E5E5] bg-[#FAFAFA] px-4 py-3 text-[#6B7280]">
+                submission_runs 집계 데이터가 없습니다. 채점 완료 후에도 비어 있으면 테스트 결과가 DB에
+                저장되지 않았을 수 있습니다.
+              </p>
+            )}
+          </div>
+
+          {failedRuns.length > 0 ? (
+            <div>
+              <p className="mb-3 font-medium text-[#374151]">실패·비정답 케이스</p>
+              <div className="overflow-x-auto rounded-lg border border-[#E5E5E5]">
+                <table className="w-full min-w-[560px] text-left text-sm">
+                  <thead className="bg-[#FAFAFA]">
+                    <tr className="border-b border-[#E5E5E5] text-xs text-[#6B7280]">
+                      <th className="px-4 py-3 font-medium">케이스</th>
+                      <th className="px-4 py-3 font-medium">그룹</th>
+                      <th className="px-4 py-3 font-medium">판정</th>
+                      <th className="px-4 py-3 font-medium">시간</th>
+                      <th className="px-4 py-3 font-medium">메모리</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {failedRuns.map((r) => (
+                      <tr
+                        key={`${r.caseIndex}-${r.grp}-${r.verdict}`}
+                        className="border-b border-[#F3F4F6] last:border-0"
+                      >
+                        <td className="px-4 py-3 font-mono text-xs">#{r.caseIndex}</td>
+                        <td className="px-4 py-3">{TC_GROUP_LABEL[r.grp]}</td>
+                        <td className="px-4 py-3">{VERDICT_LABEL[r.verdict] ?? r.verdict}</td>
+                        <td className="px-4 py-3 font-mono text-xs">
+                          {r.timeMs != null ? `${r.timeMs} ms` : "–"}
+                        </td>
+                        <td className="px-4 py-3 font-mono text-xs">
+                          {r.memKb != null ? `${r.memKb} KB` : "–"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="mt-2 text-xs text-[#6B7280]">출처: 관리자 API runs[] (submission_runs)</p>
+            </div>
+          ) : hasAnyTcData ? (
+            <p className="text-xs text-[#6B7280]">모든 기록된 케이스가 정답(AC)입니다.</p>
+          ) : null}
+
+          <div className="rounded-lg border border-[#F3F4F6] bg-[#FAFAFA] px-4 py-3 text-xs text-[#6B7280]">
+            <p className="font-medium text-[#374151]">현재 API에서 제공되지 않음</p>
+            <ul className="mt-2 list-inside list-disc space-y-1">
+              <li>테스트 케이스별 expected / actual 입·출력 상세</li>
+              <li>표준 출력·에러 본문 (stdout_bytes / stderr_bytes는 API 미노출)</li>
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/participant-list-content.tsx
+++ b/components/participant-list-content.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from "react"
 import Link from "next/link"
 import { ArrowLeft, Eye, ChevronLeft, ChevronRight } from "lucide-react"
-import { getExams, getBoard, ExamineeBoardEntry } from "@/lib/api/admin"
+import { getExams, getBoard, ExamineeBoardEntry, type Exam } from "@/lib/api/admin"
 
 type TrendLevel = "High" | "Average" | "Low"
 
@@ -18,6 +18,31 @@ interface ParticipantDetail {
 
 interface ParticipantListContentProps {
   entryCode: string
+}
+
+/**
+ * /admin/results/[segment] 세그먼트로 시험을 찾습니다.
+ * - API entryCode와 일치(있을 때)
+ * - 시험 제목과 일치(평가 결과 목록이 title을 URL에 넣는 기존 동작)
+ * - 전부 숫자면 exam.id (직접 링크용)
+ */
+function findExamByResultsSegment(exams: Exam[], segment: string) {
+  const trimmed = segment.trim()
+  if (!trimmed) return undefined
+
+  const byEntryCode = exams.find(
+    (e) => e.entryCode != null && String(e.entryCode).length > 0 && e.entryCode === trimmed
+  )
+  if (byEntryCode) return byEntryCode
+
+  const byTitle = exams.find((e) => e.title === trimmed)
+  if (byTitle) return byTitle
+
+  if (/^\d+$/.test(trimmed)) {
+    return exams.find((e) => String(e.id) === trimmed)
+  }
+
+  return undefined
 }
 
 function TrendBadge({ trend }: { trend: TrendLevel }) {
@@ -58,7 +83,7 @@ export function ParticipantListContent({ entryCode }: ParticipantListContentProp
       try {
         // 1) 시험 목록에서 entryCode에 매핑된 examId 찾기
         const exams = await getExams()
-        const matched = exams.find((e) => e.entryCode === entryCode)
+        const matched = findExamByResultsSegment(exams, entryCode)
         if (!matched) {
           // entryCode로 직접 매핑이 안 될 때 — 첫 번째 시험 또는 에러
           setError("해당 입장 코드에 대한 시험을 찾을 수 없습니다.")

--- a/components/participant-list-content.tsx
+++ b/components/participant-list-content.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react"
 import Link from "next/link"
 import { ArrowLeft, Eye, ChevronLeft, ChevronRight } from "lucide-react"
 import { getExams, getBoard, ExamineeBoardEntry, type Exam } from "@/lib/api/admin"
+import { adminParticipantEvaluationHref } from "@/lib/paths/admin-participant-evaluation"
 
 type TrendLevel = "High" | "Average" | "Low"
 
@@ -222,14 +223,12 @@ export function ParticipantListContent({ entryCode }: ParticipantListContentProp
                   </div>
                   <div className="flex justify-center">
                     <Link
-                      href={{
-                        pathname: `/admin/results/${encodeURIComponent(entryCode)}/${encodeURIComponent(participant.id)}`,
-                        query: {
-                          entryCode,
-                          participantName: participant.name,
-                          from: "results",
-                        },
-                      }}
+                      href={adminParticipantEvaluationHref({
+                        resultsSegment: entryCode,
+                        participantId: participant.id,
+                        from: "results",
+                        participantName: participant.name,
+                      })}
                       className="inline-flex items-center gap-1.5 rounded-md border-[#3B82F6] bg-white px-3 py-1.5 text-sm text-[#3B82F6] hover:bg-[#EFF6FF]"
                     >
                       <Eye className="h-3.5 w-3.5" strokeWidth={1.5} />

--- a/components/problem-section.tsx
+++ b/components/problem-section.tsx
@@ -10,16 +10,66 @@ interface ProblemSectionProps {
 export function ProblemSection({ examId }: ProblemSectionProps) {
   const [assignment, setAssignment] = useState<AssignmentResponse | null>(null)
   const [loading, setLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   useEffect(() => {
-    getAssignment(examId)
-      .then(setAssignment)
-      .catch((err) => {
-        if (process.env.NODE_ENV === "development") {
-          console.warn("[ProblemSection] getAssignment failed:", err)
+    let cancelled = false
+
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+    const isRetryableNoAssignment = (err: any) => {
+      const status = err?.status
+      const code = err?.code
+      const msg = String(err?.apiMessage || err?.message || "")
+      return status === 400 && (code === "PROBLEM005" || msg.includes("배정된 문제가 없습니다"))
+    }
+
+    const load = async () => {
+      setLoading(true)
+      setErrorMessage(null)
+
+      const maxAttempts = 6
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          const res = await getAssignment(examId)
+          if (cancelled) return
+          setAssignment(res)
+          setLoading(false)
+          return
+        } catch (err: any) {
+          if (cancelled) return
+
+          // 인증 실패는 재시도 대신 별도 안내(자동 리다이렉트 금지)
+          if (err?.status === 401) {
+            setAssignment(null)
+            setErrorMessage("인증이 필요합니다. 다시 입장해주세요.")
+            setLoading(false)
+            return
+          }
+
+          // 배정 지연(PROBLEM005)만 짧게 재시도
+          if (isRetryableNoAssignment(err) && attempt < maxAttempts) {
+            if (process.env.NODE_ENV === "development") {
+              console.warn(`[ProblemSection] assignment not ready (attempt ${attempt}/${maxAttempts}), retrying...`, err)
+            }
+            await sleep(1000)
+            continue
+          }
+
+          if (process.env.NODE_ENV === "development") {
+            console.warn("[ProblemSection] getAssignment failed:", err)
+          }
+          setAssignment(null)
+          setErrorMessage("문제를 불러올 수 없습니다.")
+          setLoading(false)
+          return
         }
-      })
-      .finally(() => setLoading(false))
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
   }, [examId])
 
   const problem = assignment?.problem
@@ -27,7 +77,11 @@ export function ProblemSection({ examId }: ProblemSectionProps) {
   return (
     <div className="bg-white rounded-xl border border-[#D0D0D0] p-6 flex-shrink-0">
       <h2 className="text-lg font-semibold text-[#1F2937] mb-4">
-        {loading ? "문제 로딩 중..." : problem ? `문제. ${problem.title}` : "문제를 불러올 수 없습니다."}
+        {loading
+          ? "문제 배정을 확인하는 중입니다..."
+          : problem
+            ? `문제. ${problem.title}`
+            : (errorMessage ?? "문제를 불러올 수 없습니다.")}
       </h2>
 
       {problem && (

--- a/components/results-content.tsx
+++ b/components/results-content.tsx
@@ -40,7 +40,8 @@ export function ResultsContent() {
       const exams = await getExams()
       const mapped: ResultEntry[] = exams.map((exam: Exam) => ({
         id: String(exam.id),
-        entryCode: exam.title,
+        // BE ExamResponse에 entryCode가 없을 수 있음 — 목록 표시·상세 URL은 title과 동기화
+        entryCode: exam.entryCode?.trim() ? exam.entryCode : exam.title,
         total: exam.participantCount,
         completed: exam.completedCount,
       }))

--- a/components/results-content.tsx
+++ b/components/results-content.tsx
@@ -41,7 +41,7 @@ export function ResultsContent() {
       const mapped: ResultEntry[] = exams.map((exam: Exam) => ({
         id: String(exam.id),
         // BE ExamResponse에 entryCode가 없을 수 있음 — 목록 표시·상세 URL은 title과 동기화
-        entryCode: exam.entryCode?.trim() ? exam.entryCode : exam.title,
+        entryCode: exam.entryCode?.trim() || exam.title,
         total: exam.participantCount,
         completed: exam.completedCount,
       }))

--- a/components/test-session-details-content.tsx
+++ b/components/test-session-details-content.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import Link from "next/link";
-import { getBoard } from "@/lib/api/admin";
+import { getBoard, formatBoardSubmissionLabelKo, type ExamineeBoardEntry } from "@/lib/api/admin";
 
 // Participant type
 type Participant = {
@@ -16,7 +16,10 @@ type Participant = {
   name: string
   phoneNumber: string
   connectionStatus: string
-  submissionStatus: string
+  /** 제출 레코드 존재 여부 (요약 통계용) */
+  hasSubmission: boolean
+  /** 제출·채점 상태 표시 문구 */
+  submissionStatusLabel: string
   tokenUsage: number
 }
 
@@ -43,16 +46,13 @@ export default function TestSessionDetailsContent({ session, onBack }: TestSessi
     setIsLoading(true);
     try {
       const board = await getBoard(session.id);
-      const mapped: Participant[] = board.map((p) => ({
+      const mapped: Participant[] = board.map((p: ExamineeBoardEntry) => ({
         id: p.examParticipantId,
         name: p.name,
         phoneNumber: p.phoneMasked,
         connectionStatus: p.state === "ENTRANCE" ? "Connected" : "Pending",
-        submissionStatus: p.submitted
-          ? "Submitted"
-          : p.state === "ENTRANCE"
-          ? "In Progress"
-          : "Not Started",
+        hasSubmission: p.submitted,
+        submissionStatusLabel: formatBoardSubmissionLabelKo(p),
         tokenUsage: p.tokenUsed || 0,
       }));
       setParticipants(mapped);
@@ -77,7 +77,7 @@ export default function TestSessionDetailsContent({ session, onBack }: TestSessi
   const currentParticipants = participants.slice(startIndex, endIndex)
 
   // Calculate summary stats
-  const submissions = participants.filter((p) => p.submissionStatus === "Submitted").length
+  const submissions = participants.filter((p) => p.hasSubmission).length
   const avgTokenUsage =
     participants.length > 0
       ? Math.round(participants.reduce((sum, p) => sum + p.tokenUsage, 0) / participants.length)
@@ -97,14 +97,26 @@ export default function TestSessionDetailsContent({ session, onBack }: TestSessi
     return <Badge className="bg-yellow-100 text-yellow-700 hover:bg-yellow-100">대기 중</Badge>
   }
 
-  const getSubmissionBadge = (status: string) => {
-    if (status === "Submitted") {
-      return <Badge className="bg-green-100 text-green-700 hover:bg-green-100">제출됨</Badge>
+  const getSubmissionBadge = (label: string) => {
+    if (label === "시작 안 함") {
+      return <Badge className="bg-gray-100 text-gray-700 hover:bg-gray-100">시작 안 함</Badge>
     }
-    if (status === "In Progress") {
+    if (label === "진행 중") {
       return <Badge className="bg-yellow-100 text-yellow-700 hover:bg-yellow-100">진행 중</Badge>
     }
-    return <Badge className="bg-gray-100 text-gray-700 hover:bg-gray-100">시작 안 함</Badge>
+    if (label === "제출 실패") {
+      return <Badge className="bg-red-100 text-red-700 hover:bg-red-100">제출 실패</Badge>
+    }
+    if (label.startsWith("채점 완료")) {
+      return <Badge className="bg-green-100 text-green-700 hover:bg-green-100">{label}</Badge>
+    }
+    if (label === "제출·채점 중") {
+      return <Badge className="bg-amber-100 text-amber-800 hover:bg-amber-100">{label}</Badge>
+    }
+    if (label === "제출됨") {
+      return <Badge className="bg-blue-100 text-blue-700 hover:bg-blue-100">제출됨</Badge>
+    }
+    return <Badge className="bg-gray-100 text-gray-700 hover:bg-gray-100">{label}</Badge>
   }
 
   // Generate page numbers for pagination
@@ -260,7 +272,7 @@ export default function TestSessionDetailsContent({ session, onBack }: TestSessi
                       {getConnectionBadge(participant.connectionStatus)}
                     </TableCell>
                     <TableCell style={{ width: "140px" }} className="text-center">
-                      {getSubmissionBadge(participant.submissionStatus)}
+                      {getSubmissionBadge(participant.submissionStatusLabel)}
                     </TableCell>
                     <TableCell style={{ width: "120px", fontSize: "14px", color: "#6B7280" }} className="text-center">
                       {participant.tokenUsage.toLocaleString()}

--- a/components/test-session-details-content.tsx
+++ b/components/test-session-details-content.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import Link from "next/link";
 import { getBoard, formatBoardSubmissionLabelKo, type ExamineeBoardEntry } from "@/lib/api/admin";
+import { adminParticipantEvaluationHref } from "@/lib/paths/admin-participant-evaluation";
 
 // Participant type
 type Participant = {
@@ -279,13 +280,13 @@ export default function TestSessionDetailsContent({ session, onBack }: TestSessi
                     </TableCell>
                     <TableCell style={{ width: "100px" }} className="text-right">
                       <Link
-                        href={{
-                          pathname: `/admin/results/${encodeURIComponent("AIV-2024-001")}/${participant.id}`,
-                          query: {
-                            from: "master",                 // ✅ 3번 루트 표시
-                            sessionId: session.id.toString() // ✅ 어떤 세션에서 왔는지
-                          },
-                        }}
+                        href={adminParticipantEvaluationHref({
+                          resultsSegment: session.id,
+                          participantId: participant.id,
+                          from: "master",
+                          participantName: participant.name,
+                          sessionId: session.id,
+                        })}
                       >
                         <Button
                           variant="ghost"

--- a/components/test-sessions-content.tsx
+++ b/components/test-sessions-content.tsx
@@ -18,7 +18,17 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet"
-import { deleteExam, getBoard, getExams, type Exam, type ExamineeBoardEntry } from "@/lib/api/admin";
+import { deleteExam, getBoard, getExams, type Exam, type ExamineeBoardEntry, formatBoardSubmissionLabelKo } from "@/lib/api/admin";
+
+function submissionBadgeClassName(label: string): string {
+  if (label === "시작 안 함") return "bg-gray-100 text-gray-700 hover:bg-gray-100"
+  if (label === "진행 중") return "bg-yellow-100 text-yellow-700 hover:bg-yellow-100"
+  if (label === "제출 실패") return "bg-red-100 text-red-700 hover:bg-red-100"
+  if (label.startsWith("채점 완료")) return "bg-green-100 text-green-700 hover:bg-green-100"
+  if (label === "제출·채점 중") return "bg-amber-100 text-amber-800 hover:bg-amber-100"
+  if (label === "제출됨") return "bg-blue-100 text-blue-700 hover:bg-blue-100"
+  return "bg-gray-100 text-gray-700 hover:bg-gray-100"
+}
 
 export interface TestSession {
   id: number
@@ -34,7 +44,10 @@ interface Participant {
   name: string
   phoneNumber: string
   connectionStatus: string
-  submissionStatus: string
+  /** 제출 레코드 존재 */
+  hasSubmission: boolean
+  /** 표시용 한글 상태 */
+  submissionStatusLabel: string
   tokenUsage: number
 }
 
@@ -89,11 +102,8 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
         name: participant.name,
         phoneNumber: participant.phoneMasked,
         connectionStatus: participant.state === "ENTRANCE" ? "Connected" : "Disconnected",
-        submissionStatus: participant.submitted
-          ? "Submitted"
-          : participant.state === "ENTRANCE"
-            ? "In Progress"
-            : "Not Started",
+        hasSubmission: participant.submitted,
+        submissionStatusLabel: formatBoardSubmissionLabelKo(participant),
         tokenUsage: participant.tokenUsed || 0,
       }))
       setParticipants(mapped)
@@ -156,7 +166,7 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
   const participantEndIndex = Math.min(participantStartIndex + participantPageSize, totalParticipants)
   const paginatedParticipants = participants.slice(participantStartIndex, participantEndIndex)
 
-  const submittedCount = participants.filter((p) => p.submissionStatus === "Submitted").length
+  const submittedCount = participants.filter((p) => p.hasSubmission).length
   const avgTokenUsage =
     participants.length > 0
       ? Math.round(participants.reduce((sum, p) => sum + p.tokenUsage, 0) / participants.length)
@@ -680,16 +690,10 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
                         <TableCell>
                           <Badge
                             variant="secondary"
-                            className={
-                              participant.submissionStatus === "Submitted"
-                                ? "bg-blue-100 text-blue-700 hover:bg-blue-100"
-                                : participant.submissionStatus === "In Progress"
-                                  ? "bg-yellow-100 text-yellow-700 hover:bg-yellow-100"
-                                  : "bg-gray-100 text-gray-700 hover:bg-gray-100"
-                            }
+                            className={submissionBadgeClassName(participant.submissionStatusLabel)}
                             style={{ fontSize: "12px", fontWeight: 500 }}
                           >
-                            {participant.submissionStatus === "Submitted" ? "제출됨" : participant.submissionStatus === "In Progress" ? "진행 중" : "시작 안 함"}
+                            {participant.submissionStatusLabel}
                           </Badge>
                         </TableCell>
                         <TableCell className="text-[#6B7280]" style={{ fontSize: "14px", fontWeight: 400 }}>

--- a/components/user-test-screen.tsx
+++ b/components/user-test-screen.tsx
@@ -5,7 +5,7 @@ import { Clock, Coins } from "lucide-react"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button"
 import { ProblemSection } from "@/components/problem-section"
-import { CodeEditorSection } from "@/components/code-editor-section"
+import { CodeEditorSection, type CodeEditorSectionHandle } from "@/components/code-editor-section"
 import { AiAssistantSidebar } from "@/components/ai-assistant-sidebar"
 import { useRouter } from "next/navigation";
 import { CheckCircle2 } from "lucide-react";
@@ -85,6 +85,10 @@ export default function UserTestScreen() {
 
   const [isSidebarOpen, setIsSidebarOpen] = useState(false)
   const [isSubmitModalOpen, setIsSubmitModalOpen] = useState(false)
+  /** 헤더 제출 확인 모달에서 POST 제출 중 */
+  const [isModalSubmitting, setIsModalSubmitting] = useState(false)
+
+  const codeEditorRef = useRef<CodeEditorSectionHandle>(null)
 
   // ── 초기 토큰 사용량 로드 (getChatHistory.totalTokens) ──────────────────────
   useEffect(() => {
@@ -307,6 +311,7 @@ export default function UserTestScreen() {
 
             {/* Code Editor Section */}
             <CodeEditorSection
+              ref={codeEditorRef}
               isReadOnly={isExamEnded}
               examId={examId}
               onSubmitted={handleCodeSubmitted}
@@ -342,12 +347,21 @@ export default function UserTestScreen() {
               </Button>
               <Button
                 className="px-8 bg-[#2563EB] hover:bg-[#1D4ED8] text-white"
-                onClick={() => {
-                  setIsSubmitModalOpen(false);
-                  setShowFinishedModal(true);
+                disabled={isModalSubmitting}
+                onClick={async () => {
+                  setIsModalSubmitting(true)
+                  try {
+                    const ok = await codeEditorRef.current?.submit()
+                    if (ok) {
+                      setIsSubmitModalOpen(false)
+                      setShowFinishedModal(true)
+                    }
+                  } finally {
+                    setIsModalSubmitting(false)
+                  }
                 }}
               >
-                네
+                {isModalSubmitting ? "제출 중…" : "네"}
               </Button>
             </div>
           </div>

--- a/components/user-test-screen.tsx
+++ b/components/user-test-screen.tsx
@@ -145,6 +145,7 @@ export default function UserTestScreen() {
   const handleCodeSubmitted = (submissionId: number) => {
     // 이전 SSE 연결 취소
     sseCleanupRef.current?.();
+    sseCleanupRef.current = null;
 
     setIsScoring(true);
     setCaseResultCount(0);
@@ -182,6 +183,7 @@ export default function UserTestScreen() {
   useEffect(() => {
     return () => {
       sseCleanupRef.current?.();
+      sseCleanupRef.current = null;
     };
   }, []);
 
@@ -224,6 +226,8 @@ export default function UserTestScreen() {
   }, [examId, isExamEnded, showEndModal]);
 
   const handleGoHome = () => {
+    sseCleanupRef.current?.();
+    sseCleanupRef.current = null;
     router.push("/");
   };
 
@@ -458,7 +462,7 @@ export default function UserTestScreen() {
             <div className="w-full flex flex-col gap-2">
               <Button
                 className="w-full rounded-lg bg-gray-900 text-white hover:bg-black"
-                onClick={() => router.push("/")}
+                onClick={handleGoHome}
               >
                 홈 화면으로 돌아가기
               </Button>

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -1919,6 +1919,18 @@ export interface AdminSubmissionTestCaseInfo {
   groups: AdminSubmissionGroupInfo[];
 }
 
+export type AdminSubmissionRunGroup = 'SAMPLE' | 'PUBLIC' | 'PRIVATE';
+export type AdminSubmissionVerdict = 'AC' | 'WA' | 'TLE' | 'MLE' | 'RE';
+
+/** GET /api/admin/submissions/{submissionId} — submission_runs 행 (관리자 전용) */
+export interface AdminSubmissionCaseRunInfo {
+  caseIndex: number;
+  grp: AdminSubmissionRunGroup;
+  verdict: AdminSubmissionVerdict;
+  timeMs: number | null;
+  memKb: number | null;
+}
+
 /**
  * GET /api/admin/submissions/{submissionId} 응답 (코드·루브릭 포함, ADMIN/MASTER 전용)
  */
@@ -1931,6 +1943,7 @@ export interface AdminSubmissionDetailResponse {
   tc: AdminSubmissionTestCaseInfo | null;
   score: AdminSubmissionScoreInfo | null;
   rubricJson: string | null;
+  runs?: AdminSubmissionCaseRunInfo[];
 }
 
 /**

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -1891,6 +1891,71 @@ export async function getBoard(examId: number): Promise<ExamineeBoardEntry[]> {
   return data.result ?? [];
 }
 
+/** 관리자 제출 상세 API와 동일한 상태 값 (백엔드 SubmissionStatus) */
+export type AdminSubmissionStatusDto = 'QUEUED' | 'RUNNING' | 'DONE' | 'FAILED';
+
+export interface AdminSubmissionScoreInfo {
+  prompt: number | null;
+  perf: number | null;
+  correctness: number | null;
+  total: number | null;
+}
+
+export interface AdminSubmissionMetricsInfo {
+  timeMsMedian: number | null;
+  memKbPeak: number | null;
+  loc: number | null;
+}
+
+export interface AdminSubmissionGroupInfo {
+  name: string;
+  pass: number;
+  total: number;
+  weight: number;
+}
+
+export interface AdminSubmissionTestCaseInfo {
+  passRateWeighted: number | null;
+  groups: AdminSubmissionGroupInfo[];
+}
+
+/**
+ * GET /api/admin/submissions/{submissionId} 응답 (코드·루브릭 포함, ADMIN/MASTER 전용)
+ */
+export interface AdminSubmissionDetailResponse {
+  submissionId: number;
+  status: AdminSubmissionStatusDto;
+  lang: string;
+  codeInline: string | null;
+  metrics: AdminSubmissionMetricsInfo | null;
+  tc: AdminSubmissionTestCaseInfo | null;
+  score: AdminSubmissionScoreInfo | null;
+  rubricJson: string | null;
+}
+
+/**
+ * 관리자 전용 제출 상세 조회 (제출 코드·rubricJson 포함)
+ * GET /api/admin/submissions/{submissionId}
+ */
+export async function getAdminSubmissionDetail(
+  submissionId: number
+): Promise<AdminSubmissionDetailResponse> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/submissions/${submissionId}`;
+
+  const response = await fetchAdminWithRetry(url, {
+    method: 'GET',
+    headers: getAuthHeaders(),
+    credentials: 'include',
+  });
+
+  const data: BaseResponse<AdminSubmissionDetailResponse> = await response.json();
+  if (!response.ok || data.code !== 'COMMON200' || !data.result) {
+    throw new LoginFailedError(data.message || '제출 상세(관리자) 조회에 실패했습니다.', response.status);
+  }
+  return data.result;
+}
+
 // ─── SSE 채점 결과 스트리밍 ────────────────────────────────────────────────────
 // streamScoringResult는 lib/api/submissions.ts 에서 정의·export됩니다.
 // 이전에 이 파일에 존재하던 구버전 구현은 submissions.ts 의 콜백 기반 버전으로 통합되었습니다.

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -1728,6 +1728,41 @@ export interface ExamineeBoardEntry {
   tokenLimit: number;
   tokenUsed: number;
   submitted: boolean;
+  /** 최신 제출 ID (submissions.id) */
+  submissionId?: number | null;
+  /** QUEUED | RUNNING | DONE | FAILED */
+  submissionStatus?: string | null;
+  /** scores.total_score (없으면 null) */
+  totalScore?: number | null;
+  /** 제출 생성 시각 (ISO 문자열) */
+  submittedAt?: string | null;
+  /** 점수 행 기준 갱신 시각 (ISO 문자열) */
+  evaluatedAt?: string | null;
+}
+
+/**
+ * 관리자 보드 한 행의 제출·채점 상태를 한글 짧은 라벨로 변환합니다.
+ */
+export function formatBoardSubmissionLabelKo(entry: ExamineeBoardEntry): string {
+  if (!entry.submitted) {
+    return entry.state === "ENTRANCE" ? "진행 중" : "시작 안 함";
+  }
+  if (entry.submissionStatus === "FAILED") {
+    return "제출 실패";
+  }
+  if (entry.totalScore != null && entry.totalScore !== undefined) {
+    const n = Number(entry.totalScore);
+    if (!Number.isNaN(n)) {
+      return `채점 완료 (${n.toFixed(1)}점)`;
+    }
+  }
+  if (entry.submissionStatus === "DONE") {
+    return "채점 완료";
+  }
+  if (entry.submissionStatus === "RUNNING" || entry.submissionStatus === "QUEUED") {
+    return "제출·채점 중";
+  }
+  return "제출됨";
 }
 
 export interface AdminMetrics {

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -57,9 +57,7 @@ export interface ExamInfoResponse {
 }
 
 export interface SessionInfoResponse {
-  id: number;
-  examId: number;
-  participantId: number;
+  examParticipantId: number;
   tokenLimit: number;
   tokenUsed: number;
 }

--- a/lib/api/exams.ts
+++ b/lib/api/exams.ts
@@ -173,6 +173,8 @@ export interface ParticipantSessionResponse {
 export interface ActiveSessionResponse {
   examId: number;
   examParticipantId: number;
+  /** users.id */
+  participantId: number;
   assignedProblemId: number | null;
   specId: number | null;
   examState: ExamState;

--- a/lib/api/exams.ts
+++ b/lib/api/exams.ts
@@ -227,6 +227,43 @@ export async function getActiveSession(): Promise<ActiveSessionResponse | null> 
 }
 
 /**
+ * 특정 시험(examId) 기준 활성 시험 세션 조회
+ * GET /api/exams/{examId}/active-session
+ */
+export async function getActiveSessionByExam(examId: number): Promise<ActiveSessionResponse | null> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/exams/${examId}/active-session`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: getUserAuthHeaders(),
+    credentials: 'include',
+  });
+
+  let data: BaseResponse<ActiveSessionResponse>;
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error('활성 세션 응답을 파싱할 수 없습니다.');
+  }
+
+  if (!response.ok) {
+    if (response.status === 404 || data.code === 'EXAM404_5') {
+      return null;
+    }
+    const err: any = new Error(data.message || '활성 세션 조회에 실패했습니다.');
+    err.status = response.status;
+    throw err;
+  }
+
+  if (data.code !== 'COMMON200' || !data.result) {
+    return null;
+  }
+
+  return data.result;
+}
+
+/**
  * 현재 참가자의 세션 정보 조회 (대기→시험 전환 시 최신 tokenLimit 갱신용)
  * GET /api/exams/{examId}/participants/me
  */
@@ -265,8 +302,10 @@ export async function getAssignment(examId: number): Promise<AssignmentResponse>
 
   const data: BaseResponse<AssignmentResponse> = await response.json();
   if (!response.ok || data.code !== 'COMMON200' || !data.result) {
-    const err: any = new Error(data.message || '문제 조회에 실패했습니다.');
+    const err: any = new Error(data?.message || '문제 조회에 실패했습니다.');
     err.status = response.status;
+    err.code = data?.code;
+    err.apiMessage = data?.message;
     throw err;
   }
   return data.result;

--- a/lib/api/submissions.ts
+++ b/lib/api/submissions.ts
@@ -118,7 +118,7 @@ export async function getSubmission(submissionId: number): Promise<SubmissionDet
   return data.result;
 }
 
-// ─── SSE 채점 결과 스트리밍 (Admin 전용) ────────────────────────────────────────
+// ─── SSE 채점 결과 스트리밍 (응시자: 본인 제출만) ─────────────────────────────
 
 export interface CaseResultEvent {
   testCaseId: number;
@@ -155,8 +155,8 @@ export interface ScoringStreamCallbacks {
 }
 
 /**
- * 채점 결과 SSE 스트리밍 구독 (Admin/Master 전용)
- * GET /api/admin/submissions/{submissionId}/stream
+ * 채점 결과 SSE 스트리밍 구독 (로그인 응시자, 해당 submission 소유자만)
+ * GET /api/submissions/{submissionId}/stream
  *
  * EventSource는 Authorization 헤더 미지원 → fetch + ReadableStream 사용
  * 반환값: 구독을 취소하는 AbortController의 abort 함수
@@ -167,7 +167,7 @@ export function streamScoringResult(
 ): () => void {
   const controller = new AbortController();
   const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
-  const url = `${apiBaseUrl}/api/admin/submissions/${submissionId}/stream`;
+  const url = `${apiBaseUrl}/api/submissions/${submissionId}/stream`;
 
   async function connect() {
     try {

--- a/lib/api/submissions.ts
+++ b/lib/api/submissions.ts
@@ -1,12 +1,6 @@
-// Submission API 호출 함수들
+// Submission API 호출 함수들 (HttpOnly 쿠키 — lib/api/user-client.ts)
 
-function getApiBaseUrl(): string {
-  return process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
-}
-
-function getUserAuthHeaders(): HeadersInit {
-  return { 'Content-Type': 'application/json' };
-}
+import { USER_JSON_HEADERS, userApiFetch } from '@/lib/api/user-client';
 
 export interface BaseResponse<T> {
   timestamp: string;
@@ -72,13 +66,11 @@ export interface SubmissionDetailResponse {
  * HTTP 202 Accepted 반환 (비동기 채점)
  */
 export async function submitCode(examId: number, request: SubmitRequest): Promise<SubmitResponse> {
-  const url = `${getApiBaseUrl()}/api/exams/${examId}/submissions`;
-
-  const response = await fetch(url, {
+  const response = await userApiFetch(`/api/exams/${examId}/submissions`, {
     method: 'POST',
-    headers: getUserAuthHeaders(),
-    body: JSON.stringify(request),
     credentials: 'include',
+    headers: USER_JSON_HEADERS,
+    body: JSON.stringify(request),
   });
 
   // 202 Accepted도 성공으로 처리
@@ -101,12 +93,10 @@ export async function submitCode(examId: number, request: SubmitRequest): Promis
  * GET /api/submissions/{submissionId}
  */
 export async function getSubmission(submissionId: number): Promise<SubmissionDetailResponse> {
-  const url = `${getApiBaseUrl()}/api/submissions/${submissionId}`;
-
-  const response = await fetch(url, {
+  const response = await userApiFetch(`/api/submissions/${submissionId}`, {
     method: 'GET',
-    headers: getUserAuthHeaders(),
     credentials: 'include',
+    headers: USER_JSON_HEADERS,
   });
 
   const data: BaseResponse<SubmissionDetailResponse> = await response.json();
@@ -166,15 +156,13 @@ export function streamScoringResult(
   callbacks: ScoringStreamCallbacks
 ): () => void {
   const controller = new AbortController();
-  const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
-  const url = `${apiBaseUrl}/api/submissions/${submissionId}/stream`;
 
   async function connect() {
     try {
-      const response = await fetch(url, {
+      const response = await userApiFetch(`/api/submissions/${submissionId}/stream`, {
         method: 'GET',
-        headers: { Accept: 'text/event-stream' },
         credentials: 'include',
+        headers: { Accept: 'text/event-stream' },
         signal: controller.signal,
       });
 

--- a/lib/api/user-client.ts
+++ b/lib/api/user-client.ts
@@ -1,0 +1,36 @@
+/**
+ * 응시자(일반 사용자) API용 공통 fetch.
+ * HttpOnly Cookie 인증 — Authorization 헤더 대신 항상 credentials: "include" 로 쿠키 전송.
+ */
+
+export function getUserApiBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080';
+}
+
+export const USER_JSON_HEADERS: HeadersInit = {
+  'Content-Type': 'application/json',
+};
+
+function resolveUrl(pathOrAbsolute: string): string {
+  if (pathOrAbsolute.startsWith('http://') || pathOrAbsolute.startsWith('https://')) {
+    return pathOrAbsolute;
+  }
+  const base = getUserApiBaseUrl().replace(/\/$/, '');
+  const path = pathOrAbsolute.startsWith('/') ? pathOrAbsolute : `/${pathOrAbsolute}`;
+  return `${base}${path}`;
+}
+
+/**
+ * 사용자 세션 쿠키를 반드시 실어 보내는 fetch.
+ * 호출부에서 credentials 를 덮어써도 최종적으로 include 가 적용된다.
+ */
+export async function userApiFetch(pathOrAbsolute: string, init: RequestInit = {}): Promise<Response> {
+  if (typeof fetch === 'undefined') {
+    throw new Error('fetch is not available');
+  }
+  const url = resolveUrl(pathOrAbsolute);
+  return fetch(url, {
+    ...init,
+    credentials: 'include',
+  });
+}

--- a/lib/code-quality-metrics-labels.ts
+++ b/lib/code-quality-metrics-labels.ts
@@ -1,0 +1,83 @@
+/** 코드 품질 메트릭 화면 표시용 라벨 (값/계산 로직과 무관) */
+
+import { asNumber, asString, isRecord } from "@/lib/rubric-json"
+
+const CODE_QUALITY_METRIC_LABELS: Record<string, string> = {
+  "radon_cc.avg_cc": "평균 순환 복잡도",
+  "radon_cc.max_cc": "최대 순환 복잡도",
+  "radon_cc.junior_grade": "주니어 기준 초과 여부",
+  "reference_radon_cc.avg_cc": "기준 평균 순환 복잡도",
+  "reference_radon_cc.max_cc": "기준 최대 순환 복잡도",
+  "delta_cc_vs_reference.delta_cc_pct": "기준 대비 복잡도 증가율(%)",
+  "delta_cc_vs_reference.v1_avg_cc": "기준 평균 순환 복잡도",
+  "delta_cc_vs_reference.v2_avg_cc": "제출 평균 순환 복잡도",
+  "delta_cc_vs_reference.v1_max_cc": "기준 최대 순환 복잡도",
+  "delta_cc_vs_reference.v2_max_cc": "제출 최대 순환 복잡도",
+  "delta_cc.delta_cc_pct": "이전 코드 대비 복잡도 증가율(%)",
+  "delta_cc.v1_avg_cc": "이전 평균 순환 복잡도",
+  "delta_cc.v2_avg_cc": "현재 평균 순환 복잡도",
+  "delta_cc.v1_max_cc": "이전 최대 순환 복잡도",
+  "delta_cc.v2_max_cc": "현재 최대 순환 복잡도",
+  "v2_metrics.radon_cc.avg_cc": "현재 평균 순환 복잡도",
+  "v2_metrics.radon_cc.max_cc": "현재 최대 순환 복잡도",
+  has_v1: "이전 코드 존재 여부",
+  junior_grade: "주니어 기준 초과 여부",
+  ast_applicable: "AST 패턴 검사 적용 여부",
+  ast_pattern_matched: "AST 패턴 일치 여부",
+}
+
+export function formatCodeQualityMetricLabel(metricKey: string): string {
+  return CODE_QUALITY_METRIC_LABELS[metricKey] ?? metricKey
+}
+
+function formatFunctionComplexityRecord(record: Record<string, unknown>): string | null {
+  const name = asString(record.name) ?? asString(record.function)
+  const complexity = asNumber(record.complexity ?? record.cc)
+  if (name && complexity !== null) {
+    return `${name}: 복잡도 ${complexity}`
+  }
+  if (name) return name
+  return null
+}
+
+function parseFunctionComplexityLine(item: unknown): string | null {
+  if (item == null) return null
+
+  if (typeof item === "string") {
+    const trimmed = item.trim()
+    if (!trimmed) return null
+    if (trimmed.startsWith("{")) {
+      try {
+        const parsed: unknown = JSON.parse(trimmed)
+        if (isRecord(parsed)) return formatFunctionComplexityRecord(parsed)
+      } catch {
+        /* 원문 fallback */
+      }
+    }
+    return trimmed
+  }
+
+  if (isRecord(item)) {
+    return formatFunctionComplexityRecord(item)
+  }
+
+  return String(item)
+}
+
+/** functions 배열을 사람이 읽기 쉬운 줄 목록으로 변환 (중복 제거) */
+export function collectFunctionComplexityDisplayLines(...sources: unknown[]): string[] {
+  const seen = new Set<string>()
+  const lines: string[] = []
+
+  for (const source of sources) {
+    if (!Array.isArray(source)) continue
+    for (const item of source) {
+      const line = parseFunctionComplexityLine(item)
+      if (!line || seen.has(line)) continue
+      seen.add(line)
+      lines.push(line)
+    }
+  }
+
+  return lines
+}

--- a/lib/paths/admin-participant-evaluation.ts
+++ b/lib/paths/admin-participant-evaluation.ts
@@ -1,0 +1,34 @@
+/**
+ * 관리자 평가 결과 — 참가자 상세 화면 URL
+ * 라우트: app/admin/results/[entryCode]/[participantId]/page.tsx
+ *
+ * 첫 경로 세그먼트는 participant-list-content 의 findExamByResultsSegment 와 동일하게
+ * entryCode · 시험 제목 · 또는 숫자 exam id 를 사용할 수 있습니다.
+ */
+export type AdminParticipantEvaluationFrom = "results" | "analytics" | "master"
+
+export function adminParticipantEvaluationHref(opts: {
+  resultsSegment: string | number
+  participantId: string | number
+  from: AdminParticipantEvaluationFrom
+  participantName?: string
+  /** from === "master" 일 때 뒤로가기용 */
+  sessionId?: string | number
+}): string {
+  const seg = String(opts.resultsSegment).trim()
+  const pid = String(opts.participantId)
+  const path = `/admin/results/${encodeURIComponent(seg)}/${encodeURIComponent(pid)}`
+  const q = new URLSearchParams()
+  q.set("from", opts.from)
+  if (opts.participantName != null && String(opts.participantName).trim() !== "") {
+    q.set("participantName", String(opts.participantName).trim())
+  }
+  if (opts.from === "results") {
+    q.set("entryCode", seg)
+  }
+  if (opts.from === "master" && opts.sessionId != null && String(opts.sessionId) !== "") {
+    q.set("sessionId", String(opts.sessionId))
+  }
+  const qs = q.toString()
+  return qs ? `${path}?${qs}` : path
+}

--- a/lib/performance-level.ts
+++ b/lib/performance-level.ts
@@ -1,0 +1,43 @@
+/** 보드·상세 화면 공통 — 총점 기준 성과 수준 (80 / 50 구간) */
+export type BoardPerformanceLevel = "high" | "medium" | "low" | "unscored"
+
+export interface BoardPerformanceLevelDisplay {
+  level: BoardPerformanceLevel
+  label: string
+  badgeClass: string
+}
+
+const THRESHOLD_HIGH = 80
+const THRESHOLD_MEDIUM = 50
+
+export function resolveBoardPerformanceLevel(
+  totalScore: number | null | undefined
+): BoardPerformanceLevelDisplay {
+  if (totalScore === null || totalScore === undefined || Number.isNaN(Number(totalScore))) {
+    return {
+      level: "unscored",
+      label: "미채점",
+      badgeClass: "bg-[#F3F4F6] text-[#6B7280]",
+    }
+  }
+  const n = Number(totalScore)
+  if (n >= THRESHOLD_HIGH) {
+    return {
+      level: "high",
+      label: "높음",
+      badgeClass: "bg-[#DCFCE7] text-[#16A34A]",
+    }
+  }
+  if (n >= THRESHOLD_MEDIUM) {
+    return {
+      level: "medium",
+      label: "보통",
+      badgeClass: "bg-[#FEF3C7] text-[#D97706]",
+    }
+  }
+  return {
+    level: "low",
+    label: "낮음",
+    badgeClass: "bg-[#FEE2E2] text-[#DC2626]",
+  }
+}

--- a/lib/rubric-json.ts
+++ b/lib/rubric-json.ts
@@ -11,7 +11,13 @@ export function parseRubricJson(
 ): ParseRubricJsonResult | null {
   if (input == null) return null
   if (typeof input === "object" && !Array.isArray(input)) {
-    return { ok: true, data: input as RubricJsonRecord, raw: JSON.stringify(input, null, 2) }
+    let raw: string
+    try {
+      raw = JSON.stringify(input, null, 2)
+    } catch {
+      raw = String(input)
+    }
+    return { ok: true, data: input as RubricJsonRecord, raw }
   }
   const raw = String(input).trim()
   if (!raw) return null

--- a/lib/rubric-json.ts
+++ b/lib/rubric-json.ts
@@ -1,0 +1,219 @@
+/** scores.rubric_json 파싱·접근 유틸 (관리자 평가 리포트용) */
+
+export type RubricJsonRecord = Record<string, unknown>
+
+export type ParseRubricJsonResult =
+  | { ok: true; data: RubricJsonRecord; raw: string }
+  | { ok: false; raw: string; error?: string }
+
+export function parseRubricJson(
+  input: string | RubricJsonRecord | null | undefined
+): ParseRubricJsonResult | null {
+  if (input == null) return null
+  if (typeof input === "object" && !Array.isArray(input)) {
+    return { ok: true, data: input as RubricJsonRecord, raw: JSON.stringify(input, null, 2) }
+  }
+  const raw = String(input).trim()
+  if (!raw) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return { ok: true, data: parsed as RubricJsonRecord, raw }
+    }
+    return { ok: false, raw, error: "object가 아님" }
+  } catch (e) {
+    return { ok: false, raw, error: e instanceof Error ? e.message : "parse 실패" }
+  }
+}
+
+export function isRecord(v: unknown): v is RubricJsonRecord {
+  return v != null && typeof v === "object" && !Array.isArray(v)
+}
+
+export function hasPresentValue(v: unknown): boolean {
+  if (v === null || v === undefined) return false
+  if (typeof v === "string") return v.trim().length > 0
+  if (typeof v === "number") return !Number.isNaN(v)
+  if (Array.isArray(v)) return v.length > 0
+  if (isRecord(v)) return Object.keys(v).length > 0
+  return true
+}
+
+export function asNumber(v: unknown): number | null {
+  if (v === null || v === undefined || v === "") return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+export function asString(v: unknown): string | null {
+  if (v === null || v === undefined) return null
+  if (typeof v === "string") {
+    const t = v.trim()
+    return t.length > 0 ? t : null
+  }
+  if (typeof v === "number" || typeof v === "boolean") return String(v)
+  return null
+}
+
+export function asStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return []
+  return v
+    .map((item) => {
+      if (typeof item === "string") return item.trim()
+      if (item != null && typeof item === "object") return JSON.stringify(item)
+      return item != null ? String(item) : ""
+    })
+    .filter((s) => s.length > 0)
+}
+
+export function asRecordArray(v: unknown): RubricJsonRecord[] {
+  if (!Array.isArray(v)) return []
+  return v.filter(isRecord)
+}
+
+/** rubric 최상위 또는 중첩에서 숫자 점수 조회 */
+export function pickScore(data: RubricJsonRecord, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const n = asNumber(data[key])
+    if (n !== null) return n
+  }
+  return null
+}
+
+export function pickNestedNumber(obj: unknown, ...path: string[]): number | null {
+  let cur: unknown = obj
+  for (const key of path) {
+    if (!isRecord(cur)) return null
+    cur = cur[key]
+  }
+  return asNumber(cur)
+}
+
+export function pickNestedString(obj: unknown, ...path: string[]): string | null {
+  let cur: unknown = obj
+  for (const key of path) {
+    if (!isRecord(cur)) return null
+    cur = cur[key]
+  }
+  return asString(cur)
+}
+
+export interface HolisticAnalysisSection {
+  title: string
+  body: string
+}
+
+const HOLISTIC_SECTION_PATTERN =
+  /\[(합의 요약|종합 분석|점수 근거|R4 맥락 유지)\]/g
+
+export function splitHolisticFlowAnalysis(text: string): HolisticAnalysisSection[] {
+  const trimmed = text.trim()
+  if (!trimmed) return []
+
+  const markers: { index: number; title: string }[] = []
+  let match: RegExpExecArray | null
+  const re = new RegExp(HOLISTIC_SECTION_PATTERN.source, "g")
+  while ((match = re.exec(trimmed)) !== null) {
+    markers.push({ index: match.index, title: match[1] })
+  }
+
+  if (markers.length === 0) {
+    return [{ title: "종합 분석", body: trimmed }]
+  }
+
+  const sections: HolisticAnalysisSection[] = []
+  for (let i = 0; i < markers.length; i++) {
+    const start = markers[i].index
+    const headerEnd = start + markers[i].title.length + 2
+    const end = i + 1 < markers.length ? markers[i + 1].index : trimmed.length
+    const body = trimmed.slice(headerEnd, end).trim()
+    if (body) sections.push({ title: markers[i].title, body })
+  }
+  return sections
+}
+
+export function collectDebateEntries(data: RubricJsonRecord): RubricJsonRecord[] {
+  for (const key of ["debate_log", "debate_rebuttals", "debate_initial_opinions"] as const) {
+    const arr = asRecordArray(data[key])
+    if (arr.length > 0) return arr
+  }
+  return []
+}
+
+export function isVerdictDebateEntry(entry: RubricJsonRecord): boolean {
+  return asString(entry.agent)?.toLowerCase() === "verdict"
+}
+
+/** debate 항목의 라운드 번호 (데이터에 있는 값만, 1 이상 정수) */
+export function pickDebateRoundNumber(entry: RubricJsonRecord): number | null {
+  const raw = entry.round ?? entry.round_number ?? entry.roundNumber
+  const n = asNumber(raw)
+  if (n === null || n <= 0) return null
+  return Math.trunc(n)
+}
+
+export interface GroupedDebateEntries {
+  /** 데이터에 실제 존재하는 라운드 번호 (오름차순, 고정 개수 없음) */
+  roundNumbers: number[]
+  byRound: Map<number, RubricJsonRecord[]>
+  verdicts: RubricJsonRecord[]
+}
+
+export function groupDebateEntriesByRound(entries: RubricJsonRecord[]): GroupedDebateEntries {
+  const verdicts = entries.filter(isVerdictDebateEntry)
+  const opinions = entries.filter((e) => !isVerdictDebateEntry(e))
+  const byRound = new Map<number, RubricJsonRecord[]>()
+
+  for (const entry of opinions) {
+    const round = pickDebateRoundNumber(entry)
+    if (round === null) continue
+    const list = byRound.get(round) ?? []
+    list.push(entry)
+    byRound.set(round, list)
+  }
+
+  const roundNumbers = Array.from(byRound.keys()).sort((a, b) => a - b)
+
+  return { roundNumbers, byRound, verdicts }
+}
+
+export function rubricHasStructuredFields(data: RubricJsonRecord): boolean {
+  if (asString(data.grade)) return true
+  if (pickScore(data, "total_score", "totalScore") !== null) return true
+  if (pickScore(data, "prompt_score", "promptScore") !== null) return true
+  if (
+    pickScore(
+      data,
+      "correctness_score",
+      "code_correctness_score",
+      "performance_score",
+      "code_performance_score"
+    ) !== null
+  ) {
+    return true
+  }
+  if (pickScore(data, "holistic_flow_score") !== null) return true
+  if (isRecord(data.weights) && Object.keys(data.weights).length > 0) return true
+  if (asString(data.holistic_flow_analysis)) return true
+  if (isRecord(data.code_eval_report) || isRecord(data.codeEvalReport)) return true
+  if (collectDebateEntries(data).length > 0) return true
+  if (isRecord(data.turn_scores) || isRecord(data.turnScores)) return true
+  if (isRecord(data.code_quality_metrics) || isRecord(data.codeQualityMetrics)) return true
+  return false
+}
+
+export function formatWeightLabel(value: unknown, label: string): string | null {
+  const n = asNumber(value)
+  if (n === null) return null
+  const pct = n <= 1 ? n * 100 : n
+  return `${label}: ${pct.toFixed(0)}%`
+}
+
+export function formatRubricJsonPretty(data: RubricJsonRecord | string): string {
+  if (typeof data === "string") return data
+  try {
+    return JSON.stringify(data, null, 2)
+  } catch {
+    return String(data)
+  }
+}

--- a/lib/stores/exam-session-store.ts
+++ b/lib/stores/exam-session-store.ts
@@ -2,7 +2,10 @@ import { create } from "zustand";
 
 interface ExamSessionState {
   examId: number | null;
+  /** users.id — 채팅 STOMP·JWT·assignment/draft와 동일 */
   participantId: number | null;
+  /** exam_participants.id (PK) */
+  examParticipantId: number | null;
   tokenLimit: number;
   accessToken: string | null;
   setSession: (examId: number, participantId: number, tokenLimit?: number) => void;
@@ -13,10 +16,17 @@ interface ExamSessionState {
 export const useExamSessionStore = create<ExamSessionState>((set) => ({
   examId: null,
   participantId: null,
+  examParticipantId: null,
   tokenLimit: 20000,
   accessToken: null,
   setSession: (examId, participantId, tokenLimit = 20000) => set({ examId, participantId, tokenLimit }),
   setAccessToken: (token) => set({ accessToken: token }),
-  clearSession: () => set({ examId: null, participantId: null, tokenLimit: 20000, accessToken: null }),
+  clearSession: () =>
+    set({
+      examId: null,
+      participantId: null,
+      examParticipantId: null,
+      tokenLimit: 20000,
+      accessToken: null,
+    }),
 }));
-


### PR DESCRIPTION
## 작업 내용

### 관리자 참가자 평가 상세 화면 API 연동

기존 Mock 기반 관리자 평가 상세 화면을 실제 관리자 제출 상세 API 기반으로 전환했습니다.

연결 데이터:

* 참가자 정보
* examId / submissionId
* 제출 상태 / 평가 상태
* token 사용량
* prompt/perf/correctness 점수
* metrics
* tc group
* AI rubric / debate JSON 일부

이를 통해 실제 제출 데이터 기반 관리자 평가 흐름으로 전환했습니다.

---

### AI 피드백(루브릭/턴 평가) UI 개선

#### Accordion 구조 개선

* 모든 섹션 기본 닫힘 상태 적용
* 초기 진입 시 긴 평가 화면 가독성 개선

#### 평가관 토론 요약 구조 개선

기존:

* Strict / Advocate / Neutral 장문 전체 반복 출력

변경:

* Round 단위 그룹화
* 평가관 핵심 주장만 compact 표시
* Final Verdict는 상세 유지

#### 동적 Round 렌더링 처리

* Round 1/2 하드코딩 제거
* JSON의 round 값 기준 동적 렌더링
* Round N까지 자동 대응 가능하도록 개선

---

### 코드 품질 메트릭 UI 개선

기존 metric key(raw JSON 형태) 대신 사용자 친화적 label로 변경했습니다.

예시:

* 평균 순환 복잡도
* 최대 순환 복잡도
* 기준 대비 복잡도 증가율(%)

또한:

* 함수별 복잡도 표시 추가
* JSON dump 느낌 제거

---

### 참가자 평가 상세 레이아웃 정리

문제:

* 해당 페이지에만 추가 wrapper(py-6 px-8)가 존재하여
  헤더와 콘텐츠 시작 위치가 다른 관리자 페이지 대비 아래로 밀려 보였음

수정:

* 불필요한 wrapper 제거
* 관리자 페이지 공통 layout 구조로 통일
* 중첩 overflow 제거
* spacing/padding 정리

결과:

* 관리자 화면 간 vertical alignment 통일

---

### 관리자 결과/상세 조회 흐름 개선

관리자 결과 화면 및 참가자 상세 화면에서 실제 제출 데이터를 기반으로 상태 및 평가 결과를 조회할 수 있도록 흐름을 정리했습니다.

연동 범위:

* submissions row 기반 제출 상태 조회
* submissionId 연결
* 관리자 board/results 상태 반영
* 관리자 상세 API 기반 평가 결과 조회
* metrics/tc/score 데이터 연결

---

## 참고 사항

* 현재 AI 토론 데이터는 round 값 기준으로 FE에서 동적 렌더링 가능하도록 처리되어 있습니다.
* debate round 수 및 runs/tc 상세 데이터는 AI 파이프라인 연동 범위에서 추가 확장 가능합니다.
