### PR TITLE
관리자 분석 및 참가자 관리 UI 개선

### DIFF
--- a/components/analytics-content.tsx
+++ b/components/analytics-content.tsx
@@ -2,25 +2,30 @@
 
 import { useState, useMemo, useEffect } from "react"
 import Link from "next/link"
-import { Download, TrendingUp, TrendingDown, Minus, ChevronDown, X, CheckCircle } from "lucide-react"
-import { getExams, getBoard, Exam, ExamineeBoardEntry } from "@/lib/api/admin"
+import { Download, ChevronDown, X, CheckCircle } from "lucide-react"
+import {
+  getExams,
+  getBoard,
+  formatBoardSubmissionLabelKo,
+  type Exam,
+  type ExamineeBoardEntry,
+} from "@/lib/api/admin"
+import {
+  computeParticipantLetterGrade,
+  computeSessionAnalytics,
+  isExamineeBoardSubmitted,
+} from "@/lib/admin-board-analytics"
+import {
+  buildBoardParticipantsCsvBody,
+  downloadUtf8Csv,
+} from "@/lib/admin-board-csv-export"
 import { adminParticipantEvaluationHref } from "@/lib/paths/admin-participant-evaluation"
 
-type Trend = "높음" | "보통" | "낮음"
-type Status = "완료" | "진행 중"
-
-interface Participant {
-  id: string
-  name: string
-  entryCode: string
-  avgScore: number
-  status: Status
-  trend: Trend
-  sparklineData: number[]
-  testDate: Date
-  promptScore: number
-  performanceScore: number
-  correctnessScore: number
+interface BoardRow {
+  entry: ExamineeBoardEntry
+  examId: number
+  examTitle: string
+  examResultsSegment: string
 }
 
 interface Toast {
@@ -29,133 +34,76 @@ interface Toast {
   description: string
 }
 
-function mapBoardToParticipant(entry: ExamineeBoardEntry, examTitle: string): Participant {
-  const submitted = entry.submitted
-  // tokenUsed를 0~100 스케일로 정규화 (tokenLimit 기준)
-  const tokenRatio =
-    entry.tokenLimit > 0 ? Math.min(100, Math.round((entry.tokenUsed / entry.tokenLimit) * 100)) : 0
-
-  const total =
-    entry.totalScore != null && entry.totalScore !== undefined ? Number(entry.totalScore) : null
-  const avgScore = total != null && !Number.isNaN(total) ? total : 0
-
-  return {
-    id: entry.examParticipantId.toString(),
-    name: entry.name,
-    entryCode: examTitle,
-    avgScore,
-    status: submitted ? "완료" : "진행 중",
-    trend: "보통",
-    sparklineData: [0, tokenRatio], // 토큰 사용 추이
-    testDate: new Date(),
-    promptScore: 0,
-    performanceScore: 0,
-    correctnessScore: 0,
-  }
-}
-
-function Sparkline({ data, trend }: { data: number[]; trend: Trend }) {
-  const width = 100
-  const height = 32
-  const padding = 4
-
-  const min = Math.min(...data)
-  const max = Math.max(...data)
-  const range = max - min || 1
-
-  const points = data
-    .map((value, index) => {
-      const x = padding + (index / (data.length - 1)) * (width - padding * 2)
-      const y = height - padding - ((value - min) / range) * (height - padding * 2)
-      return `${x},${y}`
-    })
-    .join(" ")
-
-  const lineColor = trend === "높음" ? "#4AA785" : trend === "낮음" ? "#D6455D" : "#9CA3AF"
-
-  return (
-    <svg width={width} height={height} className="shrink-0">
-      <polyline
-        points={points}
-        fill="none"
-        stroke={lineColor}
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-}
-
-function TrendIcon({ trend }: { trend: Trend }) {
-  if (trend === "높음") {
-    return <TrendingUp className="h-4 w-4 text-[#4AA785]" strokeWidth={2} />
-  } else if (trend === "낮음") {
-    return <TrendingDown className="h-4 w-4 text-[#D6455D]" strokeWidth={2} />
-  }
-  return <Minus className="h-4 w-4 text-[#9CA3AF]" strokeWidth={2} />
-}
-
-function StatusBadge({ status }: { status: Status }) {
-  const styles = status === "완료" ? "bg-[#DCFCE7] text-[#16A34A]" : "bg-[#E0E7FF] text-[#6366F1]"
-  return <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${styles}`}>{status}</span>
-}
-
-function TrendBadge({ trend }: { trend: Trend }) {
-  const styles = {
-    "높음": "bg-[#DCFCE7] text-[#16A34A]",
-    "보통": "bg-[#F3F4F6] text-[#6B7280]",
-    "낮음": "bg-[#FEE2E2] text-[#DC2626]",
-  }
-  return <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${styles[trend]}`}>{trend}</span>
-}
-
-function MetricCard({ label, value, suffix }: { label: string; value: string; suffix?: string }) {
+function MetricCard({
+  label,
+  value,
+  suffix,
+  isLoading,
+}: {
+  label: string
+  value: string
+  suffix?: string
+  isLoading?: boolean
+}) {
+  const display = isLoading ? "–" : value
   return (
     <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
       <p className="text-sm text-[#6B7280]">{label}</p>
       <p className="mt-1 text-2xl font-semibold text-[#1A1A1A]">
-        {value}
-        {suffix && <span className="ml-1 text-base font-normal text-[#6B7280]">{suffix}</span>}
+        {display}
+        {suffix && !isLoading && (
+          <span className="ml-1 text-base font-normal text-[#6B7280]">{suffix}</span>
+        )}
       </p>
     </div>
   )
 }
 
-function ParticipantCard({ participant }: { participant: Participant }) {
+function ParticipantCard({ row }: { row: BoardRow }) {
+  const { entry, examTitle, examResultsSegment } = row
+  const grade = computeParticipantLetterGrade(entry)
+  const statusLabel = formatBoardSubmissionLabelKo(entry)
+
+  const gradeColor =
+    grade === "A"
+      ? "text-[#16A34A]"
+      : grade === "B"
+        ? "text-[#2563EB]"
+        : grade === "C"
+          ? "text-[#D97706]"
+          : grade === "D"
+            ? "text-[#EA580C]"
+            : grade === "F"
+              ? "text-[#DC2626]"
+              : "text-[#9CA3AF]"
+
   return (
     <div className="rounded-xl border border-[#E5E5E5] bg-white px-6 py-5 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md">
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
-          <h3 className="text-base font-semibold text-[#1A1A1A]">{participant.name}</h3>
-          <p className="mt-0.5 text-sm text-[#9CA3AF]">{participant.entryCode}</p>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <h3 className="text-base font-semibold text-[#1A1A1A]">{entry.name || "–"}</h3>
+          <p className="mt-0.5 text-sm text-[#9CA3AF]">{examTitle}</p>
         </div>
-        <div className="flex items-center gap-2">
-          <StatusBadge status={participant.status} />
-          <TrendBadge trend={participant.trend} />
+        <div className="flex shrink-0 flex-col items-center justify-center px-2">
+          <span className={`text-5xl font-bold leading-none tracking-tight ${gradeColor}`}>
+            {grade}
+          </span>
+          <span className="mt-1 text-xs font-medium text-[#9CA3AF]">등급</span>
         </div>
       </div>
 
-      <div className="mt-4 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div>
-            <p className="text-sm text-[#6B7280]">제출 상태</p>
-            <div className="flex items-center gap-2">
-              <span className="text-base font-bold text-[#1A1A1A]">{participant.status}</span>
-              <TrendIcon trend={participant.trend} />
-            </div>
-          </div>
-        </div>
-        <Sparkline data={participant.sparklineData} trend={participant.trend} />
+      <div className="mt-4">
+        <p className="text-sm text-[#6B7280]">제출 상태</p>
+        <p className="mt-0.5 text-base font-medium text-[#1A1A1A]">{statusLabel}</p>
       </div>
 
       <div className="mt-4 flex justify-end">
         <Link
           href={adminParticipantEvaluationHref({
-            resultsSegment: participant.entryCode,
-            participantId: participant.id,
+            resultsSegment: examResultsSegment,
+            participantId: String(entry.examParticipantId),
             from: "analytics",
-            participantName: participant.name,
+            participantName: entry.name,
           })}
           className="text-sm font-medium text-[#3B82F6] transition-colors hover:text-[#2563EB]"
         >
@@ -166,61 +114,121 @@ function ParticipantCard({ participant }: { participant: Participant }) {
   )
 }
 
+async function loadBoardRowsForExams(exams: Exam[]): Promise<BoardRow[]> {
+  const boards = await Promise.all(
+    exams.map(async (exam) => {
+      try {
+        const entries = await getBoard(exam.id)
+        return entries.map((entry) => ({
+          entry,
+          examId: exam.id,
+          examTitle: exam.title,
+          examResultsSegment: String(exam.id),
+        }))
+      } catch (e) {
+        console.error(`[Analytics] getBoard failed for examId=${exam.id}`, e)
+        return [] as BoardRow[]
+      }
+    })
+  )
+  return boards.flat()
+}
+
 export function AnalyticsContent() {
   const [exams, setExams] = useState<Exam[]>([])
-  const [participants, setParticipants] = useState<Participant[]>([])
+  const [boardRows, setBoardRows] = useState<BoardRow[]>([])
   const [isLoadingExams, setIsLoadingExams] = useState(true)
   const [isLoadingBoard, setIsLoadingBoard] = useState(false)
+  const [boardLoadError, setBoardLoadError] = useState(false)
   const [selectedExamId, setSelectedExamId] = useState<string>("all")
   const [toasts, setToasts] = useState<Toast[]>([])
 
-  // 시험 목록 로드
   useEffect(() => {
+    let cancelled = false
     async function loadExams() {
       try {
         const data = await getExams()
-        setExams(data)
+        if (!cancelled) setExams(data)
       } catch (e) {
-        console.error("Failed to load exams", e)
+        console.error("[Analytics] Failed to load exams", e)
+        if (!cancelled) setExams([])
       } finally {
-        setIsLoadingExams(false)
+        if (!cancelled) setIsLoadingExams(false)
       }
     }
     loadExams()
+    return () => {
+      cancelled = true
+    }
   }, [])
 
-  // 선택된 시험 보드 로드
   useEffect(() => {
+    if (isLoadingExams) return
+
+    let cancelled = false
+
     async function loadBoard() {
-      if (isLoadingExams) return
       setIsLoadingBoard(true)
+      setBoardLoadError(false)
       try {
         if (selectedExamId === "all") {
-          // 모든 시험의 보드를 병렬 조회
-          const boards = await Promise.all(
-            exams.map((e) =>
-              getBoard(e.id)
-                .then((entries) => entries.map((p) => mapBoardToParticipant(p, e.title)))
-                .catch(() => [] as Participant[])
-            )
+          if (exams.length === 0) {
+            if (!cancelled) setBoardRows([])
+            return
+          }
+          const rows = await loadBoardRowsForExams(exams)
+          if (!cancelled) setBoardRows(rows)
+          return
+        }
+
+        const examId = Number.parseInt(selectedExamId, 10)
+        if (Number.isNaN(examId)) {
+          if (!cancelled) setBoardRows([])
+          return
+        }
+
+        const exam = exams.find((e) => e.id === examId)
+        const board = await getBoard(examId)
+        if (!cancelled) {
+          setBoardRows(
+            board.map((entry) => ({
+              entry,
+              examId,
+              examTitle: exam?.title ?? String(examId),
+              examResultsSegment: String(examId),
+            }))
           )
-          setParticipants(boards.flat())
-        } else {
-          const examId = parseInt(selectedExamId, 10)
-          const exam = exams.find((e) => e.id === examId)
-          const board = await getBoard(examId)
-          setParticipants(board.map((p) => mapBoardToParticipant(p, exam?.title ?? selectedExamId)))
         }
       } catch (e) {
-        console.error("Failed to load board", e)
-        setParticipants([])
+        console.error("[Analytics] Failed to load board", e)
+        if (!cancelled) {
+          setBoardRows([])
+          setBoardLoadError(true)
+        }
       } finally {
-        setIsLoadingBoard(false)
+        if (!cancelled) setIsLoadingBoard(false)
       }
     }
+
     loadBoard()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedExamId, isLoadingExams])
+    return () => {
+      cancelled = true
+    }
+  }, [selectedExamId, isLoadingExams, exams])
+
+  const entries = useMemo(() => boardRows.map((r) => r.entry), [boardRows])
+
+  const analytics = useMemo(() => computeSessionAnalytics(entries), [entries])
+
+  const submittedRows = useMemo(
+    () => boardRows.filter((r) => isExamineeBoardSubmitted(r.entry)),
+    [boardRows]
+  )
+
+  const inProgressRows = useMemo(
+    () => boardRows.filter((r) => !isExamineeBoardSubmitted(r.entry)),
+    [boardRows]
+  )
 
   const showToast = (title: string, description: string) => {
     const id = crypto.randomUUID()
@@ -235,29 +243,14 @@ export function AnalyticsContent() {
   }
 
   const handleExport = () => {
-    const csvContent =
-      "이름,시험,제출상태\n" +
-      participants.map((p) => `${p.name},${p.entryCode},${p.status}`).join("\n")
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement("a")
-    link.href = url
-    link.download = "analytics-results.csv"
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    URL.revokeObjectURL(url)
-    showToast("내보내기 시작", "통계 분석 결과가 CSV 파일로 다운로드되고 있습니다.")
+    const csvBody = buildBoardParticipantsCsvBody(
+      boardRows.map((r) => ({ entry: r.entry, examLabel: r.examTitle }))
+    )
+    downloadUtf8Csv("analytics-results.csv", csvBody)
+    showToast("보내기 시작", "통계 분석 결과가 CSV 파일로 다운로드되고 있습니다.")
   }
 
-  const completedParticipants = useMemo(
-    () => participants.filter((p) => p.status === "완료"),
-    [participants]
-  )
-  const inProgressParticipants = useMemo(
-    () => participants.filter((p) => p.status === "진행 중"),
-    [participants]
-  )
+  const metricsLoading = isLoadingExams || isLoadingBoard
 
   return (
     <div className="flex h-full flex-1 flex-col">
@@ -265,7 +258,7 @@ export function AnalyticsContent() {
         <div>
           <h1 className="text-2xl font-semibold text-[#1A1A1A]">통계 분석</h1>
           <p className="text-sm text-[#6B7280]">
-            모든 시험 세션의 참가자 현황 및 제출 상태를 시각화합니다.
+            선택한 시험 세션의 참가자 현황·채점 점수를 집계합니다.
           </p>
         </div>
       </header>
@@ -292,61 +285,81 @@ export function AnalyticsContent() {
           </div>
 
           <button
+            type="button"
             onClick={handleExport}
-            className="inline-flex items-center gap-2 rounded-lg bg-[#3B82F6] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#2563EB]"
+            disabled={metricsLoading || boardRows.length === 0}
+            className="inline-flex items-center gap-2 rounded-lg bg-[#3B82F6] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#2563EB] disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Download className="h-4 w-4" strokeWidth={2} />
-            결과 내보내기 (CSV)
+            결과보내기 (CSV)
           </button>
         </div>
 
-        {/* 메트릭 카드 — 점수는 채점 완료 후 집계됨 */}
         <div className="mb-6 grid grid-cols-4 gap-4">
-          <MetricCard label="프롬프트 점수" value="–" />
-          <MetricCard label="성능 점수" value="–" />
-          <MetricCard label="정답률 점수" value="–" />
-          <MetricCard label="누적 사용자 수" value={isLoadingBoard ? "..." : participants.length.toString()} />
+          <MetricCard label="평균 프롬프트 점수" value={analytics.avgPrompt} isLoading={metricsLoading} />
+          <MetricCard label="평균 성능 점수" value={analytics.avgPerformance} isLoading={metricsLoading} />
+          <MetricCard label="평균 정답률 점수" value={analytics.avgCorrectness} isLoading={metricsLoading} />
+          <MetricCard
+            label="누적 사용자 수"
+            value={String(analytics.cumulativeUsers)}
+            suffix="명"
+            isLoading={metricsLoading}
+          />
         </div>
 
-        {/* 점수 미집계 안내 */}
+        {boardLoadError && (
+          <div className="mb-6 rounded-lg border border-[#FECACA] bg-[#FEF2F2] px-4 py-3">
+            <p className="text-sm text-[#B91C1C]">
+              참가자 데이터를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+            </p>
+          </div>
+        )}
+
         <div className="mb-6 rounded-lg border border-[#E5E5E5] bg-[#F9FAFB] px-4 py-3">
           <p className="text-sm text-[#6B7280]">
-            평가 점수는 채점 완료 후 집계됩니다. 현재는 참가자 현황 및 제출 상태를 기준으로 표시합니다.
+            평균 점수는 채점이 완료된 참가자만 집계합니다. 채점 전이거나 점수가 없으면 &quot;–&quot;로
+            표시됩니다. 등급(A~F)은 종합 점수(또는 항목 점수 평균)를 100점 만점 기준으로 산정합니다.
           </p>
         </div>
 
-        {isLoadingBoard ? (
+        {metricsLoading ? (
           <div className="flex flex-col items-center justify-center rounded-xl border border-[#E5E5E5] bg-white py-16">
             <p className="text-lg font-medium text-[#6B7280]">불러오는 중...</p>
           </div>
-        ) : participants.length === 0 ? (
+        ) : boardRows.length === 0 ? (
           <div className="flex flex-col items-center justify-center rounded-xl border border-[#E5E5E5] bg-white py-16">
             <p className="text-lg font-medium text-[#6B7280]">조회된 참가자가 없습니다</p>
             <p className="mt-1 text-sm text-[#9CA3AF]">시험 세션을 선택하거나 참가자를 확인해보세요.</p>
           </div>
         ) : (
           <>
-            {completedParticipants.length > 0 && (
+            {submittedRows.length > 0 && (
               <div className="mb-8">
                 <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-[#6B7280]">
-                  제출 완료 ({completedParticipants.length}명)
+                  제출 완료 ({submittedRows.length}명)
                 </h2>
                 <div className="grid grid-cols-2 gap-6">
-                  {completedParticipants.map((participant) => (
-                    <ParticipantCard key={participant.id} participant={participant} />
+                  {submittedRows.map((row) => (
+                    <ParticipantCard
+                      key={`${row.examId}-${row.entry.examParticipantId}`}
+                      row={row}
+                    />
                   ))}
                 </div>
               </div>
             )}
 
-            {inProgressParticipants.length > 0 && (
+            {inProgressRows.length > 0 && (
               <div className="mb-8">
                 <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-[#6B7280]">
-                  진행 중 ({inProgressParticipants.length}명)
+                  진행 중 ({inProgressRows.length}명)
                 </h2>
                 <div className="grid grid-cols-2 gap-6">
-                  {inProgressParticipants.map((participant) => (
-                    <ParticipantCard key={participant.id} participant={participant} />
+                  {inProgressRows.map((row) => (
+                    <ParticipantCard
+                      key={`${row.examId}-${row.entry.examParticipantId}`}
+                      row={row}
+                    />
                   ))}
                 </div>
               </div>
@@ -369,6 +382,7 @@ export function AnalyticsContent() {
               <p className="mt-0.5 text-xs text-[#6B7280]">{toast.description}</p>
             </div>
             <button
+              type="button"
               onClick={() => removeToast(toast.id)}
               className="shrink-0 rounded p-0.5 text-[#9CA3AF] transition-colors hover:bg-[#F3F4F6] hover:text-[#6B7280]"
             >

--- a/components/dashboard-content.tsx
+++ b/components/dashboard-content.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import Link from "next/link"
 import { Users, CheckCircle, Play, Plus, BarChart3, ArrowRight } from "lucide-react"
 import { getExams, getBoard } from "@/lib/api/admin"
+import { computeSessionAnalytics } from "@/lib/admin-board-analytics"
 
 // Sample recent activity data (정적 - 활동 로그 API 미지원)
 const recentActivity = [
@@ -48,6 +49,7 @@ export function DashboardContent() {
   const [totalParticipants, setTotalParticipants] = useState<number | null>(null)
   const [completedCount, setCompletedCount] = useState<number | null>(null)
   const [runningExams, setRunningExams] = useState<number | null>(null)
+  const [avgPromptScore, setAvgPromptScore] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
@@ -66,8 +68,10 @@ export function DashboardContent() {
         const allParticipants = boards.flat()
         setTotalParticipants(allParticipants.length)
         setCompletedCount(allParticipants.filter((p) => p.submitted).length)
+        setAvgPromptScore(computeSessionAnalytics(allParticipants).avgPrompt)
       } catch (e) {
         console.error("Failed to load dashboard stats", e)
+        setAvgPromptScore(null)
       } finally {
         setIsLoading(false)
       }
@@ -77,6 +81,8 @@ export function DashboardContent() {
 
   const displayValue = (val: number | null) =>
     isLoading ? "..." : val !== null ? val.toLocaleString() : "–"
+
+  const displayAvgPromptScore = isLoading ? "–" : (avgPromptScore ?? "–")
 
   return (
     <div className="flex h-full flex-1 flex-col">
@@ -117,7 +123,7 @@ export function DashboardContent() {
             </p>
           </div>
 
-          {/* Average Prompt Score - no API available */}
+          {/* Average Prompt Score */}
           <div className="flex flex-col rounded-xl border border-[#E5E5E5] bg-white px-6 py-8 shadow-sm">
             <div className="flex items-center gap-3">
               <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-50">
@@ -125,8 +131,8 @@ export function DashboardContent() {
               </div>
               <span className="text-sm font-medium text-gray-500">평균 프롬프트 점수</span>
             </div>
-            <p className="mt-6 text-4xl font-bold text-gray-900">–</p>
-            <p className="mt-1 text-xs text-gray-400">채점 완료 후 집계</p>
+            <p className="mt-6 text-4xl font-bold text-gray-900">{displayAvgPromptScore}</p>
+            <p className="mt-1 text-xs text-gray-400">채점 완료 후 집계 (전체 세션)</p>
           </div>
 
           {/* Active Test Sessions */}

--- a/components/participant-evaluation-content.tsx
+++ b/components/participant-evaluation-content.tsx
@@ -13,6 +13,11 @@ import {
   type ExamineeBoardEntry,
   type AdminSubmissionDetailResponse,
 } from "@/lib/api/admin"
+import {
+  buildKeyValueCsvBody,
+  buildParticipantEvaluationCsvFilename,
+  downloadUtf8Csv,
+} from "@/lib/admin-board-csv-export"
 import { resolveBoardPerformanceLevel } from "@/lib/performance-level"
 import { ParticipantEvaluationTestSummary } from "@/components/participant-evaluation-test-summary"
 import { ParticipantEvaluationRubricReport } from "@/components/participant-evaluation-rubric-report"
@@ -65,11 +70,6 @@ function LanguageBadge({ language }: { language: string }) {
 function formatScore(n: number | null | undefined): string {
   if (n === null || n === undefined || Number.isNaN(Number(n))) return "–"
   return `${Number(n).toFixed(1)}`
-}
-
-const escapeCsv = (value: unknown) => {
-  const str = String(value ?? "")
-  return `"${str.replace(/"/g, '""')}"`
 }
 
 export function ParticipantEvaluationContent({
@@ -208,32 +208,49 @@ export function ParticipantEvaluationContent({
   }
 
   const handleExport = () => {
-    const header = "Field,Value"
-    const rows = [
-      `Name,${escapeCsv(displayName)}`,
-      `EntryCodeSegment,${escapeCsv(entryCode)}`,
-      `ExamParticipantId,${escapeCsv(participantId)}`,
-      `ExamId,${escapeCsv(examId ?? "")}`,
-      `SubmissionId,${escapeCsv(submissionId ?? "")}`,
-      `HasSubmissionCode,${escapeCsv(submissionDetail?.codeInline?.trim() ? "yes" : "no")}`,
-      `HasRubricJson,${escapeCsv(submissionDetail?.rubricJson?.trim() ? "yes" : "no")}`,
-      `BoardStatus,${escapeCsv(submissionStatusLabel ?? "")}`,
-      `PromptScore,${escapeCsv(scoreFromDetail?.prompt ?? "")}`,
-      `PerfScore,${escapeCsv(scoreFromDetail?.perf ?? "")}`,
-      `CorrectnessScore,${escapeCsv(scoreFromDetail?.correctness ?? "")}`,
-      `TotalScore,${escapeCsv(scoreFromDetail?.total ?? boardEntry?.totalScore ?? "")}`,
-    ]
-    const csvContent = [header, ...rows].join("\n")
-    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement("a")
-    link.href = url
-    link.download = "participant-evaluation.csv"
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    URL.revokeObjectURL(url)
-    showToast("보내기 완료", "participant-evaluation.csv")
+    try {
+      const examLabel = entryCode.trim() || "session"
+      const csvBody = buildKeyValueCsvBody([
+        { label: "이름", value: displayName },
+        { label: "시험", value: examLabel, excelTextValue: true },
+        { label: "제출 상태", value: submissionStatusLabel ?? "–" },
+        {
+          label: "총점",
+          value: effectiveTotalScore != null ? formatScore(effectiveTotalScore) : "–",
+        },
+        {
+          label: "프롬프트 점수",
+          value: detailScoresMeaningful ? formatScore(scoreFromDetail?.prompt ?? null) : "–",
+        },
+        {
+          label: "성능 점수",
+          value: detailScoresMeaningful ? formatScore(scoreFromDetail?.perf ?? null) : "–",
+        },
+        {
+          label: "정답률 점수",
+          value: detailScoresMeaningful ? formatScore(scoreFromDetail?.correctness ?? null) : "–",
+        },
+        {
+          label: "코드 LOC",
+          value:
+            submissionDetail?.metrics?.loc != null
+              ? String(submissionDetail.metrics.loc)
+              : "–",
+        },
+        { label: "제출 언어", value: submissionDetail?.lang ?? "–" },
+        { label: "참가자 ID", value: participantId },
+        ...(submissionId != null
+          ? [{ label: "제출 ID", value: String(submissionId) }]
+          : []),
+      ])
+
+      const filename = buildParticipantEvaluationCsvFilename(examLabel, displayName)
+      downloadUtf8Csv(filename, csvBody)
+      showToast("보내기 완료", filename)
+    } catch (e) {
+      console.error("[ParticipantEvaluation] CSV export failed", e)
+      showToast("보내기 실패", "CSV 파일을 생성하지 못했습니다.")
+    }
   }
 
   const handleBackClick = (e: MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {
@@ -255,7 +272,7 @@ export function ParticipantEvaluationContent({
         </div>
       </header>
 
-      <div className="flex min-h-0 flex-1 flex-col p-6">
+      <div className="flex min-h-0 flex-1 flex-col px-6 pt-6 pb-12">
         <div className="mb-4 shrink-0">
           <button
             type="button"
@@ -450,7 +467,7 @@ export function ParticipantEvaluationContent({
             detail={submissionDetail}
             boardStatusLabel={submissionStatusLabel}
           />
-          <div className="mt-6 flex justify-end">
+          <div className="mt-6 flex justify-end pb-4">
             <button
               type="button"
               onClick={handleExport}

--- a/components/participant-evaluation-rubric-report.tsx
+++ b/components/participant-evaluation-rubric-report.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useMemo, useState } from "react"
+import { cleanupAiFeedbackText } from "@/lib/utils/cleanup-ai-feedback"
 import type { ReactNode } from "react"
 import { ChevronDown, ChevronRight, Info } from "lucide-react"
 import {
@@ -87,8 +88,11 @@ function MetricCell({
 }
 
 function TextBlock({ text }: { text: string }) {
+  const displayText = useMemo(() => cleanupAiFeedbackText(text), [text])
   return (
-    <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-[#374151]">{text}</p>
+    <p className="whitespace-pre-wrap break-words text-sm leading-relaxed text-[#374151]">
+      {displayText}
+    </p>
   )
 }
 
@@ -183,10 +187,11 @@ const R4_CONTEXT_SECTION_TITLE = "R4 맥락 유지"
 const R4_CONTEXT_SECTION_HINT = "대화 흐름과 문맥 유지 능력 평가"
 
 function HolisticSubsectionTitle({ title }: { title: string }) {
-  const showHint = title === R4_CONTEXT_SECTION_TITLE
+  const displayTitle = useMemo(() => cleanupAiFeedbackText(title), [title])
+  const showHint = displayTitle === R4_CONTEXT_SECTION_TITLE
   return (
     <div className="mb-2 flex items-center gap-1">
-      <p className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">{title}</p>
+      <p className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">{displayTitle}</p>
       {showHint && (
         <span
           className="inline-flex shrink-0 text-[#9CA3AF]"
@@ -304,7 +309,9 @@ function DebateRoundCompactRow({ entry }: { entry: RubricJsonRecord }) {
       </div>
       <div className="min-w-0 flex-1 rounded-md border border-[#FDE68A] bg-[#FFFBEB] px-3 py-2">
         {summary ? (
-          <p className="whitespace-pre-wrap break-words text-sm leading-snug text-[#78350F]">{summary}</p>
+          <p className="whitespace-pre-wrap break-words text-sm leading-snug text-[#78350F]">
+            {cleanupAiFeedbackText(summary)}
+          </p>
         ) : (
           <p className="text-sm text-[#9CA3AF]">제공되지 않음</p>
         )}
@@ -371,7 +378,7 @@ function DebateVerdictCard({ entry }: { entry: RubricJsonRecord }) {
           <ul className="list-inside list-disc space-y-1 text-sm text-[#374151]">
             {keyPoints.map((p, i) => (
               <li key={i} className="whitespace-pre-wrap break-words">
-                {p}
+                {cleanupAiFeedbackText(p)}
               </li>
             ))}
           </ul>
@@ -448,7 +455,9 @@ function TurnScoresSection({ data }: { data: RubricJsonRecord }) {
         const ts = asNumber(val.turn_score ?? val.turnScore ?? val.score)
         const parts: string[] = []
         if (hasPresentValue(val.intent)) parts.push(`intent: ${asString(val.intent)}`)
-        if (hasPresentValue(val.feedback)) parts.push(asString(val.feedback) ?? "")
+        if (hasPresentValue(val.feedback)) {
+          parts.push(cleanupAiFeedbackText(asString(val.feedback) ?? ""))
+        }
         rows.push({
           turn,
           score: ts !== null ? formatScoreDisplay(ts) : "–",

--- a/components/results-content.tsx
+++ b/components/results-content.tsx
@@ -2,8 +2,13 @@
 
 import { useState, useEffect } from "react"
 import Link from "next/link"
-import { Search, Download, Eye, X, CheckCircle, ChevronLeft, ChevronRight } from "lucide-react"
-import { getExams, type Exam } from "@/lib/api/admin"
+import { Search, Download, Eye, X, CheckCircle, ChevronLeft, ChevronRight, Loader2 } from "lucide-react"
+import { getExams, getBoard, type Exam } from "@/lib/api/admin"
+import {
+  buildBoardParticipantsCsvBody,
+  downloadUtf8Csv,
+  sanitizeCsvFilenameSegment,
+} from "@/lib/admin-board-csv-export"
 
 interface ResultEntry {
   id: string
@@ -23,6 +28,7 @@ export function ResultsContent() {
   const [isLoading, setIsLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState("")
   const [toasts, setToasts] = useState<Toast[]>([])
+  const [downloadingExamId, setDownloadingExamId] = useState<string | null>(null)
   const [currentPage, setCurrentPage] = useState(1)
   const pageSize = 10
 
@@ -61,11 +67,32 @@ export function ResultsContent() {
     setToasts((prev) => prev.filter((t) => t.id !== id))
   }
 
-  const handleDownload = (entryCode: string) => {
-    showToast(
-      "CSV 다운로드 준비 중",
-      "현재 해당 기능을 서버에서 준비 중입니다. 조만간 업데이트될 예정입니다.",
-    )
+  const handleDownload = async (result: ResultEntry) => {
+    const examId = Number.parseInt(result.id, 10)
+    if (Number.isNaN(examId)) {
+      showToast("다운로드 실패", "유효하지 않은 시험 ID입니다.")
+      return
+    }
+
+    setDownloadingExamId(result.id)
+    try {
+      const board = await getBoard(examId)
+      const csvBody = buildBoardParticipantsCsvBody(
+        board.map((entry) => ({ entry, examLabel: result.entryCode })),
+        { includeScores: true }
+      )
+      const filename = `results-${sanitizeCsvFilenameSegment(result.entryCode)}.csv`
+      downloadUtf8Csv(filename, csvBody)
+      showToast("다운로드 완료", `${result.entryCode} 세션 결과가 CSV로 저장되었습니다.`)
+    } catch (error) {
+      console.error(`[Results] CSV download failed for examId=${examId}`, error)
+      showToast(
+        "다운로드 실패",
+        "참가자 결과를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요."
+      )
+    } finally {
+      setDownloadingExamId(null)
+    }
   }
 
   const filteredResults = results.filter((result) => result.entryCode.toLowerCase().includes(searchQuery.toLowerCase()))
@@ -211,15 +238,21 @@ export function ResultsContent() {
               {/* Right Side - Action Buttons */}
               <div className="flex items-center gap-3">
                 <button
-                  onClick={() => handleDownload(result.entryCode)}
-                  className="flex items-center gap-2 px-4 py-2 rounded-lg bg-[#3B82F6] text-white hover:bg-[#2563EB] transition-colors"
+                  type="button"
+                  onClick={() => handleDownload(result)}
+                  disabled={downloadingExamId === result.id}
+                  className="flex items-center gap-2 rounded-lg bg-[#3B82F6] px-4 py-2 text-white transition-colors hover:bg-[#2563EB] disabled:cursor-not-allowed disabled:opacity-60"
                   style={{
                     fontSize: "14px",
                     fontWeight: 500,
                   }}
                 >
-                  <Download size={18} />
-                  <span>다운로드</span>
+                  {downloadingExamId === result.id ? (
+                    <Loader2 size={18} className="animate-spin" />
+                  ) : (
+                    <Download size={18} />
+                  )}
+                  <span>{downloadingExamId === result.id ? "다운로드 중…" : "다운로드"}</span>
                 </button>
                 <Link
                   href={`/admin/results/${encodeURIComponent(result.entryCode)}`}

--- a/components/server-status-content.tsx
+++ b/components/server-status-content.tsx
@@ -1,85 +1,124 @@
 "use client"
 
-import { Server, Database, Cpu, Wifi, Activity, HardDrive, Users } from "lucide-react"
+import { useEffect, useState } from "react"
+import { Server, Database, Cpu, type LucideIcon } from "lucide-react"
+import { getSystemStatus, type SystemStatusServiceItem } from "@/lib/api/admin"
 
-const servicesData = [
-  { id: 1, name: "API 서버", icon: Server, latency: "45ms", status: "정상 운영 중" },
-  { id: 2, name: "데이터베이스", icon: Database, latency: "12ms", status: "정상 운영 중" },
-  { id: 3, name: "AI 게이트웨이", icon: Cpu, latency: "230ms", status: "정상 운영 중" },
-  { id: 4, name: "웹소켓", icon: Wifi, latency: "8ms", status: "정상 운영 중" },
+const SERVICE_ICONS: Record<string, LucideIcon> = {
+  api: Server,
+  database: Database,
+  ai: Cpu,
+}
+
+const FALLBACK_SERVICES: SystemStatusServiceItem[] = [
+  { key: "api", name: "API 서버", status: "DOWN", latencyMs: null },
+  { key: "database", name: "데이터베이스", status: "DOWN", latencyMs: null },
+  { key: "ai", name: "AI 게이트웨이", status: "DOWN", latencyMs: null },
 ]
 
-const metricsData = [
-  { id: 1, label: "CPU 사용량", value: "34%", icon: Activity },
-  { id: 2, label: "메모리 사용량", value: "2.4 GB / 8 GB", icon: HardDrive },
-  { id: 3, label: "활성화된 연결 수", value: "4", icon: Users },
-]
+function formatLatency(latencyMs: number | null | undefined, isLoading: boolean): string {
+  if (isLoading) return "–"
+  if (latencyMs === null || latencyMs === undefined || Number.isNaN(Number(latencyMs))) {
+    return "–"
+  }
+  return `${Math.round(Number(latencyMs))}ms`
+}
+
+function formatStatusLabel(status: string | undefined, isLoading: boolean): string {
+  if (isLoading) return "–"
+  if (status === "UP") return "정상 운영 중"
+  return "점검 필요"
+}
+
+function statusBadgeClass(status: string | undefined, isLoading: boolean): string {
+  if (isLoading) {
+    return "px-3 py-1 text-xs font-medium text-[#6B7280] bg-[#F3F4F6] border border-[#E5E7EB] rounded-full"
+  }
+  if (status === "UP") {
+    return "px-3 py-1 text-xs font-medium text-[#059669] bg-[#ECFDF5] border border-[#A7F3D0] rounded-full"
+  }
+  return "px-3 py-1 text-xs font-medium text-[#B91C1C] bg-[#FEF2F2] border border-[#FECACA] rounded-full"
+}
 
 export function ServerStatusContent() {
+  const [services, setServices] = useState<SystemStatusServiceItem[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      setIsLoading(true)
+      setLoadError(false)
+      try {
+        const data = await getSystemStatus()
+        if (!cancelled) {
+          setServices(data.services?.length ? data.services : FALLBACK_SERVICES)
+        }
+      } catch (e) {
+        console.error("[ServerStatus] Failed to load system status", e)
+        if (!cancelled) {
+          setLoadError(true)
+          setServices(FALLBACK_SERVICES)
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const displayServices = services.length > 0 ? services : FALLBACK_SERVICES
+
   return (
-    <div className="flex flex-col h-full">
-      {/* Header Section */}
-      <div className="shrink-0 px-8 py-6 border-b border-[#E5E5E5] bg-white">
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 border-b border-[#E5E5E5] bg-white px-8 py-6">
         <h1 className="text-2xl font-semibold text-[#111111]">서버 상태</h1>
-        <p className="text-sm text-[#6B7280] mt-1">시스템 상태 및 성능</p>
+        <p className="mt-1 text-sm text-[#6B7280]">핵심 서비스 연결 상태</p>
       </div>
 
-      {/* Main Content Section */}
-      <div className="flex-1 p-8 overflow-y-auto">
-        <div className="bg-white border border-[#E5E5E5] rounded-xl px-12 py-6">
-          {/* Services Section */}
-          <div className="mb-8">
-            <h2 className="text-sm font-medium text-[#6B7280] uppercase tracking-wide mb-4">서비스</h2>
-            <div className="flex flex-col gap-3">
-              {servicesData.map((service) => {
-                const IconComponent = service.icon
-                return (
-                  <div
-                    key={service.id}
-                    className="flex items-center justify-between px-5 py-4 bg-white border border-[#E5E5E5] rounded-lg"
-                  >
-                    {/* Left: Icon + Name */}
-                    <div className="flex items-center gap-3">
-                      <IconComponent className="w-5 h-5 text-[#6B7280]" strokeWidth={1.5} />
-                      <span className="text-sm font-medium text-[#111111]">{service.name}</span>
-                    </div>
+      <div className="flex-1 overflow-y-auto p-8">
+        <div className="rounded-xl border border-[#E5E5E5] bg-white px-8 py-6 md:px-12">
+          {loadError && (
+            <div className="mb-4 rounded-lg border border-[#FECACA] bg-[#FEF2F2] px-4 py-3">
+              <p className="text-sm text-[#B91C1C]">
+                시스템 상태를 불러오지 못했습니다. 아래는 기본 표시입니다.
+              </p>
+            </div>
+          )}
 
-                    {/* Right: Latency + Status */}
-                    <div className="flex items-center gap-6">
-                      <span className="text-sm text-[#6B7280]">{service.latency}</span>
-                      <span className="px-3 py-1 text-xs font-medium text-[#059669] bg-[#ECFDF5] border border-[#A7F3D0] rounded-full">
-                        {service.status}
+          <h2 className="mb-4 text-sm font-medium uppercase tracking-wide text-[#6B7280]">서비스</h2>
+          <div className="flex flex-col gap-3">
+            {displayServices.map((service) => {
+              const IconComponent = SERVICE_ICONS[service.key] ?? Server
+              return (
+                <div
+                  key={service.key}
+                  className="flex items-center justify-between rounded-lg border border-[#E5E5E5] bg-white px-5 py-4"
+                >
+                  <div className="flex items-center gap-3">
+                    <IconComponent className="h-5 w-5 text-[#6B7280]" strokeWidth={1.5} />
+                    <span className="text-sm font-medium text-[#111111]">{service.name}</span>
+                  </div>
+
+                  <div className="flex items-center gap-6">
+                    {service.key !== "api" && (
+                      <span className="text-sm text-[#6B7280]">
+                        {formatLatency(service.latencyMs, isLoading)}
                       </span>
-                    </div>
+                    )}
+                    <span className={statusBadgeClass(service.status, isLoading)}>
+                      {formatStatusLabel(service.status, isLoading)}
+                    </span>
                   </div>
-                )
-              })}
-            </div>
-          </div>
-
-          {/* System Metrics Section */}
-          <div>
-            <h2 className="text-sm font-medium text-[#6B7280] uppercase tracking-wide mb-4">시스템 지표</h2>
-            <div className="flex flex-col gap-3">
-              {metricsData.map((metric) => {
-                const IconComponent = metric.icon
-                return (
-                  <div
-                    key={metric.id}
-                    className="flex items-center justify-between px-5 py-4 bg-white border border-[#E5E5E5] rounded-lg"
-                  >
-                    {/* Left: Icon + Label */}
-                    <div className="flex items-center gap-3">
-                      <IconComponent className="w-5 h-5 text-[#6B7280]" strokeWidth={1.5} />
-                      <span className="text-sm font-medium text-[#111111]">{metric.label}</span>
-                    </div>
-
-                    {/* Right: Value */}
-                    <span className="text-sm font-semibold text-[#111111]">{metric.value}</span>
-                  </div>
-                )
-              })}
-            </div>
+                </div>
+              )
+            })}
           </div>
         </div>
       </div>

--- a/components/users-content.tsx
+++ b/components/users-content.tsx
@@ -1,152 +1,146 @@
 "use client"
 
-import { useState } from "react"
-import { ChevronLeft, ChevronRight } from "lucide-react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { ChevronDown, ChevronLeft, ChevronRight, Search } from "lucide-react"
+import {
+  getBoard,
+  getExams,
+  type Exam,
+  type ExamineeBoardEntry,
+} from "@/lib/api/admin"
 
-type ConnectionStatus = "연결됨" | "대기 중"
-type SubmissionStatus = "시작 전" | "진행 중" | "제출 완료"
+type ConnectionStatus = "응시 완료" | "응시 중" | "대기 중" | "종료됨"
+
+const EXAM_ENDED_STATES = new Set(["ENDED", "COMPLETED", "FINISHED", "CLOSED"])
+type SubmissionStatus = "시작 전" | "진행 중" | "채점 중" | "제출 완료"
 
 interface Participant {
   id: string
   name: string
+  examLabel: string
   phone: string
   connectionStatus: ConnectionStatus
   submissionStatus: SubmissionStatus
   tokenUsage: number
 }
 
-const initialParticipants: Participant[] = [
-  {
-    id: "1",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "연결됨",
-    submissionStatus: "제출 완료",
-    tokenUsage: 1250,
-  },
-  {
-    id: "2",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "연결됨",
-    submissionStatus: "진행 중",
-    tokenUsage: 890,
-  },
-  {
-    id: "3",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "대기 중",
-    submissionStatus: "시작 전",
-    tokenUsage: 0,
-  },
-  {
-    id: "4",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "연결됨",
-    submissionStatus: "진행 중",
-    tokenUsage: 1450,
-  },
-  {
-    id: "5",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "연결됨",
-    submissionStatus: "시작 전",
-    tokenUsage: 0,
-  },
-  {
-    id: "6",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "대기 중",
-    submissionStatus: "시작 전",
-    tokenUsage: 0,
-  },
-  {
-    id: "7",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "연결됨",
-    submissionStatus: "제출 완료",
-    tokenUsage: 1120,
-  },
-  {
-    id: "8",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "연결됨",
-    submissionStatus: "진행 중",
-    tokenUsage: 760,
-  },
-  {
-    id: "9",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "대기 중",
-    submissionStatus: "시작 전",
-    tokenUsage: 0,
-  },
-  {
-    id: "10",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "연결됨",
-    submissionStatus: "제출 완료",
-    tokenUsage: 1340,
-  },
-  {
-    id: "11",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "대기 중",
-    submissionStatus: "시작 전",
-    tokenUsage: 0,
-  },
-  {
-    id: "12",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "연결됨",
-    submissionStatus: "진행 중",
-    tokenUsage: 815,
-  },
-  {
-    id: "13",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "연결됨",
-    submissionStatus: "제출 완료",
-    tokenUsage: 980,
-  },
-  {
-    id: "14",
-    name: "Rajesh Kumar",
-    phone: "+91 98765 43210",
-    connectionStatus: "연결됨",
-    submissionStatus: "제출 완료",
-    tokenUsage: 1025,
-  },
-]
+const PARTICIPANT_WAITING_STATES = new Set(["WAITING", "PENDING", "IDLE"])
+
+const PARTICIPANT_EXAMINING_STATES = new Set([
+  "ACTIVE",
+  "RUNNING",
+  "IN_PROGRESS",
+  "ENTRANCE",
+  "STARTED",
+  "JOINED",
+])
+
+function normalizeParticipantState(state: string | null | undefined): string {
+  return (state ?? "").trim().toUpperCase()
+}
+
+function isWaitingParticipant(entry: ExamineeBoardEntry): boolean {
+  const state = normalizeParticipantState(entry.state)
+  if (PARTICIPANT_WAITING_STATES.has(state)) return true
+  if (!state && (entry.tokenUsed ?? 0) === 0 && !entry.submitted) return true
+  return false
+}
+
+function isExamineeInProgress(entry: ExamineeBoardEntry): boolean {
+  if (entry.submitted) return false
+  const state = normalizeParticipantState(entry.state)
+  if (PARTICIPANT_EXAMINING_STATES.has(state)) return true
+  if ((entry.tokenUsed ?? 0) > 0) return true
+  if (
+    entry.submissionStatus === "QUEUED" ||
+    entry.submissionStatus === "RUNNING"
+  ) {
+    return true
+  }
+  return false
+}
+
+function normalizeSubmissionStatus(status: string | null | undefined): string {
+  return (status ?? "").trim().toUpperCase()
+}
+
+function isGradingComplete(entry: ExamineeBoardEntry): boolean {
+  if (!entry.submitted) return false
+  const status = normalizeSubmissionStatus(entry.submissionStatus)
+  if (status === "FAILED") return true
+
+  if (entry.evaluatedAt) return true
+  if (entry.totalScore != null && entry.totalScore !== undefined) {
+    const n = Number(entry.totalScore)
+    if (!Number.isNaN(n)) return true
+  }
+  return false
+}
+
+function isExamEnded(exam: Exam): boolean {
+  const state = (exam.state ?? "").trim().toUpperCase()
+  if (EXAM_ENDED_STATES.has(state)) return true
+  if (exam.endsAt) {
+    const endMs = new Date(exam.endsAt).getTime()
+    if (!Number.isNaN(endMs) && endMs <= Date.now()) return true
+  }
+  return false
+}
+
+function mapConnectionStatus(entry: ExamineeBoardEntry, exam: Exam): ConnectionStatus {
+  if (isExamEnded(exam)) return "종료됨"
+  if (entry.submitted) return "응시 완료"
+  if (isWaitingParticipant(entry)) return "대기 중"
+  if (isExamineeInProgress(entry)) return "응시 중"
+  return "대기 중"
+}
+
+function mapSubmissionStatus(entry: ExamineeBoardEntry): SubmissionStatus {
+  if (!entry.submitted) {
+    if (isExamineeInProgress(entry)) return "진행 중"
+    return "시작 전"
+  }
+  if (isGradingComplete(entry)) return "제출 완료"
+  return "채점 중"
+}
+
+function resolveExamDisplayLabel(exam: Exam): string {
+  const code = exam.entryCode?.trim()
+  if (code) return code
+  return exam.title?.trim() || String(exam.id)
+}
+
+function mapBoardEntry(entry: ExamineeBoardEntry, exam: Exam): Participant {
+  return {
+    id: `${exam.id}-${entry.examParticipantId}`,
+    name: entry.name || "–",
+    examLabel: resolveExamDisplayLabel(exam),
+    phone: entry.phoneMasked || "–",
+    connectionStatus: mapConnectionStatus(entry, exam),
+    submissionStatus: mapSubmissionStatus(entry),
+    tokenUsage: entry.tokenUsed ?? 0,
+  }
+}
 
 function ConnectionBadge({ status }: { status: ConnectionStatus }) {
-  const isConnected = status === "연결됨"
+  const styles: Record<ConnectionStatus, string> = {
+    "응시 완료": "border-[#16A34A] bg-[#DCFCE7] text-[#16A34A]",
+    "응시 중": "border-[#3B82F6] bg-white text-[#3B82F6]",
+    "대기 중": "border-[#6B7280] bg-white text-[#6B7280]",
+    "종료됨": "border-[#9CA3AF] bg-[#F3F4F6] text-[#6B7280]",
+  }
   return (
-    <span
-      className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${
-        isConnected ? "border-[#3B82F6] bg-white text-[#3B82F6]" : "border-[#6B7280] bg-white text-[#6B7280]"
-      }`}
-    >
+    <span className={`rounded-full border px-2.5 py-0.5 text-xs font-medium ${styles[status]}`}>
       {status}
     </span>
   )
 }
 
 function SubmissionBadge({ status }: { status: SubmissionStatus }) {
-  const styles = {
+  const styles: Record<SubmissionStatus, string> = {
     "시작 전": "bg-[#F3F4F6] text-[#6B7280]",
     "진행 중": "bg-[#E0EDFF] text-[#3B82F6]",
+    "채점 중": "bg-[#FEF3C7] text-[#D97706]",
     "제출 완료": "bg-[#DCFCE7] text-[#16A34A]",
   }
 
@@ -154,75 +148,240 @@ function SubmissionBadge({ status }: { status: SubmissionStatus }) {
 }
 
 export function UsersContent() {
-  const [participants] = useState<Participant[]>(initialParticipants)
+  const [exams, setExams] = useState<Exam[]>([])
+  const [participants, setParticipants] = useState<Participant[]>([])
+  const [isLoadingExams, setIsLoadingExams] = useState(true)
+  const [isLoadingBoard, setIsLoadingBoard] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [selectedExamId, setSelectedExamId] = useState<string>("all")
+  const [searchQuery, setSearchQuery] = useState("")
   const [currentPage, setCurrentPage] = useState(1)
   const pageSize = 12
 
-  const totalPages = Math.ceil(participants.length / pageSize)
+  useEffect(() => {
+    let cancelled = false
+    async function loadExams() {
+      setIsLoadingExams(true)
+      try {
+        const data = await getExams()
+        if (!cancelled) setExams(data)
+      } catch (e) {
+        console.error("[Users] Failed to load exams", e)
+        if (!cancelled) {
+          setExams([])
+          setError("시험 세션 목록을 불러오는 데 실패했습니다.")
+        }
+      } finally {
+        if (!cancelled) setIsLoadingExams(false)
+      }
+    }
+    loadExams()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const loadParticipants = useCallback(async () => {
+    if (isLoadingExams) return
+
+    setIsLoadingBoard(true)
+    setError(null)
+    try {
+      if (exams.length === 0) {
+        setParticipants([])
+        setCurrentPage(1)
+        return
+      }
+
+      let mapped: Participant[] = []
+
+      if (selectedExamId === "all") {
+        const boards = await Promise.all(
+          exams.map(async (exam) => {
+            try {
+              const entries = await getBoard(exam.id)
+              return entries.map((entry) => mapBoardEntry(entry, exam))
+            } catch (e) {
+              console.error(`[Users] getBoard failed for examId=${exam.id}`, e)
+              return [] as Participant[]
+            }
+          })
+        )
+        mapped = boards.flat()
+      } else {
+        const examId = Number.parseInt(selectedExamId, 10)
+        const exam = exams.find((e) => e.id === examId)
+        if (!exam || Number.isNaN(examId)) {
+          setParticipants([])
+          setCurrentPage(1)
+          return
+        }
+        const board = await getBoard(examId)
+        mapped = board.map((entry) => mapBoardEntry(entry, exam))
+      }
+
+      setParticipants(mapped)
+      setCurrentPage(1)
+    } catch (e) {
+      console.error("[Users] Failed to load participants", e)
+      setParticipants([])
+      setError("참가자 목록을 불러오는 데 실패했습니다.")
+    } finally {
+      setIsLoadingBoard(false)
+    }
+  }, [exams, isLoadingExams, selectedExamId])
+
+  useEffect(() => {
+    void loadParticipants()
+  }, [loadParticipants])
+
+  const filteredParticipants = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase()
+    if (!q) return participants
+    return participants.filter((p) => {
+      const name = p.name.toLowerCase()
+      const exam = p.examLabel.toLowerCase()
+      return name.includes(q) || exam.includes(q)
+    })
+  }, [participants, searchQuery])
+
+  const totalPages = Math.max(1, Math.ceil(filteredParticipants.length / pageSize))
   const startIndex = (currentPage - 1) * pageSize
   const endIndex = currentPage * pageSize
-  const visibleParticipants = participants.slice(startIndex, endIndex)
+  const visibleParticipants = filteredParticipants.slice(startIndex, endIndex)
 
-  const displayStart = participants.length === 0 ? 0 : startIndex + 1
-  const displayEnd = Math.min(endIndex, participants.length)
+  const displayStart = filteredParticipants.length === 0 ? 0 : startIndex + 1
+  const displayEnd = Math.min(endIndex, filteredParticipants.length)
+
+  const completedCount = useMemo(
+    () => filteredParticipants.filter((p) => p.submissionStatus === "제출 완료").length,
+    [filteredParticipants]
+  )
+
+  const isLoading = isLoadingExams || isLoadingBoard
+
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [searchQuery, selectedExamId])
 
   return (
     <div className="flex h-full flex-1 flex-col">
-      {/* Top Header Bar */}
       <header className="flex h-[88px] shrink-0 items-center border-b border-[#E5E5E5] bg-white px-8">
         <div>
           <h1 className="text-2xl font-semibold text-[#1A1A1A]">참가자 목록</h1>
-          <p className="text-sm text-[#6B7280]">실시간 참가자 모니터링</p>
+          <p className="text-sm text-[#6B7280]">
+            모든 시험 세션의 참가자를 조회하고 제출 상태를 확인합니다.
+          </p>
         </div>
       </header>
 
-      {/* Main Content Panel */}
       <div className="flex min-h-0 flex-1 flex-col p-6">
-        {/* Table Container */}
-        <div className="flex flex-1 flex-col overflow-hidden rounded-xl border border-[#E5E5E5] bg-white shadow-sm">
-          {/* Table Header */}
-          <div className="grid shrink-0 grid-cols-[1.5fr_1.5fr_1fr_1fr_1fr] gap-4 border-b border-[#E5E5E5] bg-[#F9FAFB] px-6 py-3">
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">이름</span>
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">전화번호</span>
-            <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">연결 상태</span>
-            <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">제출 상태</span>
-            <span className="text-right text-xs font-semibold uppercase tracking-wide text-[#6B7280]">토큰 사용량</span>
+        <div className="mb-4 flex flex-wrap items-center gap-3">
+          <div className="relative">
+            <select
+              value={selectedExamId}
+              onChange={(e) => setSelectedExamId(e.target.value)}
+              disabled={isLoadingExams}
+              className="appearance-none rounded-lg border border-[#E5E5E5] bg-white py-2 pl-4 pr-10 text-sm text-[#1A1A1A] outline-none transition-colors focus:border-[#3B82F6] focus:ring-1 focus:ring-[#3B82F6] disabled:opacity-50"
+            >
+              <option value="all">모든 세션</option>
+              {exams.map((exam) => (
+                <option key={exam.id} value={String(exam.id)}>
+                  {resolveExamDisplayLabel(exam)}
+                </option>
+              ))}
+            </select>
+            <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#6B7280]" />
           </div>
 
-          {/* Table Body */}
-          <div className="flex-1 overflow-y-auto">
-            {visibleParticipants.map((participant, index) => (
-              <div
-                key={participant.id}
-                className={`grid grid-cols-[1.5fr_1.5fr_1fr_1fr_1fr] items-center gap-4 px-6 py-4 ${
-                  index !== visibleParticipants.length - 1 ? "border-b border-[#E5E5E5]" : ""
-                }`}
-              >
-                <span className="text-sm font-medium text-[#1A1A1A]">{participant.name}</span>
-                <span className="text-sm text-[#6B7280]">{participant.phone}</span>
-                <div className="flex justify-center">
-                  <ConnectionBadge status={participant.connectionStatus} />
-                </div>
-                <div className="flex justify-center">
-                  <SubmissionBadge status={participant.submissionStatus} />
-                </div>
-                <span className="text-right text-sm font-medium text-[#1A1A1A]">
-                  {participant.tokenUsage.toLocaleString()}
-                </span>
-              </div>
-            ))}
+          <div className="relative min-w-[220px] flex-1 max-w-md">
+            <Search
+              className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#9CA3AF]"
+              strokeWidth={1.5}
+            />
+            <input
+              type="text"
+              placeholder="이름 또는 시험으로 검색…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full rounded-lg border border-[#E5E5E5] bg-white py-2 pl-10 pr-4 text-sm text-[#1A1A1A] placeholder-[#9CA3AF] outline-none transition-colors focus:border-[#3B82F6] focus:ring-1 focus:ring-[#3B82F6]"
+            />
           </div>
         </div>
 
-        {/* Pagination */}
-        {participants.length > 0 && (
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3">
+            <p className="text-sm text-red-600">{error}</p>
+          </div>
+        )}
+
+        <div className="flex flex-1 flex-col overflow-hidden rounded-xl border border-[#E5E5E5] bg-white shadow-sm">
+          <div className="grid shrink-0 grid-cols-[1.2fr_1fr_1.2fr_1fr_1fr_1fr] gap-4 border-b border-[#E5E5E5] bg-[#F9FAFB] px-6 py-3">
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">이름</span>
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">시험</span>
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">전화번호</span>
+            <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+              응시 상태
+            </span>
+            <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+              제출 상태
+            </span>
+            <span className="text-right text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+              토큰 사용량
+            </span>
+          </div>
+
+          <div className="flex-1 overflow-y-auto">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-16">
+                <p className="text-sm text-[#6B7280]">불러오는 중...</p>
+              </div>
+            ) : visibleParticipants.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-2 py-16">
+                <p className="text-sm text-[#6B7280]">표시할 참가자가 없습니다.</p>
+                {!error && filteredParticipants.length === 0 && participants.length > 0 && (
+                  <p className="text-xs text-[#9CA3AF]">검색 조건에 맞는 참가자가 없습니다.</p>
+                )}
+                {!error && participants.length === 0 && (
+                  <p className="text-xs text-[#9CA3AF]">선택한 세션에 참가자가 없습니다.</p>
+                )}
+              </div>
+            ) : (
+              visibleParticipants.map((participant, index) => (
+                <div
+                  key={participant.id}
+                  className={`grid grid-cols-[1.2fr_1fr_1.2fr_1fr_1fr_1fr] items-center gap-4 px-6 py-4 ${
+                    index !== visibleParticipants.length - 1 ? "border-b border-[#E5E5E5]" : ""
+                  }`}
+                >
+                  <span className="text-sm font-medium text-[#1A1A1A]">{participant.name}</span>
+                  <span className="text-sm font-medium text-[#374151]">{participant.examLabel}</span>
+                  <span className="text-sm text-[#6B7280]">{participant.phone}</span>
+                  <div className="flex justify-center">
+                    <ConnectionBadge status={participant.connectionStatus} />
+                  </div>
+                  <div className="flex justify-center">
+                    <SubmissionBadge status={participant.submissionStatus} />
+                  </div>
+                  <span className="text-right text-sm font-medium text-[#1A1A1A]">
+                    {participant.tokenUsage.toLocaleString()}
+                  </span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {!isLoading && filteredParticipants.length > 0 && (
           <div className="mt-4 flex shrink-0 items-center justify-between border-t border-[#E5E7EB] pt-4">
             <span className="text-sm text-[#6B7280]">
-              총 {participants.length}명 중 {displayStart}–{displayEnd}명 보여주는 중
+              총 {filteredParticipants.length}명 중 {displayStart}–{displayEnd}명 표시
+              {completedCount > 0 && ` · 제출 완료 ${completedCount}명`}
             </span>
 
             <div className="flex items-center gap-1">
               <button
+                type="button"
                 onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                 disabled={currentPage === 1}
                 className="flex h-8 items-center gap-1 rounded-md border border-[#E5E7EB] bg-white px-2 text-sm text-[#6B7280] transition-colors hover:bg-[#E0EDFF] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-white"
@@ -234,6 +393,7 @@ export function UsersContent() {
               {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
                 <button
                   key={page}
+                  type="button"
                   onClick={() => setCurrentPage(page)}
                   className={`flex h-8 w-8 items-center justify-center rounded-md border text-sm transition-colors ${
                     page === currentPage
@@ -246,6 +406,7 @@ export function UsersContent() {
               ))}
 
               <button
+                type="button"
                 onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
                 disabled={currentPage === totalPages || totalPages === 0}
                 className="flex h-8 items-center gap-1 rounded-md border border-[#E5E7EB] bg-white px-2 text-sm text-[#6B7280] transition-colors hover:bg-[#E0EDFF] disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-white"

--- a/lib/admin-board-analytics.ts
+++ b/lib/admin-board-analytics.ts
@@ -1,0 +1,111 @@
+import type { ExamineeBoardEntry } from "@/lib/api/admin"
+
+function normalizeSubmissionStatus(status: string | null | undefined): string {
+  return (status ?? "").trim().toUpperCase()
+}
+
+function toNumericScore(value: number | null | undefined): number | null {
+  if (value === null || value === undefined) return null
+  const n = Number(value)
+  return Number.isNaN(n) ? null : n
+}
+
+/** 보드 API 기준 제출 완료 (submissions 행 존재) */
+export function isExamineeBoardSubmitted(entry: ExamineeBoardEntry): boolean {
+  return entry.submitted === true
+}
+
+/**
+ * 채점 완료 — Score 행(evaluatedAt·totalScore) 또는 제출 실패 등
+ * users-content 의 isGradingComplete 와 동일 규칙
+ */
+export function isExamineeBoardGradingComplete(entry: ExamineeBoardEntry): boolean {
+  if (!isExamineeBoardSubmitted(entry)) return false
+  const status = normalizeSubmissionStatus(entry.submissionStatus)
+  if (status === "FAILED") return true
+
+  if (entry.evaluatedAt) return true
+  const total = toNumericScore(entry.totalScore)
+  if (total !== null) return true
+  return false
+}
+
+/** 평균·등급 집계에 포함할 채점 완료 행 (실제 점수 데이터 존재) */
+export function isExamineeBoardScoreGraded(entry: ExamineeBoardEntry): boolean {
+  if (!isExamineeBoardSubmitted(entry)) return false
+  if (entry.evaluatedAt) return true
+  if (toNumericScore(entry.totalScore) !== null) return true
+  if (
+    toNumericScore(entry.promptScore) !== null ||
+    toNumericScore(entry.perfScore) !== null ||
+    toNumericScore(entry.correctnessScore) !== null
+  ) {
+    return true
+  }
+  return false
+}
+
+/** 종합 점수 우선, 없으면 존재하는 항목 점수의 산술 평균 (0~100 스케일) */
+export function computeParticipantCompositeScore(entry: ExamineeBoardEntry): number | null {
+  if (!isExamineeBoardScoreGraded(entry)) return null
+
+  const total = toNumericScore(entry.totalScore)
+  if (total !== null) return total
+
+  const parts: number[] = []
+  const prompt = toNumericScore(entry.promptScore)
+  const perf = toNumericScore(entry.perfScore)
+  const correctness = toNumericScore(entry.correctnessScore)
+  if (prompt !== null) parts.push(prompt)
+  if (perf !== null) parts.push(perf)
+  if (correctness !== null) parts.push(correctness)
+  if (parts.length === 0) return null
+  return parts.reduce((sum, v) => sum + v, 0) / parts.length
+}
+
+export function computeLetterGrade(score: number | null): string {
+  if (score === null) return "–"
+  if (score >= 90) return "A"
+  if (score >= 80) return "B"
+  if (score >= 70) return "C"
+  if (score >= 60) return "D"
+  return "F"
+}
+
+export function computeParticipantLetterGrade(entry: ExamineeBoardEntry): string {
+  return computeLetterGrade(computeParticipantCompositeScore(entry))
+}
+
+function averageOf(values: number[]): string {
+  if (values.length === 0) return "–"
+  const avg = values.reduce((sum, v) => sum + v, 0) / values.length
+  return avg.toFixed(1)
+}
+
+export interface SessionAnalyticsSummary {
+  avgPrompt: string
+  avgPerformance: string
+  avgCorrectness: string
+  cumulativeUsers: number
+}
+
+export function computeSessionAnalytics(entries: ExamineeBoardEntry[]): SessionAnalyticsSummary {
+  const graded = entries.filter(isExamineeBoardScoreGraded)
+
+  const promptValues = graded
+    .map((e) => toNumericScore(e.promptScore))
+    .filter((n): n is number => n !== null)
+  const perfValues = graded
+    .map((e) => toNumericScore(e.perfScore))
+    .filter((n): n is number => n !== null)
+  const correctnessValues = graded
+    .map((e) => toNumericScore(e.correctnessScore))
+    .filter((n): n is number => n !== null)
+
+  return {
+    avgPrompt: averageOf(promptValues),
+    avgPerformance: averageOf(perfValues),
+    avgCorrectness: averageOf(correctnessValues),
+    cumulativeUsers: entries.length,
+  }
+}

--- a/lib/admin-board-csv-export.ts
+++ b/lib/admin-board-csv-export.ts
@@ -1,0 +1,113 @@
+import {
+  formatBoardSubmissionLabelKo,
+  type ExamineeBoardEntry,
+} from "@/lib/api/admin"
+import { computeParticipantLetterGrade } from "@/lib/admin-board-analytics"
+
+export interface BoardCsvRowInput {
+  entry: ExamineeBoardEntry
+  examLabel: string
+}
+
+function toNumericScore(value: number | null | undefined): number | null {
+  if (value === null || value === undefined) return null
+  const n = Number(value)
+  return Number.isNaN(n) ? null : n
+}
+
+/** 채점·미채점 구분 — 없으면 "–", 0점은 "0.0" */
+export function formatCsvScoreDisplay(value: number | null | undefined): string {
+  const n = toNumericScore(value)
+  if (n === null) return "–"
+  return n.toFixed(1)
+}
+
+/** Excel에서 앞자리 0·한글 깨짐 방지용 텍스트 셀 */
+export function formatCsvExcelTextCell(value: string): string {
+  return `="${String(value).replace(/"/g, '""')}"`
+}
+
+/** RFC 4180 — 쉼표·줄바꿈·따옴표 포함 값 이스케이프 */
+export function escapeCsvCell(value: string): string {
+  const str = String(value ?? "")
+  if (/[",\r\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+export interface KeyValueCsvRow {
+  label: string
+  value: string
+  /** 값을 Excel 문자열 수식(="051700")으로보낼지 */
+  excelTextValue?: boolean
+}
+
+/** 항목/값 2열 key-value CSV 본문 (BOM은 downloadUtf8Csv에서 추가) */
+export function buildKeyValueCsvBody(rows: KeyValueCsvRow[]): string {
+  const lines = [
+    `${escapeCsvCell("항목")},${escapeCsvCell("값")}`,
+    ...rows.map(({ label, value, excelTextValue }) => {
+      const valueCell = excelTextValue ? formatCsvExcelTextCell(value) : escapeCsvCell(value)
+      return `${escapeCsvCell(label)},${valueCell}`
+    }),
+  ]
+  return lines.join("\n")
+}
+
+export function buildParticipantEvaluationCsvFilename(
+  examLabel: string,
+  participantName: string
+): string {
+  const examSeg = sanitizeCsvFilenameSegment(examLabel)
+  const nameSeg = sanitizeCsvFilenameSegment(participantName)
+  return `participant-evaluation-${examSeg}-${nameSeg}.csv`
+}
+
+export function sanitizeCsvFilenameSegment(name: string): string {
+  const sanitized = name.replace(/[<>:"/\\|?*\u0000-\u001f]/g, "_").trim()
+  return sanitized.length > 0 ? sanitized : "session"
+}
+
+export function buildBoardParticipantsCsvBody(
+  rows: BoardCsvRowInput[],
+  options?: { includeScores?: boolean }
+): string {
+  const includeScores = options?.includeScores ?? false
+  const header = includeScores
+    ? "이름,시험,제출상태,등급,총점,프롬프트 점수,성능 점수,정답률 점수"
+    : "이름,시험,제출상태,등급"
+
+  const lines = rows.map(({ entry, examLabel }) => {
+    const grade = computeParticipantLetterGrade(entry)
+    const status = formatBoardSubmissionLabelKo(entry)
+    const examCell = formatCsvExcelTextCell(examLabel)
+    const name = entry.name || "–"
+
+    const cells = [name, examCell, status, grade]
+    if (includeScores) {
+      cells.push(
+        formatCsvScoreDisplay(entry.totalScore),
+        formatCsvScoreDisplay(entry.promptScore),
+        formatCsvScoreDisplay(entry.perfScore),
+        formatCsvScoreDisplay(entry.correctnessScore)
+      )
+    }
+    return cells.join(",")
+  })
+
+  return `${header}\n${lines.join("\n")}`
+}
+
+export function downloadUtf8Csv(filename: string, csvBody: string): void {
+  const csvContent = "\uFEFF" + csvBody
+  const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -1732,6 +1732,12 @@ export interface ExamineeBoardEntry {
   submissionId?: number | null;
   /** QUEUED | RUNNING | DONE | FAILED */
   submissionStatus?: string | null;
+  /** scores.prompt_score (Score 행 없으면 null) */
+  promptScore?: number | null;
+  /** scores.perf_score (Score 행 없으면 null) */
+  perfScore?: number | null;
+  /** scores.correctness_score (Score 행 없으면 null) */
+  correctnessScore?: number | null;
   /** scores.total_score (없으면 null) */
   totalScore?: number | null;
   /** 제출 생성 시각 (ISO 문자열) */
@@ -1778,6 +1784,17 @@ export interface AdminMetrics {
     rate1m: number;
     last: string | null;
   };
+}
+
+export interface SystemStatusServiceItem {
+  key: string;
+  name: string;
+  status: string;
+  latencyMs: number | null;
+}
+
+export interface SystemStatusResponse {
+  services: SystemStatusServiceItem[];
 }
 
 // ─── 시험 연장 ─────────────────────────────────────────────────────────────────
@@ -1848,6 +1865,27 @@ export async function deleteEntryCode(code: string): Promise<void> {
 }
 
 // ─── 시험 지표·보드 ────────────────────────────────────────────────────────────
+
+/**
+ * 관리자 시스템 상태 조회 API 호출
+ * GET /api/admin/system-status
+ */
+export async function getSystemStatus(): Promise<SystemStatusResponse> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/system-status`;
+
+  const response = await fetchAdminWithRetry(url, {
+    method: 'GET',
+    headers: getAuthHeaders(),
+    credentials: 'include',
+  });
+
+  const data: BaseResponse<SystemStatusResponse> = await response.json();
+  if (!response.ok || data.code !== 'COMMON200' || !data.result) {
+    throw new LoginFailedError(data.message || '시스템 상태 조회에 실패했습니다.', response.status);
+  }
+  return data.result;
+}
 
 /**
  * 시험 실시간 지표 조회 API 호출

--- a/lib/utils/cleanup-ai-feedback.ts
+++ b/lib/utils/cleanup-ai-feedback.ts
@@ -1,0 +1,43 @@
+/**
+ * AI 피드백·루브릭 텍스트 표시용 — Markdown 장식만 제거하고 plain text 유지
+ * (react-markdown 미사용, inline code 백틱은 유지)
+ */
+
+const INLINE_CODE_PATTERN = /(`[^`\n]+`)/g
+
+function cleanupMarkdownProse(prose: string): string {
+  let s = prose
+
+  // # heading (줄 시작)
+  s = s.replace(/^#{1,6}\s+/gm, "")
+
+  // **bold** / __bold__ (여러 겹이면 반복 제거)
+  let prev = ""
+  while (prev !== s) {
+    prev = s
+    s = s.replace(/\*\*([^*\n]+)\*\*/g, "$1")
+    s = s.replace(/__([^_\n]+)__/g, "$1")
+  }
+
+  // 닫히지 않은 잔여 마커
+  s = s.replace(/\*\*/g, "")
+  s = s.replace(/__/g, "")
+
+  return s
+}
+
+/**
+ * AI 피드백 문자열에서 bold/heading 등 Markdown 흔적만 제거합니다.
+ * inline code (`...`)·줄바꿈·번호 목록은 유지합니다.
+ */
+export function cleanupAiFeedbackText(text: string): string {
+  if (!text) return text
+
+  const parts = text.split(INLINE_CODE_PATTERN)
+  return parts
+    .map((part, index) => {
+      if (index % 2 === 1) return part
+      return cleanupMarkdownProse(part)
+    })
+    .join("")
+}


### PR DESCRIPTION
## 작업 내용

### 관리자 통계/분석 화면 개선
- `/admin/analytics` 실제 데이터 연동
  - 평균 프롬프트 점수
  - 평균 성능 점수
  - 평균 정답률 점수
  - 누적 사용자 수
- 제출 완료 참가자 카드 개선
  - 장식 그래프 제거
  - A~F 등급 표시 추가
- 세션별 통계 집계 및 필터링 개선

### CSV export 개선
- UTF-8 BOM 적용으로 Excel 한글 깨짐 수정
- 시험 코드 앞자리 0 유지 (`="051700"`)
- analytics/results/export 공통 CSV 유틸 추가
- 참가자 평가 상세 CSV 개선
  - 항목/값 구조 정리
  - 파일명 개선
  - CSV escape 처리 개선

### 관리자 대시보드 개선
- 평균 프롬프트 점수 카드 실제 데이터 연동
- analytics 집계 로직 재사용

### 서버 상태 페이지 개선
- `/admin/server-status` 실제 API 연동
- 핵심 서비스 상태만 표시하도록 구조 단순화
  - API 서버
  - 데이터베이스
  - AI 게이트웨이
- 불필요한 mock 시스템 지표 제거
  - CPU
  - 메모리
  - WebSocket
  - 활성 연결 수

### 참가자 목록 페이지 개선
- 전체 세션 참가자 조회 구조로 변경
- 세션 필터 추가
- 이름/시험 검색 기능 추가
- 시험 종료 시 응시 상태 표시 개선 (`종료됨`)
- 전체/필터 기준 요약 정보 개선

### 참가자 평가 상세 화면 개선
- AI 피드백 Markdown cleanup 처리
  - `**bold**` 제거
  - heading 기호 제거
  - inline code(`value`) 유지
- CSV export 개선
- 하단 버튼 영역 padding 보완

## 확인 사항

- analytics/results/dashboard/server-status/users 정상 동작 확인
- CSV export Excel 호환 확인
- UTF-8 BOM 적용 확인
- 시험 코드 앞자리 0 유지 확인
- 기존 인증 흐름(credentials: "include") 유지
- DB schema 변경 없음

## 참고

- AI 피드백 cleanup은 FE 표시 단계에서만 적용됩니다.
- 원본 JSON 보기(raw 데이터)는 기존 데이터 형태를 유지합니다.