### PR TITLE
Feature/master UI layout refactor

### DIFF
--- a/app/admin-login/page.tsx
+++ b/app/admin-login/page.tsx
@@ -1,0 +1,9 @@
+import LoginCard from "@/components/login-card"
+
+export default function AdminLoginPage() {
+  return (
+    <main className="min-h-screen w-full flex items-center justify-center bg-muted/40 py-16 md:py-24">
+      <LoginCard />
+    </main>
+  )
+}

--- a/app/admin-signup/page.tsx
+++ b/app/admin-signup/page.tsx
@@ -1,10 +1,8 @@
-"use client";
-
 import AdminSignupForm from "@/components/admin-signup-form";
 
 export default function AdminSignupPage() {
   return (
-    <main className="min-h-screen bg-[#F5F5F5] flex items-center justify-center py-16">
+    <main className="flex min-h-screen items-center justify-center bg-[#F5F5F5] px-4 py-16">
       <AdminSignupForm />
     </main>
   );

--- a/app/master/layout.tsx
+++ b/app/master/layout.tsx
@@ -1,16 +1,7 @@
-import type React from "react"
-import type { ReactNode } from "react";
+import type { ReactNode } from "react"
 import type { Metadata } from "next"
-import { Geist, Geist_Mono } from "next/font/google"
-import { Analytics } from "@vercel/analytics/next"
-import "../globals.css"
-import { Sidebar } from "@/components/sidebar";
-import { TopNavBar } from "@/components/top-nav-bar";
+import { Sidebar } from "@/components/sidebar"
 
-const _geist = Geist({ subsets: ["latin"] })
-const _geistMono = Geist_Mono({ subsets: ["latin"] })
-
-// <CHANGE> Updated metadata for Master Dashboard
 export const metadata: Metadata = {
   title: "Master Dashboard - AI Vibe Coding Test",
   description: "Admin dashboard for AI Vibe Coding Test platform",
@@ -34,23 +25,23 @@ export const metadata: Metadata = {
   },
 }
 
-export default function RootLayout({
+export default function MasterLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode
+  children: ReactNode
 }>) {
   return (
-    <div className="flex min-h-screen bg-[#F5F5F5]">
-      {/* 왼쪽 고정 사이드바 */}
-      <Sidebar />
+    <div className="flex h-screen w-full overflow-hidden" style={{ maxWidth: "1920px" }}>
+      <div className="fixed left-0 top-0 z-30 h-screen" style={{ width: "240px" }}>
+        <Sidebar />
+      </div>
 
-      {/* 오른쪽 영역(상단바 + 페이지 내용) */}
-      <div className="flex-1 ml-[0px] flex flex-col">
-        <TopNavBar />
-        <main className="mt-[0px] min-h-[calc(100vh-80px)] overflow-y-auto">
-          {children}
-        </main>
+      <div
+        className="ml-[240px] flex h-screen flex-1 flex-col"
+        style={{ backgroundColor: "#F9FAFB" }}
+      >
+        <main className="flex-1 overflow-y-auto">{children}</main>
       </div>
     </div>
-  );
+  )
 }

--- a/app/master/test-sessions/[ID]/page.tsx
+++ b/app/master/test-sessions/[ID]/page.tsx
@@ -1,29 +1,18 @@
-"use client";
+"use client"
 
-import { useRouter, useParams } from "next/navigation";
-import TestSessionDetailsContent from "@/components/test-session-details-content";
+import { useParams, useRouter } from "next/navigation"
+import TestSessionDetailsContent from "@/components/test-session-details-content"
+import { parseExamIdParam } from "@/lib/master-test-sessions"
 
 export default function Page() {
-  const router = useRouter();
-  const params = useParams<{ id: string }>();
-  const sessionId = params?.id;
-
-  // 임시 더미 데이터 (나중에 실제 API 연동 시 여기만 교체)
-  const session = {
-    id: Number(sessionId),
-    sessionId: `SESSION-${sessionId}`,         // ➜ Session ID
-    createdBy: "Master Admin",                // ➜ Created By
-    createdAt: "2025-12-05 10:00",            // ➜ Created At
-    status: "Completed",                      // ➜ Status (Active / Completed 등)
-    participants: 48,                         // ➜ Participants
-  };
+  const router = useRouter()
+  const params = useParams<{ ID?: string; id?: string }>()
+  const examId = parseExamIdParam(params?.ID ?? params?.id)
 
   return (
-    <main className="mt-[0px] min-h-[calc(100vh-80px)] overflow-y-auto py-6 px-8">
-      <TestSessionDetailsContent
-        session={session}
-        onBack={() => router.push("/master/test-sessions")}
-      />
-    </main>
-  );
+    <TestSessionDetailsContent
+      examId={examId}
+      onBack={() => router.push("/master/test-sessions")}
+    />
+  )
 }

--- a/app/master/test-sessions/[ID]/participants/[participantId]/page.tsx
+++ b/app/master/test-sessions/[ID]/participants/[participantId]/page.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { useParams, useRouter, useSearchParams } from "next/navigation"
+import { ParticipantEvaluationContent } from "@/components/participant-evaluation-content"
+import { parseExamIdParam } from "@/lib/master-test-sessions"
+
+export default function MasterParticipantEvaluationPage() {
+  const router = useRouter()
+  const params = useParams<{ ID?: string; id?: string; participantId: string }>()
+  const searchParams = useSearchParams()
+
+  const examId = parseExamIdParam(params?.ID ?? params?.id)
+  const participantId = String(params?.participantId ?? "")
+  const participantName = searchParams.get("participantName") ?? undefined
+
+  const handleBack = () => {
+    if (examId != null) {
+      router.push(`/master/test-sessions/${examId}`)
+    } else {
+      router.push("/master/test-sessions")
+    }
+  }
+
+  if (examId == null || !participantId.trim()) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8">
+        <p className="text-sm text-[#6B7280]">세션 또는 참가자 정보를 찾을 수 없습니다.</p>
+      </div>
+    )
+  }
+
+  return (
+    <ParticipantEvaluationContent
+      examId={examId}
+      participantId={participantId}
+      participantName={participantName}
+      backLabel="테스트 세션 상세로 돌아가기"
+      onBack={handleBack}
+    />
+  )
+}

--- a/components/admin-accounts-content.tsx
+++ b/components/admin-accounts-content.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { MoreHorizontal, Copy, Check, Eye, Power, RotateCcw, KeyRound, Trash2, EyeOff } from "lucide-react"
+import { MoreHorizontal, Copy, Check, Eye, Power, RotateCcw, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
@@ -20,108 +20,92 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { useToast } from "@/hooks/use-toast"
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { Separator } from "@/components/ui/separator"
-import { getAllAdmins, AdminInfo, LoginFailedError, NetworkError, issueAdminNumber, updateAdminNumber, AdminNumberUpdateRequest, toggleAdminNumberActive, AdminNumberDto } from "@/lib/api/admin"
-import { isMasterAdmin, isSystemMasterAdmin, SYSTEM_MASTER_ADMIN_NUMBER } from "@/lib/auth/utils"
+import {
+  fetchMasterAdminAccounts,
+  issueMasterAdminNumber,
+  updateMasterAdminAccountStatus,
+  resetMasterAdminPassword,
+  deleteMasterAdminAccount,
+  sortMasterAdminAccounts,
+  LoginFailedError,
+  NetworkError,
+  type MasterAdminAccount,
+} from "@/lib/api/master-admin-accounts"
+import { isMasterAdmin, isSystemMasterAdmin } from "@/lib/auth/utils"
 import { useRouter } from "next/navigation"
+import { AdminPageHeader } from "@/components/admin-page-header"
 
-type Admin = AdminInfo & {
-  status?: string; // UI 표시용: "활성화" | "비활성화"
-  lastLogin?: string;
-  createdAt?: string;
-  secretKey?: string;
-  lastKeyIssued?: string;
-}
-
-function generateSecretKey(): string {
-  const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
-  let key = "sk_prod_"
-  for (let i = 0; i < 22; i++) {
-    key += chars.charAt(Math.floor(Math.random() * chars.length))
-  }
-  return key
-}
-
-function generateTempPassword(): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-  let password = "temp-"
-  for (let i = 0; i < 5; i++) {
-    password += chars.charAt(Math.floor(Math.random() * chars.length))
-  }
-  password += "!"
-  password += chars.charAt(Math.floor(Math.random() * 26)) // Add a letter at the end
-  return password
+function displayValue(value: string | null | undefined): string {
+  return value && value.trim() ? value : "-"
 }
 
 export function AdminAccountsContent() {
-  const [adminUsers, setAdminUsers] = useState<Admin[]>([])
+  const [adminUsers, setAdminUsers] = useState<MasterAdminAccount[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [listError, setListError] = useState<string | null>(null)
   const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false)
   const [generatedKey, setGeneratedKey] = useState("")
   const [copied, setCopied] = useState(false)
-  const [selectedAdmin, setSelectedAdmin] = useState<Admin | null>(null)
+  const [selectedAdmin, setSelectedAdmin] = useState<MasterAdminAccount | null>(null)
   const [isChangeStatusOpen, setIsChangeStatusOpen] = useState(false)
   const [isResetPasswordOpen, setIsResetPasswordOpen] = useState(false)
   const [isResetPasswordResultOpen, setIsResetPasswordResultOpen] = useState(false)
   const [tempPassword, setTempPassword] = useState("")
   const [tempPasswordCopied, setTempPasswordCopied] = useState(false)
-  const [isReissueKeyOpen, setIsReissueKeyOpen] = useState(false)
-  const [isReissueKeyResultOpen, setIsReissueKeyResultOpen] = useState(false)
-  const [reissuedSecretKey, setReissuedSecretKey] = useState("")
-  const [reissuedKeyCopied, setReissuedKeyCopied] = useState(false)
   const [isDeleteAdminOpen, setIsDeleteAdminOpen] = useState(false)
   const [isDetailsOpen, setIsDetailsOpen] = useState(false)
-  const [showSecretKey, setShowSecretKey] = useState(false)
-  const [detailsKeyCopied, setDetailsKeyCopied] = useState(false)
   const [isChangingStatus, setIsChangingStatus] = useState(false)
+  const [isResettingPassword, setIsResettingPassword] = useState(false)
+  const [isDeletingAdmin, setIsDeletingAdmin] = useState(false)
   const { toast } = useToast()
   const router = useRouter()
 
-  // 관리자 목록 조회 함수
   const fetchAdmins = async () => {
-    setIsLoading(true);
+    setIsLoading(true)
+    setListError(null)
     try {
-      const response = await getAllAdmins();
-      // 백엔드 AdminInfo를 Admin 타입으로 변환
-      const admins: Admin[] = response.admins.map((admin) => ({
-        ...admin,
-        status: "활성화", // 백엔드에 상태 필드가 없으면 기본값
-        lastLogin: "-", // 백엔드에 마지막 로그인 필드가 없으면 기본값
-        createdAt: "-", // 백엔드에 생성일 필드가 없으면 기본값
-      }));
-      setAdminUsers(admins);
+      const { admins } = await fetchMasterAdminAccounts()
+      setAdminUsers(admins)
     } catch (error) {
+      setAdminUsers([])
       if (error instanceof LoginFailedError) {
-        if (error.message.includes('인증')) {
+        const message = error.message || "관리자 목록 조회에 실패했습니다."
+        setListError(message)
+        if (error.message.includes("인증")) {
           toast({
             title: "인증 오류",
             description: "다시 로그인해주세요.",
             variant: "destructive",
-          });
-          router.push("/");
+          })
+          router.push("/")
         } else {
           toast({
             title: "조회 실패",
-            description: error.message,
+            description: message,
             variant: "destructive",
-          });
+          })
         }
       } else if (error instanceof NetworkError) {
+        const message = error.message
+        setListError(message)
         toast({
           title: "네트워크 오류",
-          description: error.message,
+          description: message,
           variant: "destructive",
-        });
+        })
       } else {
+        const message = "관리자 목록을 불러오는 중 오류가 발생했습니다."
+        setListError(message)
         toast({
           title: "오류",
-          description: "관리자 목록을 불러오는 중 오류가 발생했습니다.",
+          description: message,
           variant: "destructive",
-        });
+        })
       }
     } finally {
-      setIsLoading(false);
+      setIsLoading(false)
     }
-  };
+  }
 
   // 관리자 목록 조회
   useEffect(() => {
@@ -149,7 +133,7 @@ export function AdminAccountsContent() {
     if (!generatedKey) {
       // 관리자 번호 발급 API 호출
       try {
-        const response = await issueAdminNumber({
+        const response = await issueMasterAdminNumber({
           label: undefined,
           expiresAt: undefined,
         })
@@ -187,7 +171,7 @@ export function AdminAccountsContent() {
     }
   }
 
-  const handleOpenChangeStatus = (admin: Admin) => {
+  const handleOpenChangeStatus = (admin: MasterAdminAccount) => {
     // MASTER-0001 보호 로직
     if (isSystemMasterAdmin({ adminNumber: admin.adminNumber })) {
       toast({
@@ -203,7 +187,7 @@ export function AdminAccountsContent() {
   }
 
   // 공용 상태 변경 핸들러 (모달에서 확인 버튼을 누른 후 호출됨)
-  const handleToggleStatus = async (admin: Admin) => {
+  const handleToggleStatus = async (admin: MasterAdminAccount) => {
     // MASTER-0001 보호 로직 (이중 체크)
     if (isSystemMasterAdmin({ adminNumber: admin.adminNumber })) {
       toast({
@@ -218,47 +202,24 @@ export function AdminAccountsContent() {
     setIsChangingStatus(true);
 
     try {
-      // 현재 상태를 기반으로 active 값 추론
-      const currentActive = admin.status === "활성화";
+      const updated = await updateMasterAdminAccountStatus(admin)
 
-      // AdminNumberDto 구성 (status 기반으로 active 추론)
-      const adminNumberDto: AdminNumberDto = {
-        adminNumber: admin.adminNumber,
-        label: undefined,
-        active: currentActive,
-        issuedBy: 0, // 실제 값은 필요 없음 (API에서 사용하지 않음)
-        assignedAdminId: admin.id,
-        expiresAt: undefined,
-        usedAt: undefined,
-        createdAt: "",
-      };
-
-      // toggleAdminNumberActive 호출
-      const updated = await toggleAdminNumberActive(adminNumberDto);
-
-      // 성공 시 목록(state) 즉시 업데이트
       setAdminUsers((prevUsers) =>
         prevUsers.map((user) =>
-          user.adminNumber === admin.adminNumber
-            ? { ...user, status: updated.active ? "활성화" : "비활성화" }
-            : user
+          user.adminNumber === admin.adminNumber ? updated : user
         )
-      );
+      )
 
-      // 상세 패널이 열려 있으면 selectedAdmin도 업데이트
       if (selectedAdmin && selectedAdmin.adminNumber === admin.adminNumber) {
-        setSelectedAdmin({
-          ...selectedAdmin,
-          status: updated.active ? "활성화" : "비활성화",
-        });
+        setSelectedAdmin(updated)
       }
 
       toast({
         title: "상태 변경 성공",
-        description: updated.active
+        description: updated.isActive
           ? "관리자 계정이 활성화되었습니다."
           : "관리자 계정이 비활성화되었습니다.",
-      });
+      })
 
       setIsChangeStatusOpen(false);
       setSelectedAdmin(null);
@@ -292,9 +253,8 @@ export function AdminAccountsContent() {
     await handleToggleStatus(selectedAdmin);
   }
 
-  const handleOpenResetPassword = (admin: Admin) => {
-    // MASTER-0001 보호 로직
-    if (isSystemMasterAdmin({ adminNumber: admin.adminNumber })) {
+  const handleOpenResetPassword = (admin: MasterAdminAccount) => {
+    if (isSystemMasterAdmin({ adminNumber: admin.adminNumber }) || admin.role === "MASTER") {
       toast({
         title: "변경 불가",
         description: "마스터 관리자 계정은 비밀번호를 재설정할 수 없습니다.",
@@ -307,12 +267,29 @@ export function AdminAccountsContent() {
     setIsResetPasswordOpen(true)
   }
 
-  const handleConfirmResetPassword = () => {
-    const newTempPassword = generateTempPassword()
-    setTempPassword(newTempPassword)
-    setTempPasswordCopied(false)
-    setIsResetPasswordOpen(false)
-    setIsResetPasswordResultOpen(true)
+  const handleConfirmResetPassword = async () => {
+    if (!selectedAdmin) return
+
+    setIsResettingPassword(true)
+    try {
+      const { temporaryPassword } = await resetMasterAdminPassword(selectedAdmin)
+      setTempPassword(temporaryPassword)
+      setTempPasswordCopied(false)
+      setIsResetPasswordOpen(false)
+      setIsResetPasswordResultOpen(true)
+    } catch (error) {
+      const message =
+        error instanceof LoginFailedError || error instanceof NetworkError
+          ? error.message
+          : "비밀번호 재설정에 실패했습니다."
+      toast({
+        title: "비밀번호 재설정 불가",
+        description: message,
+        variant: "destructive",
+      })
+    } finally {
+      setIsResettingPassword(false)
+    }
   }
 
   const handleCopyTempPassword = async () => {
@@ -324,75 +301,14 @@ export function AdminAccountsContent() {
     setTimeout(() => setTempPasswordCopied(false), 2000)
   }
 
-  const handleOpenReissueKey = (admin: Admin) => {
-    // MASTER-0001 보호 로직
-    if (isSystemMasterAdmin({ adminNumber: admin.adminNumber })) {
-      toast({
-        title: "변경 불가",
-        description: "마스터 관리자 계정은 시크릿 키를 재발급할 수 없습니다.",
-        variant: "destructive",
-      });
-      return;
-    }
-    
-    setSelectedAdmin(admin)
-    setIsReissueKeyOpen(true)
+  const handleCloseResetPasswordResult = () => {
+    setIsResetPasswordResultOpen(false)
+    setTempPassword("")
+    setTempPasswordCopied(false)
   }
 
-  const formatDateToKorean = (date: Date) => {
-    const year = date.getFullYear()
-    const month = date.getMonth() + 1
-    const day = date.getDate()
-    const hours = date.getHours()
-    const minutes = date.getMinutes()
-    const ampm = hours >= 12 ? "오후" : "오전"
-    const displayHours = hours % 12 || 12
-    const displayMinutes = minutes.toString().padStart(2, "0")
-    return `${year}년 ${month}월 ${day}일 ${ampm} ${displayHours}:${displayMinutes}`
-  }
-
-  const handleConfirmReissueKey = () => {
-    const randomStr = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 11)
-    const newKey = `sk_prod_${randomStr}`
-    setReissuedSecretKey(newKey)
-    
-    // Update the admin user's secret key and lastKeyIssued date
-    if (selectedAdmin) {
-      const now = new Date()
-      const koreanDate = formatDateToKorean(now)
-      setAdminUsers((prevUsers) =>
-        prevUsers.map((user) =>
-          user.id === selectedAdmin.id
-            ? { ...user, secretKey: newKey, lastKeyIssued: koreanDate }
-            : user
-        )
-      )
-      // Update selectedAdmin to reflect the changes
-      setSelectedAdmin((prev) => prev ? {
-        ...prev,
-        secretKey: newKey,
-        lastKeyIssued: koreanDate,
-      } : null)
-    }
-    
-    setIsReissueKeyOpen(false)
-    setIsReissueKeyResultOpen(true)
-    setReissuedKeyCopied(false)
-  }
-
-  const copyReissuedKey = async () => {
-    await navigator.clipboard.writeText(reissuedSecretKey)
-    setReissuedKeyCopied(true)
-    toast({
-      title: "Secret key copied to clipboard",
-      duration: 2000,
-    })
-    setTimeout(() => setReissuedKeyCopied(false), 2000)
-  }
-
-  const handleOpenDeleteAdmin = (admin: Admin) => {
-    // MASTER-0001 보호 로직
-    if (isSystemMasterAdmin({ adminNumber: admin.adminNumber })) {
+  const handleOpenDeleteAdmin = (admin: MasterAdminAccount) => {
+    if (isSystemMasterAdmin({ adminNumber: admin.adminNumber }) || admin.role === "MASTER") {
       toast({
         title: "삭제 불가",
         description: "마스터 관리자 계정은 삭제할 수 없습니다.",
@@ -405,30 +321,37 @@ export function AdminAccountsContent() {
     setIsDeleteAdminOpen(true)
   }
 
-  const handleConfirmDeleteAdmin = () => {
-    if (selectedAdmin) {
+  const handleConfirmDeleteAdmin = async () => {
+    if (!selectedAdmin) return
+    setIsDeletingAdmin(true)
+    try {
+      await deleteMasterAdminAccount(selectedAdmin)
       setAdminUsers((prev) => prev.filter((a) => a.id !== selectedAdmin.id))
       setIsDeleteAdminOpen(false)
-    }
-  }
-
-  const handleOpenDetails = (admin: Admin) => {
-    setSelectedAdmin(admin)
-    setShowSecretKey(false)
-    setDetailsKeyCopied(false)
-    setIsDetailsOpen(true)
-  }
-
-  const handleCopyDetailsKey = async () => {
-    if (selectedAdmin) {
-      // 시크릿 키는 백엔드에 없는 필드이므로 임시로 관리자 번호 복사
-      await navigator.clipboard.writeText(selectedAdmin.adminNumber)
-      setDetailsKeyCopied(true)
+      setIsDetailsOpen(false)
+      setSelectedAdmin(null)
       toast({
-        description: "관리자 번호가 클립보드에 복사되었습니다.",
+        title: "관리자 삭제 완료",
+        description: "관리자 계정이 삭제되었습니다.",
       })
-      setTimeout(() => setDetailsKeyCopied(false), 2000)
+    } catch (error) {
+      const message =
+        error instanceof LoginFailedError || error instanceof NetworkError
+          ? error.message
+          : "관리자 삭제에 실패했습니다."
+      toast({
+        title: "관리자 삭제 불가",
+        description: message,
+        variant: "destructive",
+      })
+    } finally {
+      setIsDeletingAdmin(false)
     }
+  }
+
+  const handleOpenDetails = (admin: MasterAdminAccount) => {
+    setSelectedAdmin(admin)
+    setIsDetailsOpen(true)
   }
 
   const handleChangeStatusFromPanel = () => {
@@ -437,8 +360,9 @@ export function AdminAccountsContent() {
   }
 
   const handleResetPasswordFromPanel = () => {
+    if (!selectedAdmin) return
     setIsDetailsOpen(false)
-    setIsResetPasswordOpen(true)
+    handleOpenResetPassword(selectedAdmin)
   }
 
   const handleDeleteAdminFromPanel = () => {
@@ -447,29 +371,13 @@ export function AdminAccountsContent() {
   }
 
   return (
-    <div className="flex flex-col gap-4 p-6 min-h-[calc(100vh-80px)]">
-      {/* Page Header */}
-      <div>
-        <h1
-          style={{
-            fontSize: "24px",
-            fontWeight: 600,
-            color: "#1A1A1A",
-            marginBottom: "4px",
-          }}
-        >
-          관리자 계정 관리
-        </h1>
-        <p
-          style={{
-            fontSize: "14px",
-            color: "#6B7280",
-          }}
-        >
-          관리자 계정과 접근 권한을 관리합니다.
-        </p>
-      </div>
+    <div className="flex h-full flex-1 flex-col">
+      <AdminPageHeader
+        title="관리자 계정 관리"
+        description="관리자 계정과 접근 권한을 관리합니다."
+      />
 
+      <main className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
       {/* Admin Users Card */}
       <Card className="border border-[#E5E5E5] shadow-sm flex-1 flex flex-col">
         <CardHeader className="flex flex-row items-center justify-between py-2 px-6">
@@ -496,6 +404,14 @@ export function AdminAccountsContent() {
           </Button>
         </CardHeader>
         <CardContent className="px-0 pb-0 pt-0 flex-1 flex flex-col overflow-hidden">
+          {listError && !isLoading && (
+            <p
+              className="mx-6 mb-3 rounded-lg border border-[#FEE2E2] bg-[#FEF2F2] px-4 py-3 text-sm text-[#DC2626]"
+              role="alert"
+            >
+              {listError}
+            </p>
+          )}
           <ScrollArea className="flex-1 h-[520px]">
             <Table className="w-full table-fixed">
               <TableHeader>
@@ -578,12 +494,14 @@ export function AdminAccountsContent() {
                     </TableCell>
                   </TableRow>
                 ) : (
-                  adminUsers.map((user) => {
+                  sortMasterAdminAccounts(adminUsers).map((user) => {
                     const isMaster = isMasterAdmin({
                       adminNumber: user.adminNumber,
                       role: user.role,
                     });
-                    const isSystemMaster = isSystemMasterAdmin({ adminNumber: user.adminNumber });
+                    const isSystemMaster =
+                      isSystemMasterAdmin({ adminNumber: user.adminNumber }) ||
+                      user.role === "MASTER";
                     
                     return (
                       <TableRow key={user.id} className="border-t border-[#E5E5E5] hover:bg-[#F9FAFB]">
@@ -658,7 +576,7 @@ export function AdminAccountsContent() {
                         color: "#6B7280",
                       }}
                     >
-                      {user.lastLogin}
+                      {displayValue(user.lastLogin)}
                     </TableCell>
                     <TableCell className="w-[80px] text-right" style={{ paddingRight: "24px" }}>
                       <DropdownMenu>
@@ -686,22 +604,17 @@ export function AdminAccountsContent() {
                             상태 변경
                           </DropdownMenuItem>
                           <DropdownMenuItem
-                            className={`flex items-center gap-2 ${isSystemMaster ? "cursor-not-allowed opacity-60" : ""}`}
+                            className={`flex items-center gap-2 ${isSystemMaster || user.role === "MASTER" ? "cursor-not-allowed opacity-60" : ""}`}
                             style={{ fontSize: "14px", color: "#1A1A1A" }}
-                            disabled={isSystemMaster}
-                            onClick={() => !isSystemMaster && handleOpenResetPassword(user)}
+                            disabled={isSystemMaster || user.role === "MASTER"}
+                            onClick={() =>
+                              !isSystemMaster &&
+                              user.role !== "MASTER" &&
+                              handleOpenResetPassword(user)
+                            }
                           >
                             <RotateCcw className="h-4 w-4" />
                             비밀번호 재설정
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            className={`flex items-center gap-2 ${isSystemMaster ? "cursor-not-allowed opacity-60" : ""}`}
-                            style={{ fontSize: "14px", color: "#1A1A1A" }}
-                            disabled={isSystemMaster}
-                            onClick={() => !isSystemMaster && handleOpenReissueKey(user)}
-                          >
-                            <KeyRound className="h-4 w-4" />
-                            시크릿 키 재발급
                           </DropdownMenuItem>
                           <DropdownMenuItem
                             className={`flex items-center gap-2 ${isSystemMaster ? "cursor-not-allowed opacity-40" : ""}`}
@@ -919,24 +832,26 @@ export function AdminAccountsContent() {
                 fontSize: "14px",
                 color: "#6B7280",
                 marginBottom: "12px",
+                lineHeight: "1.6",
               }}
             >
-              관리자의 다음 로그인을 위해 임시 비밀번호가 생성됩니다.
+              해당 관리자의 비밀번호를 임시 비밀번호로 재설정하시겠습니까?
             </p>
             <p
               style={{
                 fontSize: "14px",
-                fontWeight: 600,
-                color: "#1A1A1A",
+                color: "#6B7280",
+                lineHeight: "1.6",
               }}
             >
-              이 관리자의 비밀번호를 재설정하시겠습니까?
+              생성된 임시 비밀번호는 한 번만 표시됩니다. 관리자에게 안전하게 전달한 뒤, 해당 관리자는 설정 화면에서 본인이 직접 비밀번호를 변경할 수 있습니다.
             </p>
           </div>
           <DialogFooter className="gap-2">
             <Button
               variant="outline"
               onClick={() => setIsResetPasswordOpen(false)}
+              disabled={isResettingPassword}
               style={{
                 fontSize: "14px",
                 fontWeight: 500,
@@ -946,21 +861,28 @@ export function AdminAccountsContent() {
             </Button>
             <Button
               onClick={handleConfirmResetPassword}
+              disabled={isResettingPassword}
               style={{
                 backgroundColor: "#3B82F6",
                 color: "#FFFFFF",
                 fontSize: "14px",
                 fontWeight: 500,
+                opacity: isResettingPassword ? 0.6 : 1,
               }}
             >
-              비밀번호 재설정
+              {isResettingPassword ? "처리 중..." : "비밀번호 재설정"}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
       {/* Modal — Temporary password generated (result) */}
-      <Dialog open={isResetPasswordResultOpen} onOpenChange={setIsResetPasswordResultOpen}>
+      <Dialog
+        open={isResetPasswordResultOpen}
+        onOpenChange={(open) => {
+          if (!open) handleCloseResetPasswordResult()
+        }}
+      >
         <DialogContent className="sm:max-w-xl">
           <DialogHeader>
             <DialogTitle
@@ -978,7 +900,7 @@ export function AdminAccountsContent() {
                 color: "#6B7280",
               }}
             >
-              이 비밀번호를 복사하여 관리자에게 안전하게 전달해주세요.
+              이 비밀번호는 한 번만 표시됩니다. 모달을 닫으면 다시 확인할 수 없습니다.
             </DialogDescription>
           </DialogHeader>
           <div className="py-4">
@@ -1019,7 +941,7 @@ export function AdminAccountsContent() {
           </div>
           <DialogFooter>
             <Button
-              onClick={() => setIsResetPasswordResultOpen(false)}
+              onClick={handleCloseResetPasswordResult}
               style={{
                 backgroundColor: "#3B82F6",
                 color: "#FFFFFF",
@@ -1033,75 +955,18 @@ export function AdminAccountsContent() {
         </DialogContent>
       </Dialog>
 
-      {/* Modal — Reissue Secret Key confirmation dialog */}
-      <Dialog open={isReissueKeyOpen} onOpenChange={setIsReissueKeyOpen}>
-        <DialogContent className="sm:max-w-xl">
-          <DialogHeader>
-            <DialogTitle style={{ fontSize: "18px", fontWeight: 600, color: "#1A1A1A" }}>
-              Reissue Secret Key
-            </DialogTitle>
-          </DialogHeader>
-          <div className="py-4">
-            <p style={{ fontSize: "14px", color: "#6B7280", lineHeight: "1.6" }}>
-              The current secret key will be invalidated and replaced with a new one. Do you want to continue?
-            </p>
-          </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsReissueKeyOpen(false)}>
-              Cancel
-            </Button>
-            <Button className="bg-blue-600 hover:bg-blue-700 text-white" onClick={handleConfirmReissueKey}>
-              Reissue Key
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      {/* Modal — Reissue Secret Key result dialog */}
-      <Dialog open={isReissueKeyResultOpen} onOpenChange={setIsReissueKeyResultOpen}>
-        <DialogContent className="sm:max-w-xl">
-          <DialogHeader>
-            <DialogTitle style={{ fontSize: "18px", fontWeight: 600, color: "#1A1A1A" }}>
-              New Secret Key Issued
-            </DialogTitle>
-          </DialogHeader>
-          <div className="py-4 space-y-4">
-            <p style={{ fontSize: "14px", color: "#6B7280", lineHeight: "1.6" }}>
-              This secret key will only be shown once. Please copy and store it safely.
-            </p>
-            <div className="space-y-2">
-              <label style={{ fontSize: "14px", fontWeight: 500, color: "#1A1A1A" }}>Secret Key</label>
-              <div className="flex items-center gap-2">
-                <Input readOnly value={reissuedSecretKey} style={{ fontSize: "14px", fontFamily: "monospace" }} />
-                <Button variant="outline" size="icon" onClick={copyReissuedKey} className="shrink-0 bg-transparent">
-                  {reissuedKeyCopied ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}
-                </Button>
-              </div>
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              className="bg-blue-600 hover:bg-blue-700 text-white"
-              onClick={() => setIsReissueKeyResultOpen(false)}
-            >
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
       {/* Modal — Delete Admin confirmation dialog */}
       <Dialog open={isDeleteAdminOpen} onOpenChange={setIsDeleteAdminOpen}>
         <DialogContent className="sm:max-w-xl">
           <DialogHeader>
-            <DialogTitle style={{ fontSize: "18px", fontWeight: 600, color: "#1A1A1A" }}>Delete Admin</DialogTitle>
+            <DialogTitle style={{ fontSize: "18px", fontWeight: 600, color: "#1A1A1A" }}>관리자 삭제</DialogTitle>
           </DialogHeader>
           <div className="space-y-4 py-2">
             <div className="space-y-1">
               <p style={{ fontSize: "14px", color: "#374151" }}>
-                Are you sure you want to permanently delete this admin?
+                해당 관리자 계정을 삭제하시겠습니까?
               </p>
-              <p style={{ fontSize: "14px", color: "#374151" }}>This action cannot be undone.</p>
+              <p style={{ fontSize: "14px", color: "#374151" }}>삭제된 계정은 복구할 수 없습니다.</p>
             </div>
 
             {selectedAdmin && (
@@ -1113,14 +978,18 @@ export function AdminAccountsContent() {
               </div>
             )}
 
-            <p style={{ fontSize: "14px", color: "#374151" }}>All access for this admin will be removed immediately.</p>
+            <p style={{ fontSize: "14px", color: "#374151" }}>해당 관리자의 접근 권한이 즉시 제거됩니다.</p>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setIsDeleteAdminOpen(false)}>
-              Cancel
+              취소
             </Button>
-            <Button variant="destructive" onClick={handleConfirmDeleteAdmin}>
-              Delete Admin
+            <Button
+              variant="destructive"
+              onClick={handleConfirmDeleteAdmin}
+              disabled={isDeletingAdmin}
+            >
+              {isDeletingAdmin ? "삭제 중..." : "관리자 삭제"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -1184,6 +1053,12 @@ export function AdminAccountsContent() {
                   </div>
                 </div>
                 <div className="space-y-1">
+                  <p className="text-xs text-muted-foreground">이름</p>
+                  <p className="text-sm font-medium" style={{ color: "#1A1A1A" }}>
+                    {displayValue(selectedAdmin?.displayName)}
+                  </p>
+                </div>
+                <div className="space-y-1">
                   <p className="text-xs text-muted-foreground">이메일</p>
                   <p className="text-sm font-medium" style={{ color: "#1A1A1A" }}>
                     {selectedAdmin?.email}
@@ -1207,13 +1082,13 @@ export function AdminAccountsContent() {
                 <div className="space-y-1">
                   <p className="text-xs text-muted-foreground">마지막 로그인</p>
                   <p className="text-sm font-medium" style={{ color: "#1A1A1A" }}>
-                    {selectedAdmin?.lastLogin}
+                    {displayValue(selectedAdmin?.lastLogin)}
                   </p>
                 </div>
                 <div className="space-y-1">
                   <p className="text-xs text-muted-foreground">생성일</p>
                   <p className="text-sm font-medium" style={{ color: "#1A1A1A" }}>
-                    {selectedAdmin?.createdAt}
+                    {displayValue(selectedAdmin?.createdAt)}
                   </p>
                 </div>
               </div>
@@ -1224,54 +1099,11 @@ export function AdminAccountsContent() {
             {/* Security Settings Section */}
             <div className="space-y-4">
               <h3 style={{ fontSize: "14px", fontWeight: 600, color: "#1A1A1A" }}>보안 설정</h3>
-              <div className="grid gap-4">
-                <div className="space-y-1">
-                  <p className="text-xs text-muted-foreground">비밀번호 상태</p>
-                  <p className="text-sm font-medium" style={{ color: "#1A1A1A" }}>
-                    비밀번호 설정됨
-                  </p>
-                </div>
-                <div className="space-y-1">
-                  <p className="text-xs text-muted-foreground">시크릿 키</p>
-                  <div className="flex items-center gap-2">
-                    <div
-                      className="flex-1 bg-[#F9FAFB] rounded-md px-3 py-2 font-mono text-sm"
-                      style={{ color: "#1A1A1A" }}
-                    >
-                      {showSecretKey ? selectedAdmin?.adminNumber : "•••••••••••••••••••••"}
-                    </div>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      onClick={() => setShowSecretKey(!showSecretKey)}
-                      className="h-9 w-9 shrink-0 bg-transparent border-[#E5E5E5]"
-                    >
-                      {showSecretKey ? (
-                        <EyeOff className="h-4 w-4 text-[#6B7280]" />
-                      ) : (
-                        <Eye className="h-4 w-4 text-[#6B7280]" />
-                      )}
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      onClick={handleCopyDetailsKey}
-                      className="h-9 w-9 shrink-0 bg-transparent border-[#E5E5E5]"
-                    >
-                      {detailsKeyCopied ? (
-                        <Check className="h-4 w-4 text-[#16A34A]" />
-                      ) : (
-                        <Copy className="h-4 w-4 text-[#6B7280]" />
-                      )}
-                    </Button>
-                  </div>
-                </div>
-                <div className="space-y-1">
-                  <p className="text-xs text-muted-foreground">마지막 시크릿 키 발급일</p>
-                  <p className="text-sm font-medium" style={{ color: "#1A1A1A" }}>
-                    {selectedAdmin?.lastKeyIssued}
-                  </p>
-                </div>
+              <div className="space-y-1">
+                <p className="text-xs text-muted-foreground">비밀번호 상태</p>
+                <p className="text-sm font-medium" style={{ color: "#1A1A1A" }}>
+                  {selectedAdmin?.passwordStatus ?? "-"}
+                </p>
               </div>
             </div>
           </div>
@@ -1305,18 +1137,6 @@ export function AdminAccountsContent() {
                   <RotateCcw className="h-4 w-4 mr-2" /> 비밀번호 재설정
                 </Button>
                 <Button
-                  variant="outline"
-                  className="w-full bg-transparent"
-                  disabled
-                  style={{
-                    color: "#9CA3AF",
-                    cursor: "not-allowed",
-                    opacity: 0.5,
-                  }}
-                >
-                  <KeyRound className="h-4 w-4 mr-2" /> 시크릿 키 재발급
-                </Button>
-                <Button
                   variant="destructive"
                   className="w-full"
                   disabled
@@ -1339,15 +1159,6 @@ export function AdminAccountsContent() {
                   <RotateCcw className="h-4 w-4 mr-2" />
                   비밀번호 재설정
                 </Button>
-                <Button variant="outline" className="w-full bg-transparent" onClick={() => {
-                  setIsDetailsOpen(false);
-                  if (selectedAdmin) {
-                    handleOpenReissueKey(selectedAdmin);
-                  }
-                }}>
-                  <KeyRound className="h-4 w-4 mr-2" />
-                  시크릿 키 재발급
-                </Button>
                 <Button variant="destructive" className="w-full" onClick={handleDeleteAdminFromPanel}>
                   <Trash2 className="h-4 w-4 mr-2" />
                   관리자 삭제
@@ -1357,6 +1168,7 @@ export function AdminAccountsContent() {
           </div>
         </SheetContent>
       </Sheet>
+      </main>
     </div>
   )
 }

--- a/components/admin-accounts-content.tsx
+++ b/components/admin-accounts-content.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, type CSSProperties } from "react"
 import { MoreHorizontal, Copy, Check, Eye, Power, RotateCcw, Trash2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -19,7 +19,6 @@ import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { useToast } from "@/hooks/use-toast"
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet"
-import { Separator } from "@/components/ui/separator"
 import {
   fetchMasterAdminAccounts,
   issueMasterAdminNumber,
@@ -37,6 +36,14 @@ import { AdminPageHeader } from "@/components/admin-page-header"
 
 function displayValue(value: string | null | undefined): string {
   return value && value.trim() ? value : "-"
+}
+
+/** 관리자 계정 상태 Badge (활성=초록, 비활성=빨간 계열) */
+function adminAccountStatusBadgeStyle(status: MasterAdminAccount["status"]): CSSProperties {
+  if (status === "활성화") {
+    return { backgroundColor: "#DCFCE7", color: "#166534" }
+  }
+  return { backgroundColor: "#FEE2E2", color: "#DC2626" }
 }
 
 export function AdminAccountsContent() {
@@ -438,7 +445,7 @@ export function AdminAccountsContent() {
                     이메일
                   </TableHead>
                   <TableHead
-                    className="w-[100px]"
+                    className="w-[108px] text-center align-middle"
                     style={{
                       fontSize: "12px",
                       fontWeight: 500,
@@ -448,7 +455,7 @@ export function AdminAccountsContent() {
                     역할
                   </TableHead>
                   <TableHead
-                    className="w-[120px]"
+                    className="w-[120px] text-center align-middle"
                     style={{
                       fontSize: "12px",
                       fontWeight: 500,
@@ -458,7 +465,7 @@ export function AdminAccountsContent() {
                     상태
                   </TableHead>
                   <TableHead
-                    className="w-[200px]"
+                    className="w-[200px] text-center align-middle whitespace-nowrap"
                     style={{
                       fontSize: "12px",
                       fontWeight: 500,
@@ -468,7 +475,7 @@ export function AdminAccountsContent() {
                     최근 로그인
                   </TableHead>
                   <TableHead
-                    className="w-[80px] text-right"
+                    className="w-[80px] text-center align-middle"
                     style={{
                       fontSize: "12px",
                       fontWeight: 500,
@@ -541,45 +548,52 @@ export function AdminAccountsContent() {
                         >
                           {user.email}
                         </TableCell>
-                        <TableCell className="w-[100px]">
-                          <Badge
-                            variant={user.role === "MASTER" ? "default" : "secondary"}
-                            style={{
-                              fontSize: "12px",
-                              fontWeight: 500,
-                              backgroundColor: user.role === "MASTER" ? "#FEF3C7" : "#F3F4F6",
-                              color: user.role === "MASTER" ? "#92400E" : "#6B7280",
-                              border: "none",
-                            }}
-                          >
-                            {user.role === "MASTER" ? "마스터" : "관리자"}
-                          </Badge>
+                        <TableCell className="w-[108px] text-center align-middle">
+                          <div className="flex justify-center items-center">
+                            <Badge
+                              variant={user.role === "MASTER" ? "default" : "secondary"}
+                              style={{
+                                fontSize: "12px",
+                                fontWeight: 500,
+                                backgroundColor: user.role === "MASTER" ? "#FEF3C7" : "#F3F4F6",
+                                color: user.role === "MASTER" ? "#92400E" : "#6B7280",
+                                border: "none",
+                              }}
+                            >
+                              {user.role === "MASTER" ? "마스터" : "관리자"}
+                            </Badge>
+                          </div>
                         </TableCell>
-                        <TableCell className="w-[120px]">
-                          <Badge
-                            variant={user.status === "활성화" ? "default" : "secondary"}
-                            style={{
-                              fontSize: "12px",
-                              fontWeight: 500,
-                              backgroundColor: user.status === "활성화" ? "#DCFCE7" : "#F3F4F6",
-                              color: user.status === "활성화" ? "#166534" : "#6B7280",
-                              border: "none",
-                            }}
-                          >
-                            {user.status}
-                          </Badge>
+                        <TableCell className="w-[120px] text-center align-middle">
+                          <div className="flex justify-center items-center">
+                            <Badge
+                              variant={user.status === "활성화" ? "default" : "secondary"}
+                              style={{
+                                fontSize: "12px",
+                                fontWeight: 500,
+                                ...adminAccountStatusBadgeStyle(user.status),
+                                border: "none",
+                              }}
+                            >
+                              {user.status}
+                            </Badge>
+                          </div>
                         </TableCell>
-                    <TableCell
-                      className="w-[200px]"
-                      style={{
-                        fontSize: "14px",
-                        color: "#6B7280",
-                      }}
-                    >
-                      {displayValue(user.lastLogin)}
-                    </TableCell>
-                    <TableCell className="w-[80px] text-right" style={{ paddingRight: "24px" }}>
-                      <DropdownMenu>
+                        <TableCell
+                          className="w-[200px] text-center align-middle whitespace-nowrap tabular-nums"
+                          style={{
+                            fontSize: "14px",
+                            color: "#6B7280",
+                          }}
+                        >
+                          {displayValue(user.lastLogin)}
+                        </TableCell>
+                        <TableCell
+                          className="w-[80px] text-center align-middle"
+                          style={{ paddingRight: "24px" }}
+                        >
+                          <div className="flex justify-center items-center">
+                            <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <Button variant="ghost" size="icon" className="h-8 w-8 hover:bg-[#F3F4F6]">
                             <MoreHorizontal className="h-4 w-4 text-[#6B7280]" />
@@ -626,9 +640,10 @@ export function AdminAccountsContent() {
                             관리자 삭제
                           </DropdownMenuItem>
                         </DropdownMenuContent>
-                      </DropdownMenu>
-                    </TableCell>
-                  </TableRow>
+                            </DropdownMenu>
+                          </div>
+                        </TableCell>
+                      </TableRow>
                     );
                   })
                 )}
@@ -1014,28 +1029,9 @@ export function AdminAccountsContent() {
               <div className="grid gap-4">
                 <div className="space-y-1">
                   <p className="text-xs text-muted-foreground">관리자 번호</p>
-                  <div className="flex items-center gap-2">
-                    <p className="text-sm font-medium" style={{ color: "#1A1A1A" }}>
-                      {selectedAdmin?.adminNumber}
-                    </p>
-                    {selectedAdmin && isMasterAdmin({
-                      adminNumber: selectedAdmin.adminNumber,
-                      role: selectedAdmin.role,
-                    }) && (
-                      <Badge
-                        variant="default"
-                        style={{
-                          fontSize: "10px",
-                          fontWeight: 600,
-                          backgroundColor: "#FEF3C7",
-                          color: "#92400E",
-                          border: "none",
-                        }}
-                      >
-                        MASTER
-                      </Badge>
-                    )}
-                  </div>
+                  <p className="text-sm font-medium" style={{ color: "#1A1A1A" }}>
+                    {selectedAdmin?.adminNumber}
+                  </p>
                   <div className="mt-2">
                     <p className="text-xs text-muted-foreground">역할</p>
                     <Badge
@@ -1071,8 +1067,7 @@ export function AdminAccountsContent() {
                     style={{
                       fontSize: "12px",
                       fontWeight: 500,
-                      backgroundColor: selectedAdmin?.status === "활성화" ? "#DCFCE7" : "#F3F4F6",
-                      color: selectedAdmin?.status === "활성화" ? "#166534" : "#6B7280",
+                      ...(selectedAdmin ? adminAccountStatusBadgeStyle(selectedAdmin.status) : {}),
                       border: "none",
                     }}
                   >
@@ -1091,19 +1086,6 @@ export function AdminAccountsContent() {
                     {displayValue(selectedAdmin?.createdAt)}
                   </p>
                 </div>
-              </div>
-            </div>
-
-            <Separator />
-
-            {/* Security Settings Section */}
-            <div className="space-y-4">
-              <h3 style={{ fontSize: "14px", fontWeight: 600, color: "#1A1A1A" }}>보안 설정</h3>
-              <div className="space-y-1">
-                <p className="text-xs text-muted-foreground">비밀번호 상태</p>
-                <p className="text-sm font-medium" style={{ color: "#1A1A1A" }}>
-                  {selectedAdmin?.passwordStatus ?? "-"}
-                </p>
               </div>
             </div>
           </div>

--- a/components/admin-page-header.tsx
+++ b/components/admin-page-header.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react"
+
+export type AdminPageHeaderProps = {
+  title: string
+  description?: string
+  actions?: ReactNode
+}
+
+export function AdminPageHeader({ title, description, actions }: AdminPageHeaderProps) {
+  return (
+    <header className="flex h-[88px] shrink-0 items-center justify-between border-b border-[#E5E5E5] bg-white px-8">
+      <div>
+        <h1 className="text-2xl font-semibold text-[#1A1A1A]">{title}</h1>
+        {description ? <p className="text-sm text-[#6B7280]">{description}</p> : null}
+      </div>
+      {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+    </header>
+  )
+}

--- a/components/admin-sidebar.tsx
+++ b/components/admin-sidebar.tsx
@@ -74,7 +74,7 @@ export function AdminSidebar() {
   const router = useRouter()
   const [showLogoutModal, setShowLogoutModal] = useState(false)
   const [isLoggingOut, setIsLoggingOut] = useState(false)
-  const [displayName, setDisplayName] = useState("관리자")
+  const [displayName, setDisplayName] = useState("알 수 없음")
 
   useEffect(() => {
     let cancelled = false

--- a/components/admin-sidebar.tsx
+++ b/components/admin-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
 import {
@@ -25,7 +25,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
-import { logoutAdmin } from "@/lib/api/admin"
+import { getMe, logoutAdmin, resolveAdminDisplayNameFromMe } from "@/lib/api/admin"
 
 const menuGroupA = [
   { icon: LayoutDashboard, label: "대시보드",   href: "/admin/dashboard" },
@@ -74,6 +74,30 @@ export function AdminSidebar() {
   const router = useRouter()
   const [showLogoutModal, setShowLogoutModal] = useState(false)
   const [isLoggingOut, setIsLoggingOut] = useState(false)
+  const [displayName, setDisplayName] = useState("관리자")
+
+  useEffect(() => {
+    let cancelled = false
+
+    const fetchAdminDisplayName = async () => {
+      try {
+        const response = await getMe()
+        if (!cancelled) {
+          setDisplayName(resolveAdminDisplayNameFromMe(response))
+        }
+      } catch {
+        if (!cancelled) {
+          setDisplayName("관리자")
+        }
+      }
+    }
+
+    fetchAdminDisplayName()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   const isActive = (href: string) => {
     if (href === "/") {
@@ -124,7 +148,7 @@ export function AdminSidebar() {
             <User className="h-5 w-5 text-[#7C3AED]" strokeWidth={1.5} />
           </div>
           <div className="flex flex-col">
-            <span className="text-sm font-medium text-[#1A1A1A]">Admin</span>
+            <span className="text-sm font-medium text-[#1A1A1A]">{displayName}</span>
             <span className="text-xs text-[#6B7280]">관리자</span>
           </div>
         </div>

--- a/components/admin-signup-form.tsx
+++ b/components/admin-signup-form.tsx
@@ -3,7 +3,7 @@
 import type React from "react"
 
 import { useState } from "react"
-
+import Link from "next/link"
 import { useRouter } from "next/navigation";
 import { signUpAdmin, LoginFailedError, NetworkError } from "@/lib/api/admin"
 import { useToast } from "@/hooks/use-toast"
@@ -11,6 +11,7 @@ import { useToast } from "@/hooks/use-toast"
 export default function AdminSignupForm() {
   const [formData, setFormData] = useState({
     adminNumber: "",
+    displayName: "",
     email: "",
     password: "",
     confirmPassword: "",
@@ -33,6 +34,10 @@ export default function AdminSignupForm() {
     // 입력값 검증
     if (!formData.adminNumber.trim()) {
       setError("관리자 번호를 입력해주세요.")
+      return
+    }
+    if (!formData.displayName.trim()) {
+      setError("이름을 입력해주세요.")
       return
     }
     if (!formData.email.trim()) {
@@ -63,6 +68,7 @@ export default function AdminSignupForm() {
     try {
       await signUpAdmin({
         adminNumber: formData.adminNumber.trim(),
+        displayName: formData.displayName.trim(),
         email: formData.email.trim(),
         password: formData.password.trim(),
       })
@@ -91,6 +97,13 @@ export default function AdminSignupForm() {
 
   return (
     <div className="w-full max-w-[450px] bg-white rounded-2xl shadow-[0_2px_8px_rgba(0,0,0,0.04)] p-10">
+      <Link
+        href="/admin-login"
+        className="mb-5 inline-flex items-center text-xs text-[#6B7280] transition-colors hover:text-[#1A1A1A]"
+      >
+        ← 로그인으로
+      </Link>
+
       {/* Header */}
       <h1 className="text-xl font-semibold text-center text-gray-900">관리자 회원가입</h1>
       <div className="mt-5 mb-8 h-px bg-gray-200" />
@@ -105,6 +118,19 @@ export default function AdminSignupForm() {
             name="adminNumber"
             placeholder="발급받은 관리자 번호를 입력하세요"
             value={formData.adminNumber}
+            onChange={handleChange}
+            className="w-full h-11 px-3.5 border border-[#DDDDDD] rounded-[10px] text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-200 focus:border-gray-300 transition-all"
+          />
+        </div>
+
+        {/* Display Name */}
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">이름</label>
+          <input
+            type="text"
+            name="displayName"
+            placeholder="이름을 입력하세요"
+            value={formData.displayName}
             onChange={handleChange}
             className="w-full h-11 px-3.5 border border-[#DDDDDD] rounded-[10px] text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-200 focus:border-gray-300 transition-all"
           />

--- a/components/entry-codes-content.tsx
+++ b/components/entry-codes-content.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { createExam, getExams, deleteExam, getEntryCodes, startExam, endExam, extendExam, Exam, LoginFailedError, NetworkError } from "@/lib/api/admin"
+import { getExamSortTimestamp } from "@/lib/master-test-sessions"
 import { useToast } from "@/hooks/use-toast"
 
 
@@ -63,6 +64,27 @@ const pickEntryCode = (source: unknown): string | undefined => {
   }
 
   return undefined
+}
+
+/** 시험 시작 버튼(0) → 종료 버튼(1) → 종료됨(2). UI 버튼 분기와 동일한 state 기준 */
+function getExamEntryCodesActionPriority(state: string): number {
+  const normalized = (state ?? "").trim().toUpperCase()
+  if (["ENDED", "COMPLETED", "CLOSED", "FINISHED", "DONE"].includes(normalized)) {
+    return 2
+  }
+  if (["RUNNING", "IN_PROGRESS", "ACTIVE"].includes(normalized)) {
+    return 1
+  }
+  return 0
+}
+
+/** 상태 우선 정렬 후, 같은 그룹 내에서는 시작/생성 시각 내림차순(기존 시각 기준) */
+function sortExamsForEntryCodes<T extends Exam>(exams: T[]): T[] {
+  return [...exams].sort((a, b) => {
+    const byAction = getExamEntryCodesActionPriority(a.state) - getExamEntryCodesActionPriority(b.state)
+    if (byAction !== 0) return byAction
+    return getExamSortTimestamp(b) - getExamSortTimestamp(a)
+  })
 }
 
 export function EntryCodesContent() {
@@ -149,7 +171,7 @@ export function EntryCodesContent() {
         })
       )
       
-      setExams(examsWithEntryCodes)
+      setExams(sortExamsForEntryCodes(examsWithEntryCodes))
       // 시험 목록을 새로 가져올 때 페이지를 1로 리셋
       setCurrentExamPage(1)
     } catch (error) {
@@ -252,7 +274,7 @@ export function EntryCodesContent() {
         if (prev === null) {
           return [createdExamWithEntryCode]
         }
-        return [createdExamWithEntryCode, ...prev]
+        return sortExamsForEntryCodes([createdExamWithEntryCode, ...prev])
       })
 
       // 모달 닫기
@@ -471,7 +493,7 @@ export function EntryCodesContent() {
         } else if (newList.length === 0) {
           setCurrentExamPage(1)
         }
-        return newList
+        return sortExamsForEntryCodes(newList)
       })
 
       // 성공 토스트 표시

--- a/components/global-settings-content.tsx
+++ b/components/global-settings-content.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Switch } from "@/components/ui/switch"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { useToast } from "@/hooks/use-toast"
+import { AdminPageHeader } from "@/components/admin-page-header"
 
 type Settings = {
   defaultTestDuration: string
@@ -116,32 +117,13 @@ export function GlobalSettingsContent() {
   }
 
   return (
-    <div className="flex flex-col min-h-[calc(100vh-80px)] p-6 gap-4">
-      {/* Page Header */}
-      <div className="mb-2">
-        <h1
-          style={{
-            fontSize: "24px",
-            fontWeight: 600,
-            color: "#1A1A1A",
-            fontFamily: "Inter, system-ui, -apple-system, sans-serif",
-            lineHeight: "32px",
-          }}
-        >
-          전역 설정
-        </h1>
-        <p
-          style={{
-            fontSize: "14px",
-            color: "#6B7280",
-            fontFamily: "Inter, system-ui, -apple-system, sans-serif",
-            marginTop: "4px",
-          }}
-        >
-          플랫폼 전역 설정 및 시스템 보안 정책을 관리합니다
-        </p>
-      </div>
+    <div className="flex h-full flex-1 flex-col">
+      <AdminPageHeader
+        title="전역 설정"
+        description="플랫폼 전역 설정 및 시스템 보안 정책을 관리합니다"
+      />
 
+      <main className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
       {/* Settings Cards Container */}
       <div className="flex flex-col gap-6 flex-1">
         {/* Section 1: Test Configuration */}
@@ -415,6 +397,7 @@ export function GlobalSettingsContent() {
           </span>
         )}
       </div>
+      </main>
     </div>
   )
 }

--- a/components/master-dashboard-content.tsx
+++ b/components/master-dashboard-content.tsx
@@ -1,12 +1,30 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Users, UserCheck, CheckCircle2, CalendarClock, FileCode, ScrollText, ArrowRight, KeyRound, Copy, Check } from "lucide-react"
 import Link from "next/link";
-import { issueAdminNumber, LoginFailedError, NetworkError } from "@/lib/api/admin"
+import {
+  getBoard,
+  getExams,
+  getSystemStatus,
+  issueAdminNumber,
+  LoginFailedError,
+  NetworkError,
+} from "@/lib/api/admin"
+import {
+  countActiveExamSessions,
+  countTodayParticipants,
+  deriveMasterSystemStatusDisplay,
+  type MasterSystemStatusDisplay,
+} from "@/lib/master-dashboard-kpi"
+import {
+  isMasterSessionInProgress,
+  pickRecentSessions,
+  type MasterRecentSession,
+} from "@/lib/master-test-sessions"
 import { useToast } from "@/hooks/use-toast"
 import {
   Dialog,
@@ -18,13 +36,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-
-const recentSessions = [
-  { id: 1, sessionId: "SESSION-2025-001", status: "진행 중", createdAt: "2025년 1월 14일", participants: 18 },
-  { id: 2, sessionId: "SESSION-2025-002", status: "완료", createdAt: "2025년 1월 13일", participants: 25 },
-  { id: 3, sessionId: "SESSION-2025-003", status: "진행 중", createdAt: "2025년 1월 12일", participants: 12 },
-  { id: 4, sessionId: "SESSION-2025-004", status: "완료", createdAt: "2025년 1월 11일", participants: 30 },
-]
+import { AdminPageHeader } from "@/components/admin-page-header"
 
 const recentLogs = [
   { id: 1, timestamp: "오전 10:33", type: "관리자", description: "관리자 'john.smith'가 플랫폼 설정을 업데이트했습니다" },
@@ -43,7 +55,78 @@ export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {
   const [issuedAdminNumber, setIssuedAdminNumber] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [activeSessions, setActiveSessions] = useState<number | null>(null)
+  const [todayParticipants, setTodayParticipants] = useState<number | null>(null)
+  const [systemStatus, setSystemStatus] = useState<MasterSystemStatusDisplay>(
+    deriveMasterSystemStatusDisplay({ type: "fetch_failed" })
+  )
+  const [kpiLoading, setKpiLoading] = useState(true)
+  const [recentSessions, setRecentSessions] = useState<MasterRecentSession[]>([])
+  const [recentSessionsLoading, setRecentSessionsLoading] = useState(true)
+  const [recentSessionsError, setRecentSessionsError] = useState(false)
   const { toast } = useToast()
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadKpi() {
+      setKpiLoading(true)
+      setRecentSessionsLoading(true)
+      setRecentSessionsError(false)
+      try {
+        const [examsResult, statusResult] = await Promise.allSettled([
+          (async () => {
+            const exams = await getExams()
+            const boards = await Promise.all(
+              exams.map((e) => getBoard(e.id).catch(() => []))
+            )
+            return { exams, boards }
+          })(),
+          getSystemStatus(),
+        ])
+
+        if (cancelled) return
+
+        if (examsResult.status === "fulfilled") {
+          const { exams, boards } = examsResult.value
+          setActiveSessions(countActiveExamSessions(exams))
+          setTodayParticipants(countTodayParticipants(exams, boards))
+          setRecentSessions(pickRecentSessions(exams))
+        } else {
+          console.error("[MasterDashboard] Failed to load session/participant KPI", examsResult.reason)
+          setActiveSessions(0)
+          setTodayParticipants(0)
+          setRecentSessions([])
+          setRecentSessionsError(true)
+        }
+
+        if (statusResult.status === "fulfilled") {
+          setSystemStatus(
+            deriveMasterSystemStatusDisplay({
+              type: "services",
+              services: statusResult.value.services ?? [],
+            })
+          )
+        } else {
+          console.error("[MasterDashboard] Failed to load system status", statusResult.reason)
+          setSystemStatus(deriveMasterSystemStatusDisplay({ type: "fetch_failed" }))
+        }
+      } finally {
+        if (!cancelled) {
+          setKpiLoading(false)
+          setRecentSessionsLoading(false)
+        }
+      }
+    }
+
+    loadKpi()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const displayKpiNumber = (val: number | null) =>
+    kpiLoading ? "..." : val !== null ? val.toLocaleString() : "0"
 
   const handleIssueAdminNumber = async () => {
     setIsLoading(true)
@@ -105,15 +188,10 @@ export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {
   }
 
   return (
-    <div className="flex flex-col gap-6 p-6" style={{ minHeight: "calc(100vh - 80px)" }}>
-      {/* Page Header */}
-      <div className="flex flex-col gap-1">
-        <h1 style={{ fontSize: "24px", fontWeight: 600, color: "#1A1A1A", letterSpacing: "-0.01em" }}>
-          마스터 대시보드
-        </h1>
-        <p style={{ fontSize: "14px", color: "#6B7280" }}>플랫폼 활동 및 코딩 테스트 운영 개요.</p>
-      </div>
+    <div className="flex h-full flex-1 flex-col">
+      <AdminPageHeader title="마스터 대시보드" />
 
+      <main className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-6">
       {/* Section 1: KPI Summary Cards */}
       <div className="grid grid-cols-3 gap-4">
         {/* Active Sessions */}
@@ -121,7 +199,9 @@ export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {
           <CardContent className="p-5">
             <div className="flex items-center justify-between">
               <div className="flex flex-col gap-1">
-                <span style={{ fontSize: "32px", fontWeight: 700, color: "#1A1A1A" }}>12</span>
+                <span style={{ fontSize: "32px", fontWeight: 700, color: "#1A1A1A" }}>
+                  {displayKpiNumber(activeSessions)}
+                </span>
                 <span style={{ fontSize: "14px", color: "#6B7280" }}>진행 중인 세션</span>
               </div>
               <div
@@ -144,7 +224,9 @@ export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {
           <CardContent className="p-5">
             <div className="flex items-center justify-between">
               <div className="flex flex-col gap-1">
-                <span style={{ fontSize: "32px", fontWeight: 700, color: "#1A1A1A" }}>148</span>
+                <span style={{ fontSize: "32px", fontWeight: 700, color: "#1A1A1A" }}>
+                  {displayKpiNumber(todayParticipants)}
+                </span>
                 <span style={{ fontSize: "14px", color: "#6B7280" }}>오늘의 참가자</span>
               </div>
               <div
@@ -167,7 +249,15 @@ export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {
           <CardContent className="p-5">
             <div className="flex items-center justify-between">
               <div className="flex flex-col gap-1">
-                <span style={{ fontSize: "32px", fontWeight: 700, color: "#22C55E" }}>운영 중</span>
+                <span
+                  style={{
+                    fontSize: "32px",
+                    fontWeight: 700,
+                    color: kpiLoading ? "#1A1A1A" : systemStatus.valueColor,
+                  }}
+                >
+                  {kpiLoading ? "..." : systemStatus.label}
+                </span>
                 <span style={{ fontSize: "14px", color: "#6B7280" }}>시스템 상태</span>
               </div>
               <div
@@ -175,11 +265,14 @@ export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {
                 style={{
                   width: "48px",
                   height: "48px",
-                  backgroundColor: "#F0FDF4",
+                  backgroundColor: kpiLoading ? "#F3F4F6" : systemStatus.iconBg,
                   borderRadius: "12px",
                 }}
               >
-                <CheckCircle2 size={24} style={{ color: "#22C55E" }} />
+                <CheckCircle2
+                  size={24}
+                  style={{ color: kpiLoading ? "#9CA3AF" : systemStatus.iconColor }}
+                />
               </div>
             </div>
           </CardContent>
@@ -197,8 +290,17 @@ export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {
             <CardTitle style={{ fontSize: "18px", fontWeight: 600, color: "#1A1A1A" }}>최근 세션</CardTitle>
           </CardHeader>
           <CardContent className="pt-0 flex flex-col flex-1">
-            <div className="flex flex-col gap-3 flex-1 mb-5">
-              {recentSessions.map((session) => (
+            <div className="mb-5 flex flex-1 flex-col gap-3">
+              {recentSessionsLoading ? (
+                <p className="py-6 text-center text-sm text-[#6B7280]">최근 세션을 불러오는 중…</p>
+              ) : recentSessionsError ? (
+                <p className="py-6 text-center text-sm text-[#DC2626]">
+                  최근 세션을 불러오지 못했습니다.
+                </p>
+              ) : recentSessions.length === 0 ? (
+                <p className="py-6 text-center text-sm text-[#6B7280]">최근 세션이 없습니다.</p>
+              ) : (
+                recentSessions.map((session) => (
                 <div
                   key={session.id}
                   className="flex items-center justify-between p-3"
@@ -216,8 +318,10 @@ export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {
                   </div>
                   <Badge
                     style={{
-                      backgroundColor: session.status === "진행 중" ? "#DCFCE7" : "#F3F4F6",
-                      color: session.status === "진행 중" ? "#22C55E" : "#6B7280",
+                      backgroundColor: isMasterSessionInProgress(session.status)
+                        ? "#DCFCE7"
+                        : "#F3F4F6",
+                      color: isMasterSessionInProgress(session.status) ? "#22C55E" : "#6B7280",
                       fontWeight: 500,
                       fontSize: "12px",
                       border: "none",
@@ -226,7 +330,8 @@ export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {
                     {session.status}
                   </Badge>
                 </div>
-              ))}
+              ))
+              )}
             </div>
             <div className="mt-auto pt-3" style={{ borderTop: "1px solid #E5E5E5" }}>
               <Button
@@ -567,6 +672,7 @@ export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+      </main>
     </div>
   )
 }

--- a/components/master-dashboard-content.tsx
+++ b/components/master-dashboard-content.tsx
@@ -18,6 +18,7 @@ import {
   countActiveExamSessions,
   countTodayParticipants,
   deriveMasterSystemStatusDisplay,
+  isActiveExam,
   type MasterSystemStatusDisplay,
 } from "@/lib/master-dashboard-kpi"
 import {
@@ -77,9 +78,15 @@ export function MasterDashboardContent({ onNavigate }: DashboardContentProps) {
         const [examsResult, statusResult] = await Promise.allSettled([
           (async () => {
             const exams = await getExams()
-            const boards = await Promise.all(
-              exams.map((e) => getBoard(e.id).catch(() => []))
+            // ACTIVE(state) 시험에만 getBoard 호출 — 전체 시험 대상 board 조회 제거
+            const boardByExamId = new Map<number, Awaited<ReturnType<typeof getBoard>>>()
+            await Promise.all(
+              exams.filter(isActiveExam).map(async (e) => {
+                const board = await getBoard(e.id).catch(() => [])
+                boardByExamId.set(e.id, board)
+              })
             )
+            const boards = exams.map((e) => boardByExamId.get(e.id) ?? [])
             return { exams, boards }
           })(),
           getSystemStatus(),

--- a/components/master-dashboard.tsx
+++ b/components/master-dashboard.tsx
@@ -2,8 +2,7 @@
 
 import { useState } from "react"
 import { Sidebar } from "@/components/sidebar"
-import { TopNavBar } from "@/components/top-nav-bar"
-import { DashboardContent } from "@/components/dashboard-content"
+import { MasterDashboardContent } from "@/components/master-dashboard-content"
 import { AdminAccountsContent } from "@/components/admin-accounts-content"
 import { TestSessionsContent } from "@/components/test-sessions-content"
 import TestSessionDetailsContent from "@/components/test-session-details-content"
@@ -43,19 +42,15 @@ export function MasterDashboard() {
         <Sidebar activeItem={activeItem} onItemClick={handleSidebarItemClick} />
       </div>
 
-      <div className="flex-1 flex flex-col h-screen ml-[240px]" style={{ backgroundColor: "#F9FAFB" }}>
-        <div className="fixed top-0 z-20" style={{ left: "240px", right: "0", maxWidth: "calc(1920px - 240px)" }}>
-          <TopNavBar />
-        </div>
-
-        <main className="flex-1 mt-[80px] overflow-y-auto">
-          {activeItem === "Dashboard" && <DashboardContent />}
+      <div className="ml-[240px] flex h-screen flex-1 flex-col" style={{ backgroundColor: "#F9FAFB" }}>
+        <main className="flex-1 overflow-y-auto">
+          {activeItem === "Dashboard" && <MasterDashboardContent />}
           {activeItem === "Admin Accounts" && <AdminAccountsContent />}
           {activeItem === "Test Sessions" && !selectedSession && (
             <TestSessionsContent onViewDetails={handleViewSessionDetails} />
           )}
           {activeItem === "Test Sessions" && selectedSession && (
-            <TestSessionDetailsContent session={selectedSession} onBack={handleBackToSessions} />
+            <TestSessionDetailsContent examId={selectedSession.id} onBack={handleBackToSessions} />
           )}
           {activeItem === "Global Settings" && <GlobalSettingsContent />}
           {activeItem === "Problem" && <ProblemContent />}

--- a/components/participant-evaluation-content.tsx
+++ b/components/participant-evaluation-content.tsx
@@ -105,6 +105,7 @@ export function ParticipantEvaluationContent({
       setBoardError(null)
       setBoardEntry(null)
       setExamTitle(null)
+      setExamId(null)
 
       const directExamId =
         examIdProp != null && Number.isFinite(examIdProp) && examIdProp > 0 ? examIdProp : null

--- a/components/participant-evaluation-content.tsx
+++ b/components/participant-evaluation-content.tsx
@@ -23,11 +23,16 @@ import { ParticipantEvaluationTestSummary } from "@/components/participant-evalu
 import { ParticipantEvaluationRubricReport } from "@/components/participant-evaluation-rubric-report"
 
 interface ParticipantEvaluationContentProps {
-  entryCode: string
+  /** Admin: entryCode / title / exam id 문자열. Master: 생략 가능(examId 사용) */
+  entryCode?: string
+  /** Master 전용 — 지정 시 entryCode 조회 없이 직접 보드 로드 */
+  examId?: number
   participantName?: string
   /** URL 세그먼트 — 목록·보드와 동일하게 `exam_participants.id` (examParticipantId) */
   participantId: string
   onBack?: () => void
+  /** 뒤로가기 버튼 문구 (기본: 이전 페이지로 돌아가기) */
+  backLabel?: string
 }
 
 interface ToastItem {
@@ -73,15 +78,18 @@ function formatScore(n: number | null | undefined): string {
 }
 
 export function ParticipantEvaluationContent({
-  entryCode,
+  entryCode = "",
+  examId: examIdProp,
   participantName: participantNameProp,
   participantId,
   onBack,
+  backLabel = "이전 페이지로 돌아가기",
 }: ParticipantEvaluationContentProps) {
   const router = useRouter()
   const [toasts, setToasts] = useState<ToastItem[]>([])
 
-  const [examId, setExamId] = useState<number | null>(null)
+  const [examId, setExamId] = useState<number | null>(examIdProp ?? null)
+  const [examTitle, setExamTitle] = useState<string | null>(null)
   const [boardEntry, setBoardEntry] = useState<ExamineeBoardEntry | null>(null)
   const [boardError, setBoardError] = useState<string | null>(null)
   const [isLoadingBoard, setIsLoadingBoard] = useState(true)
@@ -96,18 +104,40 @@ export function ParticipantEvaluationContent({
       setIsLoadingBoard(true)
       setBoardError(null)
       setBoardEntry(null)
-      setExamId(null)
+      setExamTitle(null)
+
+      const directExamId =
+        examIdProp != null && Number.isFinite(examIdProp) && examIdProp > 0 ? examIdProp : null
+
       try {
-        const exams = await getExams()
-        const matched = findExamByResultsSegment(exams, entryCode)
-        if (!matched) {
-          if (!cancelled) setBoardError("해당 입장 코드·시험명에 맞는 시험을 찾을 수 없습니다.")
+        let resolvedExamId: number | null = directExamId
+        let resolvedTitle: string | null = null
+
+        if (directExamId != null) {
+          const exams = await getExams()
+          const matched = exams.find((e) => e.id === directExamId)
+          resolvedTitle = matched?.title?.trim() || `시험 #${directExamId}`
+        } else {
+          const exams = await getExams()
+          const matched = findExamByResultsSegment(exams, entryCode)
+          if (!matched) {
+            if (!cancelled) setBoardError("해당 입장 코드·시험명에 맞는 시험을 찾을 수 없습니다.")
+            return
+          }
+          resolvedExamId = matched.id
+          resolvedTitle = matched.title?.trim() || entryCode
+        }
+
+        if (resolvedExamId == null) {
+          if (!cancelled) setBoardError("시험 정보를 확인할 수 없습니다.")
           return
         }
-        const board = await getBoard(matched.id)
+
+        const board = await getBoard(resolvedExamId)
         const entry = board.find((p) => String(p.examParticipantId) === String(participantId))
         if (!cancelled) {
-          setExamId(matched.id)
+          setExamId(resolvedExamId)
+          setExamTitle(resolvedTitle)
           if (entry) setBoardEntry(entry)
           else setBoardError("참가자를 보드에서 찾을 수 없습니다. (ID가 examParticipantId와 일치하는지 확인하세요)")
         }
@@ -122,7 +152,7 @@ export function ParticipantEvaluationContent({
     return () => {
       cancelled = true
     }
-  }, [entryCode, participantId])
+  }, [entryCode, examIdProp, participantId])
 
   const submissionId = boardEntry?.submissionId ?? null
 
@@ -209,7 +239,7 @@ export function ParticipantEvaluationContent({
 
   const handleExport = () => {
     try {
-      const examLabel = entryCode.trim() || "session"
+      const examLabel = (examTitle ?? entryCode).trim() || "session"
       const csvBody = buildKeyValueCsvBody([
         { label: "이름", value: displayName },
         { label: "시험", value: examLabel, excelTextValue: true },
@@ -280,7 +310,7 @@ export function ParticipantEvaluationContent({
             className="inline-flex items-center gap-1.5 text-sm text-[#6B7280] transition-colors hover:text-[#4B5563]"
           >
             <ArrowLeft className="h-4 w-4" strokeWidth={1.5} />
-            이전 페이지로 돌아가기
+            {backLabel}
           </button>
         </div>
 
@@ -303,8 +333,12 @@ export function ParticipantEvaluationContent({
             </div>
           </div>
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">시험 구분 (URL)</span>
-            <p className="mt-3 text-lg font-semibold text-[#1A1A1A]">{entryCode}</p>
+            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+              {examIdProp != null ? "시험" : "시험 구분 (URL)"}
+            </span>
+            <p className="mt-3 text-lg font-semibold text-[#1A1A1A]">
+              {isLoadingBoard ? "…" : (examTitle ?? entryCode) || "–"}
+            </p>
             {examId != null && <p className="mt-1 text-xs text-[#6B7280]">examId: {examId}</p>}
           </div>
           <div className="rounded-xl border border-[#E5E5E5] bg-white p-5 shadow-sm">

--- a/components/platform-logs-content.tsx
+++ b/components/platform-logs-content.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { Input } from "@/components/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Search } from "lucide-react"
+import { AdminPageHeader } from "@/components/admin-page-header"
 
 type LogType = "Admin Activity" | "System" | "Error"
 type BadgeType = "System Updated" | "Error" | "Admin Change" | "Evaluation Completed" | "Room Started"
@@ -310,32 +311,13 @@ export function PlatformLogsContent() {
   const sortedDates = Object.keys(groupedLogs).sort((a, b) => b.localeCompare(a))
 
   return (
-    <div className="flex flex-col gap-4 p-6" style={{ minHeight: "calc(100vh - 80px)" }}>
-      {/* Page Header */}
-      <div className="flex flex-col gap-1">
-        <h1
-          style={{
-            fontSize: "24px",
-            fontWeight: 600,
-            color: "#1A1A1A",
-            lineHeight: "32px",
-            letterSpacing: "-0.01em",
-          }}
-        >
-          플랫폼 로그
-        </h1>
-        <p
-          style={{
-            fontSize: "14px",
-            fontWeight: 400,
-            color: "#6B7280",
-            lineHeight: "20px",
-          }}
-        >
-          플랫폼 전역의 시스템 활동 로그를 확인하고 모니터링합니다.
-        </p>
-      </div>
+    <div className="flex h-full flex-1 flex-col">
+      <AdminPageHeader
+        title="플랫폼 로그"
+        description="플랫폼 전역의 시스템 활동 로그를 확인하고 모니터링합니다."
+      />
 
+      <main className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
       {/* Search Bar and Filters Row */}
       <div className="flex items-center justify-between gap-4">
         {/* Search Bar */}
@@ -555,6 +537,7 @@ export function PlatformLogsContent() {
           </div>
         )}
       </div>
+      </main>
     </div>
   )
 }

--- a/components/problem-content-md-view.tsx
+++ b/components/problem-content-md-view.tsx
@@ -1,0 +1,39 @@
+/**
+ * 문제 본문(contentMd) 표시 — 사용자 시험 화면(problem-section)과 동일한 스타일
+ */
+export const PROBLEM_CONTENT_MD_CLASS =
+  "text-[#4B5563] text-sm leading-relaxed whitespace-pre-wrap"
+
+type ProblemContentMdViewProps = {
+  contentMd: string | null | undefined
+  className?: string
+  emptyLabel?: string
+  /** 모달 등 긴 본문용 내부 스크롤 */
+  scrollable?: boolean
+  maxHeight?: string
+}
+
+export function ProblemContentMdView({
+  contentMd,
+  className = "",
+  emptyLabel = "등록된 문제 본문이 없습니다.",
+  scrollable = false,
+  maxHeight,
+}: ProblemContentMdViewProps) {
+  const text = contentMd?.trim()
+
+  if (!text) {
+    return <p className="text-sm text-[#6B7280]">{emptyLabel}</p>
+  }
+
+  return (
+    <div
+      className={[PROBLEM_CONTENT_MD_CLASS, scrollable ? "overflow-y-auto" : "", className]
+        .filter(Boolean)
+        .join(" ")}
+      style={maxHeight ? { maxHeight } : undefined}
+    >
+      {text}
+    </div>
+  )
+}

--- a/components/problem-content.tsx
+++ b/components/problem-content.tsx
@@ -1,268 +1,201 @@
 "use client"
 
-import { useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { Search, Eye } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { AdminPageHeader } from "@/components/admin-page-header"
+import { ProblemContentMdView } from "@/components/problem-content-md-view"
+import { getProblems, getProblemDetail, type AdminProblem } from "@/lib/api/admin"
+import {
+  buildMasterProblemDetailFromApi,
+  filterMasterProblems,
+  mapAdminProblemToMasterListItem,
+  type MasterProblemDetail,
+  type MasterProblemListItem,
+  type ProblemDifficultyKo,
+} from "@/lib/master-problems"
 
-const initialProblems = [
-  {
-    id: 1,
-    title: "문제 1. 문자열 압축하기",
-    createdBy: "John Smith",
-    lastUpdated: "2일 전",
-    usedInSessions: 12,
-    description:
-      "주어진 문자열에서 연속으로 반복되는 문자를 압축하여 표현하세요. 연속으로 반복되는 문자는 해당 문자와 반복 횟수로 표현합니다. 반복 횟수가 1인 경우에는 숫자를 생략합니다.",
-    example: "aabbaccc → 2a2ba3c",
-    inputExample: "aabbaccc",
-    outputExample: "2a2ba3c",
-  },
-  {
-    id: 2,
-    title: "문제 2. 이진 탐색 구현",
-    createdBy: "Sarah Johnson",
-    lastUpdated: "5일 전",
-    usedInSessions: 8,
-    description:
-      "정렬된 배열에서 특정 값의 위치를 이진 탐색 알고리즘을 사용하여 찾으세요. 값이 존재하면 해당 인덱스를, 존재하지 않으면 -1을 반환합니다.",
-    example: "[1, 3, 5, 7, 9], target=5 → 2",
-    inputExample: "[1, 3, 5, 7, 9]\ntarget = 5",
-    outputExample: "2",
-  },
-  {
-    id: 3,
-    title: "문제 3. 연결 리스트 뒤집기",
-    createdBy: "Mike Davis",
-    lastUpdated: "1주 전",
-    usedInSessions: 15,
-    description:
-      "단일 연결 리스트가 주어졌을 때, 리스트의 순서를 뒤집어서 반환하세요. 리스트의 각 노드는 정수 값을 가지고 있습니다.",
-    example: "1 → 2 → 3 → 4 → 5 를 5 → 4 → 3 → 2 → 1 로 변환",
-    inputExample: "1 → 2 → 3 → 4 → 5",
-    outputExample: "5 → 4 → 3 → 2 → 1",
-  },
-  {
-    id: 4,
-    title: "문제 4. 배낭 문제 (동적 프로그래밍)",
-    createdBy: "John Smith",
-    lastUpdated: "3일 전",
-    usedInSessions: 6,
-    description:
-      "무게 제한이 있는 배낭에 최대 가치를 담을 수 있도록 물건을 선택하세요. 각 물건은 무게와 가치를 가지며, 같은 물건을 여러 번 선택할 수 없습니다.",
-    example: "배낭 용량 10, 물건들: [(5, 10), (4, 40), (6, 30), (3, 50)] → 최대 가치: 90",
-    inputExample: "capacity = 10\nitems = [(5,10), (4,40), (6,30), (3,50)]",
-    outputExample: "90",
-  },
-]
-
-type Problem = {
-  id: number
-  title: string
-  createdBy: string
-  lastUpdated: string
-  usedInSessions: number
-  description: string
-  example: string
-  inputExample: string
-  outputExample: string
+function DifficultyBadge({ difficulty }: { difficulty: ProblemDifficultyKo }) {
+  const styles = {
+    쉬움: "bg-[#D1FAE5] text-[#059669]",
+    중간: "bg-[#FEF3C7] text-[#D97706]",
+    어려움: "bg-[#FEE2E2] text-[#DC2626]",
+  }
+  return (
+    <span className={"rounded-full px-2.5 py-0.5 text-xs font-medium " + styles[difficulty]}>
+      {difficulty}
+    </span>
+  )
 }
 
 export function ProblemContent() {
-  const [problems] = useState<Problem[]>(initialProblems)
+  const [problems, setProblems] = useState<MasterProblemListItem[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState(false)
   const [searchQuery, setSearchQuery] = useState("")
-  const [selectedProblem, setSelectedProblem] = useState<Problem | null>(null)
+  const [selectedProblem, setSelectedProblem] = useState<MasterProblemDetail | null>(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [detailLoading, setDetailLoading] = useState(false)
+  const [detailError, setDetailError] = useState(false)
+  const [modalTitle, setModalTitle] = useState("문제 상세 정보")
 
-  const filteredProblems = problems.filter(
-    (problem) =>
-      problem.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      problem.createdBy.toLowerCase().includes(searchQuery.toLowerCase()),
+  const fetchProblems = useCallback(async () => {
+    setIsLoading(true)
+    setLoadError(false)
+    try {
+      const adminProblems = await getProblems()
+      const mapped = adminProblems.map((p: AdminProblem) => mapAdminProblemToMasterListItem(p))
+      setProblems(mapped)
+    } catch (e) {
+      console.error("[MasterProblem] Failed to fetch problems:", e)
+      setProblems([])
+      setLoadError(true)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchProblems()
+  }, [fetchProblems])
+
+  const filteredProblems = useMemo(
+    () => filterMasterProblems(problems, searchQuery),
+    [problems, searchQuery]
   )
 
-  const handleViewDetail = (problem: Problem) => {
-    setSelectedProblem(problem)
+  const handleViewDetail = async (problem: MasterProblemListItem) => {
+    setModalTitle(problem.title)
     setIsModalOpen(true)
+    setDetailLoading(true)
+    setDetailError(false)
+    setSelectedProblem(null)
+
+    try {
+      const detail = await getProblemDetail(problem.id)
+      setSelectedProblem(buildMasterProblemDetailFromApi(problem, detail))
+    } catch (e) {
+      console.error("[MasterProblem] Failed to load detail:", e)
+      setDetailError(true)
+    } finally {
+      setDetailLoading(false)
+    }
   }
 
-  const handleCloseModal = () => {
-    setIsModalOpen(false)
-    setSelectedProblem(null)
+  const handleCloseModal = (open: boolean) => {
+    setIsModalOpen(open)
+    if (!open) {
+      setSelectedProblem(null)
+      setDetailError(false)
+      setDetailLoading(false)
+    }
   }
 
   return (
-    <div className="flex flex-col gap-4 p-6" style={{ minHeight: "calc(100vh - 80px)" }}>
-      {/* Page Header */}
-      <div className="flex flex-col gap-1">
-        <h1
-          style={{
-            fontSize: "24px",
-            fontWeight: 600,
-            color: "#1A1A1A",
-            lineHeight: "32px",
-            letterSpacing: "-0.01em",
-          }}
-        >
-          문제 관리
-        </h1>
-        <p
-          style={{
-            fontSize: "14px",
-            fontWeight: 400,
-            color: "#6B7280",
-            lineHeight: "20px",
-          }}
-        >
-          플랫폼에서 사용되는 모든 문제를 검토하고 관리합니다.
-        </p>
-      </div>
+    <div className="flex h-full flex-1 flex-col">
+      <AdminPageHeader
+        title="문제 관리"
+        description="플랫폼에서 사용되는 모든 문제를 검토하고 관리합니다."
+      />
 
-      {/* Search Bar */}
-      <div className="relative w-full">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
-        <Input
-          type="text"
-          placeholder="검색"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          className="pl-10 h-11 rounded-lg border-[#E5E5E5] bg-white"
-          style={{
-            fontSize: "14px",
-            fontWeight: 400,
-          }}
-        />
-      </div>
+      <main className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
+        <div className="relative w-full">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+          <Input
+            type="text"
+            placeholder="문제 제목, 태그, 난이도 검색…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="h-11 rounded-lg border-[#E5E5E5] bg-white pl-10"
+            style={{ fontSize: "14px", fontWeight: 400 }}
+            disabled={isLoading && problems.length === 0}
+          />
+        </div>
 
-      {/* Card List */}
-      <div className="flex flex-col gap-3">
-        {filteredProblems.map((problem) => (
-          <div
-            key={problem.id}
-            onClick={() => handleViewDetail(problem)}
-            className="flex items-center justify-between bg-white border border-[#E5E5E5] rounded-xl p-5 cursor-pointer transition-all duration-200 hover:shadow-md hover:scale-[1.01]"
-            style={{
-              borderRadius: "12px",
-            }}
-          >
-            {/* Left Side - Problem Info */}
-            <div className="flex items-center gap-12">
-              {/* Problem Title */}
-              <div className="min-w-[280px]">
-                <h3
-                  style={{
-                    fontSize: "16px",
-                    fontWeight: 600,
-                    color: "#1A1A1A",
-                    lineHeight: "24px",
-                    letterSpacing: "-0.01em",
+        {isLoading ? (
+          <p className="py-12 text-center text-sm text-[#6B7280]">문제를 불러오는 중…</p>
+        ) : loadError ? (
+          <p className="py-12 text-center text-sm text-[#DC2626]">문제 목록을 불러오지 못했습니다.</p>
+        ) : problems.length === 0 ? (
+          <p className="py-12 text-center text-sm text-[#6B7280]">등록된 문제가 없습니다.</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {filteredProblems.map((problem) => (
+              <div
+                key={problem.id}
+                className="flex cursor-pointer items-center justify-between rounded-xl border border-[#E5E5E5] bg-white p-5 transition-all duration-200 hover:scale-[1.01] hover:shadow-md"
+                style={{ borderRadius: "12px" }}
+                onClick={() => void handleViewDetail(problem)}
+              >
+                <div className="flex flex-1 flex-wrap items-start gap-8 lg:gap-12">
+                  <div className="min-w-[240px] flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3
+                        style={{
+                          fontSize: "16px",
+                          fontWeight: 600,
+                          color: "#1A1A1A",
+                          lineHeight: "24px",
+                          letterSpacing: "-0.01em",
+                        }}
+                      >
+                        {problem.title}
+                      </h3>
+                      <span className="text-sm text-[#9CA3AF]">{problem.versionLabel}</span>
+                      <DifficultyBadge difficulty={problem.difficulty} />
+                    </div>
+                    {problem.tags.length > 0 && (
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {problem.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="rounded-full border border-[#E5E5E5] bg-[#F9FAFB] px-2.5 py-0.5 text-xs font-medium text-[#6B7280]"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex min-w-[120px] flex-col gap-0.5">
+                    <span style={{ fontSize: "12px", color: "#9CA3AF", lineHeight: "16px" }}>
+                      마지막 업데이트
+                    </span>
+                    <span style={{ fontSize: "14px", fontWeight: 500, color: "#1A1A1A", lineHeight: "20px" }}>
+                      {problem.lastUpdatedLabel}
+                    </span>
+                  </div>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    void handleViewDetail(problem)
                   }}
+                  className="flex shrink-0 items-center gap-2 rounded-lg px-4 py-2 text-blue-600 transition-colors hover:bg-blue-50"
+                  style={{ fontSize: "14px", fontWeight: 500 }}
                 >
-                  {problem.title}
-                </h3>
+                  <Eye size={18} />
+                  <span>상세 보기</span>
+                </button>
               </div>
+            ))}
 
-              {/* Created By */}
-              <div className="flex flex-col gap-0.5 min-w-[140px]">
-                <span
-                  style={{
-                    fontSize: "12px",
-                    fontWeight: 400,
-                    color: "#9CA3AF",
-                    lineHeight: "16px",
-                  }}
-                >
-                  생성자
-                </span>
-                <span
-                  style={{
-                    fontSize: "14px",
-                    fontWeight: 500,
-                    color: "#1A1A1A",
-                    lineHeight: "20px",
-                  }}
-                >
-                  {problem.createdBy}
-                </span>
+            {filteredProblems.length === 0 && (
+              <div className="flex items-center justify-center py-12 text-gray-500">
+                <p style={{ fontSize: "14px" }}>검색 결과가 없습니다.</p>
               </div>
-
-              {/* Last Updated */}
-              <div className="flex flex-col gap-0.5 min-w-[120px]">
-                <span
-                  style={{
-                    fontSize: "12px",
-                    fontWeight: 400,
-                    color: "#9CA3AF",
-                    lineHeight: "16px",
-                  }}
-                >
-                  마지막 업데이트
-                </span>
-                <span
-                  style={{
-                    fontSize: "14px",
-                    fontWeight: 500,
-                    color: "#1A1A1A",
-                    lineHeight: "20px",
-                  }}
-                >
-                  {problem.lastUpdated}
-                </span>
-              </div>
-
-              {/* Used In Sessions */}
-              <div className="flex flex-col gap-0.5 min-w-[120px]">
-                <span
-                  style={{
-                    fontSize: "12px",
-                    fontWeight: 400,
-                    color: "#9CA3AF",
-                    lineHeight: "16px",
-                  }}
-                >
-                  사용된 세션
-                </span>
-                <span
-                  style={{
-                    fontSize: "14px",
-                    fontWeight: 500,
-                    color: "#1A1A1A",
-                    lineHeight: "20px",
-                  }}
-                >
-                  {problem.usedInSessions}개
-                </span>
-              </div>
-            </div>
-
-            {/* Right Side - View Detail Button */}
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                handleViewDetail(problem)
-              }}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg text-blue-600 hover:bg-blue-50 transition-colors"
-              style={{
-                fontSize: "14px",
-                fontWeight: 500,
-              }}
-            >
-              <Eye size={18} />
-              <span>상세 보기</span>
-            </button>
-          </div>
-        ))}
-
-        {/* Empty State */}
-        {filteredProblems.length === 0 && (
-          <div className="flex items-center justify-center py-12 text-gray-500">
-            <p style={{ fontSize: "14px" }}>검색 결과가 없습니다.</p>
+            )}
           </div>
         )}
-      </div>
+      </main>
 
-      <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+      <Dialog open={isModalOpen} onOpenChange={handleCloseModal}>
         <DialogContent
-          className="bg-white p-0 gap-0 overflow-hidden [&>button]:top-6 [&>button]:right-6"
+          className="flex max-h-[90vh] flex-col gap-0 overflow-hidden bg-white p-0 [&>button]:top-6 [&>button]:right-6"
           style={{
             maxWidth: "1000px",
             width: "90vw",
@@ -270,145 +203,92 @@ export function ProblemContent() {
             boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
           }}
         >
-          {selectedProblem && (
-            <div className="flex flex-col gap-8 p-8">
-              {/* Title Area */}
-              <DialogHeader className="space-y-2 p-0">
-                <DialogTitle
-                  className="text-left"
-                  style={{
-                    fontSize: "24px",
-                    fontWeight: 700,
-                    color: "#1A1A1A",
-                    lineHeight: "32px",
-                    letterSpacing: "-0.02em",
-                  }}
-                >
-                  {selectedProblem.title}
-                </DialogTitle>
-                <p
-                  style={{
-                    fontSize: "14px",
-                    fontWeight: 400,
-                    color: "#6B7280",
-                    lineHeight: "20px",
-                  }}
-                >
-                  생성자: {selectedProblem.createdBy} · 마지막 업데이트: {selectedProblem.lastUpdated}
-                </p>
-              </DialogHeader>
+          <DialogHeader className="sr-only">
+            <DialogTitle>{modalTitle} 상세 정보</DialogTitle>
+          </DialogHeader>
 
-              {/* Problem Description Box */}
-              <div
-                className="rounded-xl border border-[#E5E5E5] bg-[#FAFAFA]"
-                style={{
-                  padding: "24px",
-                }}
-              >
-                <h4
-                  style={{
-                    fontSize: "14px",
-                    fontWeight: 600,
-                    color: "#1A1A1A",
-                    marginBottom: "12px",
-                    textTransform: "uppercase",
-                    letterSpacing: "0.05em",
-                  }}
-                >
-                  문제 설명
-                </h4>
-                <p
-                  style={{
-                    fontSize: "15px",
-                    fontWeight: 400,
-                    color: "#374151",
-                    lineHeight: "26px",
-                    whiteSpace: "pre-wrap",
-                  }}
-                >
-                  {selectedProblem.description}
-                </p>
-                <div
-                  className="mt-4 p-4 bg-white rounded-lg border border-[#E5E5E5]"
-                  style={{
-                    fontSize: "14px",
-                    color: "#1A1A1A",
-                    fontFamily: "monospace",
-                  }}
-                >
-                  <span style={{ fontWeight: 500, color: "#6B7280" }}>예: </span>
-                  <span style={{ fontWeight: 600 }}>{selectedProblem.example}</span>
-                </div>
+          {detailLoading && (
+            <p className="p-8 text-center text-sm text-[#6B7280]">상세 정보를 불러오는 중…</p>
+          )}
+
+          {detailError && !detailLoading && (
+            <p className="p-8 text-center text-sm text-[#DC2626]">문제 상세를 불러오지 못했습니다.</p>
+          )}
+
+          {selectedProblem && !detailLoading && (
+            <div className="flex min-h-0 flex-1 flex-col">
+              <div className="shrink-0 border-b border-[#E5E5E5] p-8 pb-4">
+                <DialogHeader className="space-y-2 p-0">
+                  <div className="flex flex-wrap items-center gap-2 pr-8">
+                    <h2
+                      className="text-left"
+                      style={{
+                        fontSize: "24px",
+                        fontWeight: 700,
+                        color: "#1A1A1A",
+                        lineHeight: "32px",
+                        letterSpacing: "-0.02em",
+                      }}
+                    >
+                      {selectedProblem.title}
+                    </h2>
+                    <span className="text-sm text-[#9CA3AF]">{selectedProblem.versionLabel}</span>
+                    <DifficultyBadge difficulty={selectedProblem.difficulty} />
+                  </div>
+                  {selectedProblem.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                      {selectedProblem.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded-full border border-[#E5E5E5] bg-[#F9FAFB] px-2.5 py-0.5 text-xs font-medium text-[#6B7280]"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  <p style={{ fontSize: "14px", color: "#6B7280", lineHeight: "20px" }}>
+                    마지막 업데이트: {selectedProblem.lastUpdatedLabel}
+                    {selectedProblem.usable ? " · 사용 가능" : " · 사용 불가"}
+                  </p>
+                </DialogHeader>
               </div>
 
-              {/* Example Input/Output Section */}
-              <div className="flex gap-6">
-                {/* Input Example */}
-                <div
-                  className="flex-1 rounded-xl border border-[#E5E5E5] bg-white"
-                  style={{
-                    padding: "20px",
-                  }}
-                >
-                  <h4
-                    style={{
-                      fontSize: "13px",
-                      fontWeight: 600,
-                      color: "#6B7280",
-                      marginBottom: "12px",
-                      textTransform: "uppercase",
-                      letterSpacing: "0.05em",
-                    }}
-                  >
-                    입력 예시
-                  </h4>
+              <div className="min-h-0 flex-1 overflow-y-auto p-8 pt-4">
+                <div className="flex flex-col gap-8">
                   <div
-                    className="p-4 bg-[#F9FAFB] rounded-lg border border-[#E5E5E5]"
-                    style={{
-                      fontFamily: "monospace",
-                      fontSize: "14px",
-                      fontWeight: 500,
-                      color: "#1A1A1A",
-                      lineHeight: "22px",
-                      whiteSpace: "pre-wrap",
-                    }}
+                    className="rounded-xl border border-[#E5E5E5] bg-[#FAFAFA]"
+                    style={{ padding: "24px" }}
                   >
-                    {selectedProblem.inputExample}
+                    <h4
+                      style={{
+                        fontSize: "14px",
+                        fontWeight: 600,
+                        color: "#1A1A1A",
+                        marginBottom: "12px",
+                        textTransform: "uppercase",
+                        letterSpacing: "0.05em",
+                      }}
+                    >
+                      문제 설명
+                    </h4>
+                    <ProblemContentMdView
+                      contentMd={selectedProblem.contentMd}
+                      scrollable
+                      maxHeight="min(50vh, 480px)"
+                    />
                   </div>
-                </div>
 
-                {/* Output Example */}
-                <div
-                  className="flex-1 rounded-xl border border-[#E5E5E5] bg-white"
-                  style={{
-                    padding: "20px",
-                  }}
-                >
-                  <h4
-                    style={{
-                      fontSize: "13px",
-                      fontWeight: 600,
-                      color: "#6B7280",
-                      marginBottom: "12px",
-                      textTransform: "uppercase",
-                      letterSpacing: "0.05em",
-                    }}
-                  >
-                    출력 예시
-                  </h4>
-                  <div
-                    className="p-4 bg-[#F9FAFB] rounded-lg border border-[#E5E5E5]"
-                    style={{
-                      fontFamily: "monospace",
-                      fontSize: "14px",
-                      fontWeight: 500,
-                      color: "#1A1A1A",
-                      lineHeight: "22px",
-                      whiteSpace: "pre-wrap",
-                    }}
-                  >
-                    {selectedProblem.outputExample}
-                  </div>
+                  {selectedProblem.restrictionsInfo !== "정보 없음" && (
+                    <div>
+                      <h4 className="mb-3 text-sm font-semibold uppercase tracking-wide text-[#6B7280]">
+                        제한 정보
+                      </h4>
+                      <p className="whitespace-pre-wrap text-sm text-[#374151]">
+                        {selectedProblem.restrictionsInfo}
+                      </p>
+                    </div>
+                  )}
                 </div>
               </div>
             </div>

--- a/components/problem-section.tsx
+++ b/components/problem-section.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect } from "react"
+import { ProblemContentMdView } from "@/components/problem-content-md-view"
 import { getAssignment, AssignmentResponse } from "@/lib/api/exams"
 
 interface ProblemSectionProps {
@@ -91,9 +92,7 @@ export function ProblemSection({ examId }: ProblemSectionProps) {
 
       {problem && (
         <>
-          <div className="text-[#4B5563] text-sm leading-relaxed mb-6 whitespace-pre-wrap">
-            {problem.contentMd}
-          </div>
+          <ProblemContentMdView contentMd={problem.contentMd} className="mb-6" />
 
           <div className="flex gap-2 flex-wrap">
             {problem.tags.map((tag) => (

--- a/components/settings-content.tsx
+++ b/components/settings-content.tsx
@@ -14,7 +14,14 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { logoutAdmin, getMe, changeAdminPassword, LoginFailedError, NetworkError } from "@/lib/api/admin"
+import {
+  logoutAdmin,
+  getMe,
+  changeAdminPassword,
+  LoginFailedError,
+  NetworkError,
+  resolveAdminDisplayNameFromMe,
+} from "@/lib/api/admin"
 import { useToast } from "@/hooks/use-toast"
 import { Lock } from "lucide-react"
 
@@ -47,12 +54,14 @@ export function SettingsContent() {
       setIsLoading(true);
       try {
         const response = await getMe();
-        // ADMIN의 경우: participant.name = adminNumber, participant.phone = email
-        // 이름은 백엔드에서 제공하지 않으므로 더미 데이터 사용
+        const adminNumber =
+          response.participant.adminNumber?.trim() ||
+          response.participant.name?.trim() ||
+          "";
         setAdminProfile({
-          name: "Admin", // 더미 데이터 (백엔드에서 제공되지 않음)
-          email: response.participant.phone || "", // email
-          adminNumber: response.participant.name || "", // adminNumber
+          name: resolveAdminDisplayNameFromMe(response),
+          email: response.participant.phone || "",
+          adminNumber,
         });
       } catch (error) {
         if (error instanceof LoginFailedError) {
@@ -237,7 +246,7 @@ export function SettingsContent() {
                 {isLoading ? (
                   <div className="space-y-6">
                     <div>
-                      <Label className="text-sm font-medium text-[#374151]">관리자 이름</Label>
+                      <Label className="text-sm font-medium text-[#374151]">이름</Label>
                       <Input
                         value="불러오는 중..."
                         disabled
@@ -264,9 +273,9 @@ export function SettingsContent() {
                 ) : (
                   <>
                     <div>
-                      <Label className="text-sm font-medium text-[#374151]">관리자 이름</Label>
+                      <Label className="text-sm font-medium text-[#374151]">이름</Label>
                       <Input
-                        value={adminProfile.name || "Admin"}
+                        value={adminProfile.name || "관리자"}
                         disabled
                         className="mt-2 bg-[#F9FAFB] border-[#E5E5E5] text-[#374151]"
                       />

--- a/components/settings-content.tsx
+++ b/components/settings-content.tsx
@@ -21,6 +21,7 @@ import {
   LoginFailedError,
   NetworkError,
   resolveAdminDisplayNameFromMe,
+  resolveAdminNumberFromMe,
 } from "@/lib/api/admin"
 import { useToast } from "@/hooks/use-toast"
 import { Lock } from "lucide-react"
@@ -54,14 +55,10 @@ export function SettingsContent() {
       setIsLoading(true);
       try {
         const response = await getMe();
-        const adminNumber =
-          response.participant.adminNumber?.trim() ||
-          response.participant.name?.trim() ||
-          "";
         setAdminProfile({
           name: resolveAdminDisplayNameFromMe(response),
           email: response.participant.phone || "",
-          adminNumber,
+          adminNumber: resolveAdminNumberFromMe(response),
         });
       } catch (error) {
         if (error instanceof LoginFailedError) {
@@ -275,7 +272,7 @@ export function SettingsContent() {
                     <div>
                       <Label className="text-sm font-medium text-[#374151]">이름</Label>
                       <Input
-                        value={adminProfile.name || "관리자"}
+                        value={adminProfile.name || "알 수 없음"}
                         disabled
                         className="mt-2 bg-[#F9FAFB] border-[#E5E5E5] text-[#374151]"
                       />

--- a/components/test-session-details-content.tsx
+++ b/components/test-session-details-content.tsx
@@ -136,6 +136,7 @@ export default function TestSessionDetailsContent({ examId, onBack }: TestSessio
   const sessionMeta = exam ? mapExamToTestSession(exam) : null
   const statusLabel = exam ? getMasterSessionStatusLabel(exam.state) : "-"
   const displaySessionId = sessionMeta?.sessionId ?? "-"
+  const displayCreator = sessionMeta?.createdBy ?? "알 수 없음"
   const displayCreatedAt = exam ? getExamDisplayDate(exam) : "-"
   const participantTotal = exam?.participantCount ?? participants.length
   const submissions = participants.filter((p) => p.hasSubmission).length
@@ -245,7 +246,7 @@ export default function TestSessionDetailsContent({ examId, onBack }: TestSessio
                   </div>
                   <div>
                     <p className="mb-1 text-sm text-gray-500">생성자</p>
-                    <p className="text-sm font-medium text-gray-900">Admin</p>
+                    <p className="text-sm font-medium text-gray-900">{displayCreator}</p>
                   </div>
                   <div>
                     <p className="mb-1 text-sm text-gray-500">생성일</p>

--- a/components/test-session-details-content.tsx
+++ b/components/test-session-details-content.tsx
@@ -1,101 +1,181 @@
 "use client"
 
-import { useEffect, useState } from "react"
-import { useRouter } from "next/navigation"
+import { useCallback, useEffect, useState } from "react"
 import { ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
-import Link from "next/link";
-import { getBoard, formatBoardSubmissionLabelKo, type ExamineeBoardEntry } from "@/lib/api/admin";
-import { adminParticipantEvaluationHref } from "@/lib/paths/admin-participant-evaluation";
+import Link from "next/link"
+import { getBoard, getExams, formatBoardSubmissionLabelKo, type Exam } from "@/lib/api/admin"
+import { masterParticipantEvaluationHref } from "@/lib/paths/master-participant-evaluation"
+import { AdminPageHeader } from "@/components/admin-page-header"
+import {
+  getExamDisplayDate,
+  getMasterSessionStatusLabel,
+  mapExamToTestSession,
+  mapMasterParticipantExamStatus,
+} from "@/lib/master-test-sessions"
 
-// Participant type
 type Participant = {
   id: number
   name: string
   phoneNumber: string
-  connectionStatus: string
-  /** 제출 레코드 존재 여부 (요약 통계용) */
+  examStatus: string
   hasSubmission: boolean
-  /** 제출·채점 상태 표시 문구 */
   submissionStatusLabel: string
   tokenUsage: number
 }
 
 interface TestSessionDetailsContentProps {
-  session: {
-    id: number
-    sessionId: string
-    createdBy: string
-    createdAt: string
-    status: string
-    participants: number
-  }
+  examId: number | null
   onBack: () => void
 }
 
-export default function TestSessionDetailsContent({ session, onBack }: TestSessionDetailsContentProps) {
-  const router = useRouter()
+export default function TestSessionDetailsContent({ examId, onBack }: TestSessionDetailsContentProps) {
+  const [exam, setExam] = useState<Exam | null>(null)
+  const [examLoading, setExamLoading] = useState(true)
+  const [examError, setExamError] = useState(false)
   const [participants, setParticipants] = useState<Participant[]>([])
-  const [isLoading, setIsLoading] = useState(true)
+  const [participantsLoading, setParticipantsLoading] = useState(false)
+  const [participantsError, setParticipantsError] = useState(false)
   const [currentPage, setCurrentPage] = useState(1)
   const itemsPerPage = 10
 
-  const fetchParticipants = async () => {
-    setIsLoading(true);
-    try {
-      const board = await getBoard(session.id);
-      const mapped: Participant[] = board.map((p: ExamineeBoardEntry) => ({
-        id: p.examParticipantId,
-        name: p.name,
-        phoneNumber: p.phoneMasked,
-        connectionStatus: p.state === "ENTRANCE" ? "Connected" : "Pending",
-        hasSubmission: p.submitted,
-        submissionStatusLabel: formatBoardSubmissionLabelKo(p),
-        tokenUsage: p.tokenUsed || 0,
-      }));
-      setParticipants(mapped);
-    } catch (error) {
-      console.error("Failed to fetch participants:", error);
-    } finally {
-      setIsLoading(false);
+  const loadExam = useCallback(async () => {
+    if (examId == null) {
+      setExam(null)
+      setExamLoading(false)
+      setExamError(false)
+      return
     }
-  };
+
+    setExamLoading(true)
+    setExamError(false)
+    try {
+      const exams = await getExams()
+      const found = exams.find((e) => e.id === examId) ?? null
+      setExam(found)
+      if (!found) setExamError(true)
+    } catch (e) {
+      console.error("[TestSessionDetails] Failed to load exam:", e)
+      setExam(null)
+      setExamError(true)
+    } finally {
+      setExamLoading(false)
+    }
+  }, [examId])
+
+  const loadParticipants = useCallback(async () => {
+    if (examId == null || !Number.isFinite(examId) || examId <= 0) {
+      setParticipants([])
+      return
+    }
+
+    setParticipantsLoading(true)
+    setParticipantsError(false)
+    try {
+      const board = await getBoard(examId)
+      const examState = exam?.state
+      const mapped: Participant[] = board.map((p) => {
+        const submissionStatusLabel = formatBoardSubmissionLabelKo(p)
+        return {
+          id: p.examParticipantId,
+          name: p.name || "-",
+          phoneNumber: p.phoneMasked || "-",
+          examStatus: mapMasterParticipantExamStatus(examState, {
+            submitted: p.submitted,
+            submissionStatus: p.submissionStatus,
+            submissionStatusLabel,
+            state: p.state,
+          }),
+          hasSubmission: p.submitted === true,
+          submissionStatusLabel,
+          tokenUsage: p.tokenUsed ?? 0,
+        }
+      })
+      setParticipants(mapped)
+    } catch (e) {
+      console.error("[TestSessionDetails] Failed to fetch board:", e)
+      setParticipants([])
+      setParticipantsError(true)
+    } finally {
+      setParticipantsLoading(false)
+    }
+  }, [examId, exam?.state])
 
   useEffect(() => {
-    fetchParticipants();
-    // 30초마다 자동 갱신 (실시간성 확보)
-    const timer = setInterval(fetchParticipants, 30000);
-    return () => clearInterval(timer);
-  }, [session.id]);
+    void loadExam()
+  }, [loadExam])
 
-  // Pagination calculations
-  const totalPages = participants.length > 0 ? Math.ceil(participants.length / itemsPerPage) : 1
-  const startIndex = (currentPage - 1) * itemsPerPage
-  const endIndex = startIndex + itemsPerPage
-  const currentParticipants = participants.slice(startIndex, endIndex)
+  useEffect(() => {
+    if (exam && examId != null) {
+      void loadParticipants()
+      const timer = setInterval(() => {
+        void loadParticipants()
+      }, 30000)
+      return () => clearInterval(timer)
+    }
+    return undefined
+  }, [exam, examId, loadParticipants])
 
-  // Calculate summary stats
+  if (examId == null) {
+    return (
+      <div className="flex h-full flex-1 flex-col">
+        <AdminPageHeader
+          title="테스트 세션 상세 정보"
+          description="이 테스트 세션의 전체 정보와 실시간 진행 상황을 확인하세요."
+        />
+        <main className="flex flex-1 items-center justify-center p-6">
+          <p className="text-sm text-[#6B7280]">세션을 찾을 수 없습니다.</p>
+        </main>
+      </div>
+    )
+  }
+
+  const sessionMeta = exam ? mapExamToTestSession(exam) : null
+  const statusLabel = exam ? getMasterSessionStatusLabel(exam.state) : "-"
+  const displaySessionId = sessionMeta?.sessionId ?? "-"
+  const displayCreatedAt = exam ? getExamDisplayDate(exam) : "-"
+  const participantTotal = exam?.participantCount ?? participants.length
   const submissions = participants.filter((p) => p.hasSubmission).length
   const avgTokenUsage =
     participants.length > 0
       ? Math.round(participants.reduce((sum, p) => sum + p.tokenUsage, 0) / participants.length)
       : 0
 
-  const getStatusBadge = (status: string) => {
-    if (status === "Active") {
+  const totalPages = participants.length > 0 ? Math.ceil(participants.length / itemsPerPage) : 1
+  const startIndex = (currentPage - 1) * itemsPerPage
+  const endIndex = startIndex + itemsPerPage
+  const currentParticipants = participants.slice(startIndex, endIndex)
+
+  const getStatusBadge = (label: string) => {
+    if (label === "진행 중") {
       return <Badge className="bg-green-100 text-green-700 hover:bg-green-100">진행 중</Badge>
     }
-    return <Badge className="bg-gray-100 text-gray-700 hover:bg-gray-100">완료</Badge>
+    if (label === "대기 중") {
+      return <Badge className="bg-yellow-100 text-yellow-700 hover:bg-yellow-100">대기 중</Badge>
+    }
+    if (label === "완료") {
+      return <Badge className="bg-gray-100 text-gray-700 hover:bg-gray-100">완료</Badge>
+    }
+    return <Badge className="bg-gray-100 text-gray-700 hover:bg-gray-100">{label}</Badge>
   }
 
-  const getConnectionBadge = (status: string) => {
-    if (status === "Connected") {
-      return <Badge className="bg-green-100 text-green-700 hover:bg-green-100">연결됨</Badge>
+  const getExamStatusBadge = (status: string) => {
+    if (status === "종료됨") {
+      return <Badge className="bg-gray-100 text-gray-700 hover:bg-gray-100">종료됨</Badge>
     }
-    return <Badge className="bg-yellow-100 text-yellow-700 hover:bg-yellow-100">대기 중</Badge>
+    if (status === "응시 완료") {
+      return <Badge className="bg-green-100 text-green-700 hover:bg-green-100">응시 완료</Badge>
+    }
+    if (status === "응시 중") {
+      return <Badge className="bg-blue-100 text-blue-700 hover:bg-blue-100">응시 중</Badge>
+    }
+    if (status === "대기 중") {
+      return <Badge className="bg-yellow-100 text-yellow-700 hover:bg-yellow-100">대기 중</Badge>
+    }
+    return <Badge className="bg-gray-100 text-gray-700 hover:bg-gray-100">{status}</Badge>
   }
 
   const getSubmissionBadge = (label: string) => {
@@ -120,7 +200,6 @@ export default function TestSessionDetailsContent({ session, onBack }: TestSessi
     return <Badge className="bg-gray-100 text-gray-700 hover:bg-gray-100">{label}</Badge>
   }
 
-  // Generate page numbers for pagination
   const getPageNumbers = () => {
     const pages: number[] = []
     for (let i = 1; i <= totalPages; i++) {
@@ -130,225 +209,219 @@ export default function TestSessionDetailsContent({ session, onBack }: TestSessi
   }
 
   return (
-    <div className="flex flex-col min-h-[calc(100vh-80px)] p-6 gap-6">
-      {/* Page Header */}
-      <div className="flex flex-col gap-2">
-        {/* Back Button */}
+    <div className="flex h-full flex-1 flex-col">
+      <AdminPageHeader
+        title="테스트 세션 상세 정보"
+        description="이 테스트 세션의 전체 정보와 실시간 진행 상황을 확인하세요."
+      />
+
+      <main className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-6">
         <button
+          type="button"
           onClick={onBack}
-          className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 transition-colors w-fit"
-          style={{ fontWeight: 500 }}
+          className="inline-flex w-fit items-center gap-1.5 text-sm font-medium text-[#6B7280] transition-colors hover:text-[#4B5563]"
         >
-          <ArrowLeft className="w-4 h-4" />
+          <ArrowLeft className="h-4 w-4" strokeWidth={1.5} />
           테스트 세션으로 돌아가기
         </button>
 
-        {/* Title and Subtitle */}
-        <div className="mt-2">
-          <h1
-            className="text-gray-900"
-            style={{
-              fontSize: "24px",
-              fontWeight: 600,
-              lineHeight: "32px",
-            }}
-          >
-            테스트 세션 상세 정보
-          </h1>
-          <p
-            className="text-gray-500 mt-1"
-            style={{
-              fontSize: "14px",
-              fontWeight: 400,
-            }}
-          >
-            이 테스트 세션의 전체 정보와 실시간 진행 상황을 확인하세요.
-          </p>
-        </div>
-      </div>
+        {examLoading ? (
+          <p className="py-8 text-center text-sm text-[#6B7280]">세션 정보를 불러오는 중…</p>
+        ) : examError || !exam ? (
+          <p className="py-8 text-center text-sm text-[#6B7280]">세션을 찾을 수 없습니다.</p>
+        ) : (
+          <>
+            <Card className="border border-gray-200 shadow-sm">
+              <CardHeader className="px-6 py-4">
+                <CardTitle style={{ fontSize: "18px", fontWeight: 600, color: "#1A1A1A" }}>
+                  세션 개요
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-6 pb-6 pt-0">
+                <div className="mb-6 grid grid-cols-4 gap-6">
+                  <div>
+                    <p className="mb-1 text-sm text-gray-500">세션 ID</p>
+                    <p className="text-sm font-medium text-gray-900">{displaySessionId}</p>
+                  </div>
+                  <div>
+                    <p className="mb-1 text-sm text-gray-500">생성자</p>
+                    <p className="text-sm font-medium text-gray-900">Admin</p>
+                  </div>
+                  <div>
+                    <p className="mb-1 text-sm text-gray-500">생성일</p>
+                    <p className="text-sm font-medium text-gray-900">{displayCreatedAt}</p>
+                  </div>
+                  <div>
+                    <p className="mb-1 text-sm text-gray-500">상태</p>
+                    <div className="mt-0.5">{getStatusBadge(statusLabel)}</div>
+                  </div>
+                </div>
+                <div className="grid grid-cols-4 gap-6">
+                  <div>
+                    <p className="mb-1 text-sm text-gray-500">참가자</p>
+                    <p className="text-sm font-medium text-gray-900">{participantTotal}명</p>
+                  </div>
+                  <div>
+                    <p className="mb-1 text-sm text-gray-500">제출</p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {participantsError ? "–" : `${submissions}/${participantTotal}`}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="mb-1 text-sm text-gray-500">평균 토큰 사용량</p>
+                    <p className="text-sm font-medium text-gray-900">
+                      {participantsError ? "–" : `${avgTokenUsage.toLocaleString()} 토큰`}
+                    </p>
+                  </div>
+                  <div />
+                </div>
+              </CardContent>
+            </Card>
 
-      {/* Session Overview Card */}
-      <Card className="border border-gray-200 shadow-sm">
-        <CardHeader className="py-4 px-6">
-          <CardTitle
-            style={{
-              fontSize: "18px",
-              fontWeight: 600,
-              color: "#1A1A1A",
-            }}
-          >
-            세션 개요
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="px-6 pb-6 pt-0">
-          {/* Row 1 */}
-          <div className="grid grid-cols-4 gap-6 mb-6">
-            <div>
-              <p className="text-sm text-gray-500 mb-1">세션 ID</p>
-              <p className="text-sm font-medium text-gray-900">{session.sessionId}</p>
-            </div>
-            <div>
-              <p className="text-sm text-gray-500 mb-1">생성자</p>
-              <p className="text-sm font-medium text-gray-900">{session.createdBy}</p>
-            </div>
-            <div>
-              <p className="text-sm text-gray-500 mb-1">생성일</p>
-              <p className="text-sm font-medium text-gray-900">{session.createdAt}</p>
-            </div>
-            <div>
-              <p className="text-sm text-gray-500 mb-1">상태</p>
-              <div className="mt-0.5">{getStatusBadge(session.status)}</div>
-            </div>
-          </div>
+            <Card className="flex flex-1 flex-col border border-gray-200 shadow-sm">
+              <CardHeader className="px-6 py-4">
+                <div>
+                  <CardTitle style={{ fontSize: "18px", fontWeight: 600, color: "#1A1A1A" }}>
+                    참가자
+                  </CardTitle>
+                  <p className="mt-1 text-sm text-gray-500">
+                    이 테스트 세션에 등록된 모든 참가자입니다.
+                  </p>
+                </div>
+              </CardHeader>
+              <CardContent className="flex flex-1 flex-col px-6 pb-6 pt-0">
+                {participantsError ? (
+                  <p className="py-8 text-center text-sm text-[#DC2626]">
+                    참가자 정보를 불러오지 못했습니다.
+                  </p>
+                ) : participantsLoading && participants.length === 0 ? (
+                  <p className="py-8 text-center text-sm text-[#6B7280]">
+                    참가자 목록을 불러오는 중…
+                  </p>
+                ) : participants.length === 0 ? (
+                  <p className="py-8 text-center text-sm text-[#6B7280]">
+                    등록된 참가자가 없습니다.
+                  </p>
+                ) : (
+                  <>
+                    <div className="flex-1">
+                      <Table className="w-full table-fixed">
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead style={{ width: "180px" }}>이름</TableHead>
+                            <TableHead style={{ width: "160px" }}>전화번호</TableHead>
+                            <TableHead style={{ width: "140px" }} className="text-center">
+                              응시 상태
+                            </TableHead>
+                            <TableHead style={{ width: "140px" }} className="text-center">
+                              제출 상태
+                            </TableHead>
+                            <TableHead style={{ width: "120px" }} className="text-center">
+                              토큰 사용량
+                            </TableHead>
+                            <TableHead style={{ width: "100px" }} className="text-right">
+                              작업
+                            </TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {currentParticipants.map((participant) => (
+                            <TableRow key={participant.id}>
+                              <TableCell
+                                className="font-medium"
+                                style={{ width: "180px", fontSize: "14px", color: "#1A1A1A" }}
+                              >
+                                {participant.name}
+                              </TableCell>
+                              <TableCell style={{ width: "160px", fontSize: "14px", color: "#6B7280" }}>
+                                {participant.phoneNumber}
+                              </TableCell>
+                              <TableCell style={{ width: "140px" }} className="text-center">
+                                {getExamStatusBadge(participant.examStatus)}
+                              </TableCell>
+                              <TableCell style={{ width: "140px" }} className="text-center">
+                                {getSubmissionBadge(participant.submissionStatusLabel)}
+                              </TableCell>
+                              <TableCell
+                                style={{ width: "120px", fontSize: "14px", color: "#6B7280" }}
+                                className="text-center"
+                              >
+                                {participant.tokenUsage.toLocaleString()}
+                              </TableCell>
+                              <TableCell style={{ width: "100px" }} className="text-right">
+                                <Link
+                                  href={masterParticipantEvaluationHref({
+                                    examId: examId!,
+                                    participantId: participant.id,
+                                    participantName: participant.name,
+                                  })}
+                                >
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-8 px-2 text-blue-600 hover:bg-blue-50 hover:text-blue-700"
+                                    style={{ fontSize: "14px", fontWeight: 500 }}
+                                  >
+                                    상세 보기
+                                  </Button>
+                                </Link>
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </div>
 
-          {/* Row 2 */}
-          <div className="grid grid-cols-4 gap-6">
-            <div>
-              <p className="text-sm text-gray-500 mb-1">참가자</p>
-              <p className="text-sm font-medium text-gray-900">{session.participants}명</p>
-            </div>
-            <div>
-              <p className="text-sm text-gray-500 mb-1">제출</p>
-              <p className="text-sm font-medium text-gray-900">
-                {submissions}/{session.participants}
-              </p>
-            </div>
-            <div>
-              <p className="text-sm text-gray-500 mb-1">평균 토큰 사용량</p>
-              <p className="text-sm font-medium text-gray-900">{avgTokenUsage.toLocaleString()} 토큰</p>
-            </div>
-            <div></div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Participants Card */}
-      <Card className="border border-gray-200 shadow-sm flex-1 flex flex-col">
-        <CardHeader className="py-4 px-6">
-          <div>
-            <CardTitle
-              style={{
-                fontSize: "18px",
-                fontWeight: 600,
-                color: "#1A1A1A",
-              }}
-            >
-              참가자
-            </CardTitle>
-            <p className="text-sm text-gray-500 mt-1">이 테스트 세션에 등록된 모든 참가자입니다.</p>
-          </div>
-        </CardHeader>
-        <CardContent className="px-6 pb-6 pt-0 flex-1 flex flex-col">
-          {/* Participants Table */}
-          <div className="flex-1">
-            <Table className="table-fixed w-full">
-              <TableHeader>
-                <TableRow>
-                  <TableHead style={{ width: "180px" }}>이름</TableHead>
-                  <TableHead style={{ width: "160px" }}>전화번호</TableHead>
-                  <TableHead style={{ width: "140px" }} className="text-center">
-                    연결 상태
-                  </TableHead>
-                  <TableHead style={{ width: "140px" }} className="text-center">
-                    제출 상태
-                  </TableHead>
-                  <TableHead style={{ width: "120px" }} className="text-center">
-                    토큰 사용량
-                  </TableHead>
-                  <TableHead style={{ width: "100px" }} className="text-right">
-                    작업
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {currentParticipants.map((participant) => (
-                  <TableRow key={participant.id}>
-                    <TableCell className="font-medium" style={{ width: "180px", fontSize: "14px", color: "#1A1A1A" }}>
-                      {participant.name}
-                    </TableCell>
-                    <TableCell style={{ width: "160px", fontSize: "14px", color: "#6B7280" }}>
-                      {participant.phoneNumber}
-                    </TableCell>
-                    <TableCell style={{ width: "140px" }} className="text-center">
-                      {getConnectionBadge(participant.connectionStatus)}
-                    </TableCell>
-                    <TableCell style={{ width: "140px" }} className="text-center">
-                      {getSubmissionBadge(participant.submissionStatusLabel)}
-                    </TableCell>
-                    <TableCell style={{ width: "120px", fontSize: "14px", color: "#6B7280" }} className="text-center">
-                      {participant.tokenUsage.toLocaleString()}
-                    </TableCell>
-                    <TableCell style={{ width: "100px" }} className="text-right">
-                      <Link
-                        href={adminParticipantEvaluationHref({
-                          resultsSegment: session.id,
-                          participantId: participant.id,
-                          from: "master",
-                          participantName: participant.name,
-                          sessionId: session.id,
-                        })}
-                      >
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="text-blue-600 hover:text-blue-700 hover:bg-blue-50 px-2 h-8"
-                          style={{ fontSize: "14px", fontWeight: 500 }}
-                        >
-                          상세 보기
-                        </Button>
-                      </Link>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-
-          {/* Pagination */}
-          {totalPages > 1 && (
-            <div className="flex items-center justify-between mt-4 pt-4 border-t">
-              <p className="text-sm text-gray-500">
-                총 {participants.length}명의 참가자 중 {startIndex + 1}–{Math.min(endIndex, participants.length)} 표시
-              </p>
-              <div className="flex items-center gap-1">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setCurrentPage(currentPage - 1)}
-                  disabled={currentPage === 1}
-                  className="h-8 w-8 p-0"
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                </Button>
-                {getPageNumbers().map((page) => (
-                  <Button
-                    key={page}
-                    variant={currentPage === page ? "default" : "ghost"}
-                    size="sm"
-                    onClick={() => setCurrentPage(page)}
-                    className={`h-8 w-8 p-0 ${
-                      currentPage === page
-                        ? "bg-blue-600 text-white hover:bg-blue-700"
-                        : "text-gray-600 hover:bg-gray-100"
-                    }`}
-                  >
-                    {page}
-                  </Button>
-                ))}
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setCurrentPage(currentPage + 1)}
-                  disabled={currentPage === totalPages}
-                  className="h-8 w-8 p-0"
-                >
-                  <ChevronRight className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                    {totalPages > 1 && (
+                      <div className="mt-4 flex items-center justify-between border-t pt-4">
+                        <p className="text-sm text-gray-500">
+                          총 {participants.length}명의 참가자 중 {startIndex + 1}–
+                          {Math.min(endIndex, participants.length)} 표시
+                        </p>
+                        <div className="flex items-center gap-1">
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setCurrentPage(currentPage - 1)}
+                            disabled={currentPage === 1}
+                            className="h-8 w-8 p-0"
+                          >
+                            <ChevronLeft className="h-4 w-4" />
+                          </Button>
+                          {getPageNumbers().map((page) => (
+                            <Button
+                              key={page}
+                              variant={currentPage === page ? "default" : "ghost"}
+                              size="sm"
+                              onClick={() => setCurrentPage(page)}
+                              className={`h-8 w-8 p-0 ${
+                                currentPage === page
+                                  ? "bg-blue-600 text-white hover:bg-blue-700"
+                                  : "text-gray-600 hover:bg-gray-100"
+                              }`}
+                            >
+                              {page}
+                            </Button>
+                          ))}
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setCurrentPage(currentPage + 1)}
+                            disabled={currentPage === totalPages}
+                            className="h-8 w-8 p-0"
+                          >
+                            <ChevronRight className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                  </>
+                )}
+              </CardContent>
+            </Card>
+          </>
+        )}
+      </main>
     </div>
   )
 }

--- a/components/test-sessions-content.tsx
+++ b/components/test-sessions-content.tsx
@@ -36,6 +36,15 @@ function submissionBadgeClassName(label: string): string {
   return "bg-gray-100 text-gray-700 hover:bg-gray-100"
 }
 
+/** statusLabel 우선, 없으면 Active/Completed 매핑, 그 외 status 원문 */
+function formatSessionStatusDisplay(session: Pick<TestSessionListItem, "status" | "statusLabel">): string {
+  const label = session.statusLabel?.trim()
+  if (label) return label
+  if (session.status === "Active") return "진행 중"
+  if (session.status === "Completed") return "완료"
+  return session.status
+}
+
 export type TestSession = TestSessionListItem
 
 interface Participant {
@@ -338,7 +347,7 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
                           fontFamily: "Inter, system-ui, -apple-system, sans-serif",
                         }}
                       >
-                        {session.status === "Active" ? "진행 중" : session.status === "Completed" ? "완료" : session.statusLabel}
+                        {formatSessionStatusDisplay(session)}
                       </Badge>
                     </TableCell>
                     <TableCell
@@ -562,7 +571,7 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
                     }
                     style={{ fontSize: "12px", fontWeight: 500 }}
                   >
-                    {detailsSession?.status === "Active" ? "진행 중" : detailsSession?.status === "Completed" ? "완료" : detailsSession?.status}
+                    {detailsSession ? formatSessionStatusDisplay(detailsSession) : "–"}
                   </Badge>
                 </div>
               </div>

--- a/components/test-sessions-content.tsx
+++ b/components/test-sessions-content.tsx
@@ -18,7 +18,13 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet"
-import { deleteExam, getBoard, getExams, type Exam, type ExamineeBoardEntry, formatBoardSubmissionLabelKo } from "@/lib/api/admin";
+import { deleteExam, getBoard, getExams, type ExamineeBoardEntry, formatBoardSubmissionLabelKo } from "@/lib/api/admin";
+import { AdminPageHeader } from "@/components/admin-page-header"
+import {
+  mapBoardConnectionStatus,
+  mapExamsToTestSessions,
+  type TestSessionListItem,
+} from "@/lib/master-test-sessions"
 
 function submissionBadgeClassName(label: string): string {
   if (label === "시작 안 함") return "bg-gray-100 text-gray-700 hover:bg-gray-100"
@@ -30,14 +36,7 @@ function submissionBadgeClassName(label: string): string {
   return "bg-gray-100 text-gray-700 hover:bg-gray-100"
 }
 
-export interface TestSession {
-  id: number
-  sessionId: string     // BE의 title을 sessionId로 매핑 (필요시)
-  createdBy: string
-  createdAt: string
-  status: string
-  participants: number
-}
+export type TestSession = TestSessionListItem
 
 interface Participant {
   id: number
@@ -76,15 +75,7 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
     setIsLoading(true)
     try {
       const exams = await getExams()
-      const mapped: TestSession[] = exams.map((exam: Exam) => ({
-        id: exam.id,
-        sessionId: exam.title,
-        createdBy: "Admin",
-        createdAt: exam.startsAt ? exam.startsAt.split("T")[0] : "-",
-        status: ["RUNNING", "IN_PROGRESS"].includes(exam.state) ? "Active" : "Completed",
-        participants: exam.participantCount,
-      }))
-      setTestSessions(mapped)
+      setTestSessions(mapExamsToTestSessions(exams))
     } catch (error) {
       console.error("Failed to fetch exams:", error)
     } finally {
@@ -94,6 +85,7 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
 
   // 2. 특정 시험의 참가자 현황 조회 (Board)
   const fetchParticipants = async (examId: number) => {
+    if (!Number.isFinite(examId) || examId <= 0) return
     setIsParticipantsLoading(true)
     try {
       const board = await getBoard(examId)
@@ -101,7 +93,7 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
         id: participant.examParticipantId,
         name: participant.name,
         phoneNumber: participant.phoneMasked,
-        connectionStatus: participant.state === "ENTRANCE" ? "Connected" : "Disconnected",
+        connectionStatus: mapBoardConnectionStatus(participant.state),
         hasSubmission: participant.submitted,
         submissionStatusLabel: formatBoardSubmissionLabelKo(participant),
         tokenUsage: participant.tokenUsed || 0,
@@ -152,13 +144,14 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
   }
 
   const handleViewDetailsAction = (session: TestSession) => {
-    setDetailsSession(session);
-    setIsDetailsOpen(true);
-    fetchParticipants(session.id);
     if (onViewDetails) {
-      onViewDetails(session);
+      onViewDetails(session)
+      return
     }
-  };
+    setDetailsSession(session)
+    setIsDetailsOpen(true)
+    fetchParticipants(session.id)
+  }
 
   const totalParticipants = participants.length
   const totalParticipantPages = Math.ceil(totalParticipants / participantPageSize)
@@ -189,30 +182,13 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
   }
 
   return (
-    <div className="flex flex-col gap-4 p-6" style={{ minHeight: "calc(100vh - 80px)" }}>
-      {/* Page Header */}
-      <div>
-        <h1
-          className="text-gray-900"
-          style={{
-            fontSize: "24px",
-            fontWeight: 600,
-            lineHeight: "32px",
-          }}
-        >
-          테스트 세션
-        </h1>
-        <p
-          className="text-gray-500 mt-1"
-          style={{
-            fontSize: "14px",
-            fontWeight: 400,
-          }}
-        >
-          플랫폼의 모든 테스트 세션을 관리하고 모니터링합니다.
-        </p>
-      </div>
+    <div className="flex h-full flex-1 flex-col">
+      <AdminPageHeader
+        title="테스트 세션"
+        description="플랫폼의 모든 테스트 세션을 관리하고 모니터링합니다."
+      />
 
+      <main className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
       {/* Main Card */}
       <Card className="flex-1 flex flex-col border border-gray-200 shadow-sm">
         <CardHeader className="py-3 px-6 flex flex-row items-center justify-between">
@@ -362,7 +338,7 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
                           fontFamily: "Inter, system-ui, -apple-system, sans-serif",
                         }}
                       >
-                        {session.status === "Active" ? "진행 중" : session.status === "Completed" ? "완료" : session.status}
+                        {session.status === "Active" ? "진행 중" : session.status === "Completed" ? "완료" : session.statusLabel}
                       </Badge>
                     </TableCell>
                     <TableCell
@@ -762,6 +738,7 @@ export function TestSessionsContent({ onViewDetails }: TestSessionsContentProps)
           </div>
         </SheetContent>
       </Sheet>
+      </main>
     </div>
   )
 }

--- a/components/users-content.tsx
+++ b/components/users-content.tsx
@@ -8,100 +8,22 @@ import {
   type Exam,
   type ExamineeBoardEntry,
 } from "@/lib/api/admin"
-
-type ConnectionStatus = "응시 완료" | "응시 중" | "대기 중" | "종료됨"
-
-const EXAM_ENDED_STATES = new Set(["ENDED", "COMPLETED", "FINISHED", "CLOSED"])
-type SubmissionStatus = "시작 전" | "진행 중" | "채점 중" | "제출 완료"
+import {
+  isAdminUsersSubmissionCountedComplete,
+  resolveAdminUsersConnectionStatus,
+  resolveAdminUsersSubmissionStatus,
+  type AdminUsersConnectionStatus,
+  type AdminUsersSubmissionStatus,
+} from "@/lib/admin-users-participant-status"
 
 interface Participant {
   id: string
   name: string
   examLabel: string
   phone: string
-  connectionStatus: ConnectionStatus
-  submissionStatus: SubmissionStatus
+  connectionStatus: AdminUsersConnectionStatus
+  submissionStatus: AdminUsersSubmissionStatus
   tokenUsage: number
-}
-
-const PARTICIPANT_WAITING_STATES = new Set(["WAITING", "PENDING", "IDLE"])
-
-const PARTICIPANT_EXAMINING_STATES = new Set([
-  "ACTIVE",
-  "RUNNING",
-  "IN_PROGRESS",
-  "ENTRANCE",
-  "STARTED",
-  "JOINED",
-])
-
-function normalizeParticipantState(state: string | null | undefined): string {
-  return (state ?? "").trim().toUpperCase()
-}
-
-function isWaitingParticipant(entry: ExamineeBoardEntry): boolean {
-  const state = normalizeParticipantState(entry.state)
-  if (PARTICIPANT_WAITING_STATES.has(state)) return true
-  if (!state && (entry.tokenUsed ?? 0) === 0 && !entry.submitted) return true
-  return false
-}
-
-function isExamineeInProgress(entry: ExamineeBoardEntry): boolean {
-  if (entry.submitted) return false
-  const state = normalizeParticipantState(entry.state)
-  if (PARTICIPANT_EXAMINING_STATES.has(state)) return true
-  if ((entry.tokenUsed ?? 0) > 0) return true
-  if (
-    entry.submissionStatus === "QUEUED" ||
-    entry.submissionStatus === "RUNNING"
-  ) {
-    return true
-  }
-  return false
-}
-
-function normalizeSubmissionStatus(status: string | null | undefined): string {
-  return (status ?? "").trim().toUpperCase()
-}
-
-function isGradingComplete(entry: ExamineeBoardEntry): boolean {
-  if (!entry.submitted) return false
-  const status = normalizeSubmissionStatus(entry.submissionStatus)
-  if (status === "FAILED") return true
-
-  if (entry.evaluatedAt) return true
-  if (entry.totalScore != null && entry.totalScore !== undefined) {
-    const n = Number(entry.totalScore)
-    if (!Number.isNaN(n)) return true
-  }
-  return false
-}
-
-function isExamEnded(exam: Exam): boolean {
-  const state = (exam.state ?? "").trim().toUpperCase()
-  if (EXAM_ENDED_STATES.has(state)) return true
-  if (exam.endsAt) {
-    const endMs = new Date(exam.endsAt).getTime()
-    if (!Number.isNaN(endMs) && endMs <= Date.now()) return true
-  }
-  return false
-}
-
-function mapConnectionStatus(entry: ExamineeBoardEntry, exam: Exam): ConnectionStatus {
-  if (isExamEnded(exam)) return "종료됨"
-  if (entry.submitted) return "응시 완료"
-  if (isWaitingParticipant(entry)) return "대기 중"
-  if (isExamineeInProgress(entry)) return "응시 중"
-  return "대기 중"
-}
-
-function mapSubmissionStatus(entry: ExamineeBoardEntry): SubmissionStatus {
-  if (!entry.submitted) {
-    if (isExamineeInProgress(entry)) return "진행 중"
-    return "시작 전"
-  }
-  if (isGradingComplete(entry)) return "제출 완료"
-  return "채점 중"
 }
 
 function resolveExamDisplayLabel(exam: Exam): string {
@@ -111,19 +33,20 @@ function resolveExamDisplayLabel(exam: Exam): string {
 }
 
 function mapBoardEntry(entry: ExamineeBoardEntry, exam: Exam): Participant {
+  const connectionStatus = resolveAdminUsersConnectionStatus(entry, exam)
   return {
     id: `${exam.id}-${entry.examParticipantId}`,
     name: entry.name || "–",
     examLabel: resolveExamDisplayLabel(exam),
     phone: entry.phoneMasked || "–",
-    connectionStatus: mapConnectionStatus(entry, exam),
-    submissionStatus: mapSubmissionStatus(entry),
+    connectionStatus,
+    submissionStatus: resolveAdminUsersSubmissionStatus(entry, exam, connectionStatus),
     tokenUsage: entry.tokenUsed ?? 0,
   }
 }
 
-function ConnectionBadge({ status }: { status: ConnectionStatus }) {
-  const styles: Record<ConnectionStatus, string> = {
+function ConnectionBadge({ status }: { status: AdminUsersConnectionStatus }) {
+  const styles: Record<AdminUsersConnectionStatus, string> = {
     "응시 완료": "border-[#16A34A] bg-[#DCFCE7] text-[#16A34A]",
     "응시 중": "border-[#3B82F6] bg-white text-[#3B82F6]",
     "대기 중": "border-[#6B7280] bg-white text-[#6B7280]",
@@ -136,12 +59,15 @@ function ConnectionBadge({ status }: { status: ConnectionStatus }) {
   )
 }
 
-function SubmissionBadge({ status }: { status: SubmissionStatus }) {
-  const styles: Record<SubmissionStatus, string> = {
+function SubmissionBadge({ status }: { status: AdminUsersSubmissionStatus }) {
+  const styles: Record<AdminUsersSubmissionStatus, string> = {
     "시작 전": "bg-[#F3F4F6] text-[#6B7280]",
     "진행 중": "bg-[#E0EDFF] text-[#3B82F6]",
     "채점 중": "bg-[#FEF3C7] text-[#D97706]",
     "제출 완료": "bg-[#DCFCE7] text-[#16A34A]",
+    "채점 완료": "bg-[#DCFCE7] text-[#16A34A]",
+    "미제출": "bg-[#F3F4F6] text-[#6B7280]",
+    "제출 실패": "bg-[#FEE2E2] text-[#DC2626]",
   }
 
   return <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${styles[status]}`}>{status}</span>
@@ -254,7 +180,10 @@ export function UsersContent() {
   const displayEnd = Math.min(endIndex, filteredParticipants.length)
 
   const completedCount = useMemo(
-    () => filteredParticipants.filter((p) => p.submissionStatus === "제출 완료").length,
+    () =>
+      filteredParticipants.filter((p) =>
+        isAdminUsersSubmissionCountedComplete(p.submissionStatus)
+      ).length,
     [filteredParticipants]
   )
 

--- a/components/users-content.tsx
+++ b/components/users-content.tsx
@@ -73,6 +73,10 @@ function SubmissionBadge({ status }: { status: AdminUsersSubmissionStatus }) {
   return <span className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${styles[status]}`}>{status}</span>
 }
 
+/** 참가자 목록 그리드: 좌측(이름·시험) / 중앙(전화·상태) / 우측(토큰) */
+const PARTICIPANT_LIST_GRID_COLS =
+  "grid-cols-[1.2fr_1fr_1fr_minmax(5.5rem,1fr)_minmax(5.5rem,1fr)_minmax(4.5rem,0.95fr)]"
+
 export function UsersContent() {
   const [exams, setExams] = useState<Exam[]>([])
   const [participants, setParticipants] = useState<Participant[]>([])
@@ -245,19 +249,35 @@ export function UsersContent() {
         )}
 
         <div className="flex flex-1 flex-col overflow-hidden rounded-xl border border-[#E5E5E5] bg-white shadow-sm">
-          <div className="grid shrink-0 grid-cols-[1.2fr_1fr_1.2fr_1fr_1fr_1fr] gap-4 border-b border-[#E5E5E5] bg-[#F9FAFB] px-6 py-3">
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">이름</span>
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">시험</span>
-            <span className="text-xs font-semibold uppercase tracking-wide text-[#6B7280]">전화번호</span>
-            <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
-              응시 상태
+          <div
+            className={`grid shrink-0 ${PARTICIPANT_LIST_GRID_COLS} items-center gap-4 border-b border-[#E5E5E5] bg-[#F9FAFB] px-6 py-3`}
+          >
+            <span className="min-w-0 justify-self-start text-left text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+              이름
             </span>
-            <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
-              제출 상태
+            <span className="min-w-0 justify-self-start text-left text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+              시험
             </span>
-            <span className="text-right text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
-              토큰 사용량
-            </span>
+            <div className="flex w-full min-w-0 items-center justify-center">
+              <span className="whitespace-nowrap text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+                전화번호
+              </span>
+            </div>
+            <div className="flex w-full min-w-0 items-center justify-center">
+              <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+                응시 상태
+              </span>
+            </div>
+            <div className="flex w-full min-w-0 items-center justify-center">
+              <span className="text-center text-xs font-semibold uppercase tracking-wide text-[#6B7280]">
+                제출 상태
+              </span>
+            </div>
+            <div className="flex w-full min-w-0 items-center justify-end">
+              <span className="text-right text-xs font-semibold uppercase tracking-wide tabular-nums text-[#6B7280]">
+                토큰 사용량
+              </span>
+            </div>
           </div>
 
           <div className="flex-1 overflow-y-auto">
@@ -279,22 +299,32 @@ export function UsersContent() {
               visibleParticipants.map((participant, index) => (
                 <div
                   key={participant.id}
-                  className={`grid grid-cols-[1.2fr_1fr_1.2fr_1fr_1fr_1fr] items-center gap-4 px-6 py-4 ${
+                  className={`grid ${PARTICIPANT_LIST_GRID_COLS} items-center gap-4 px-6 py-4 ${
                     index !== visibleParticipants.length - 1 ? "border-b border-[#E5E5E5]" : ""
                   }`}
                 >
-                  <span className="text-sm font-medium text-[#1A1A1A]">{participant.name}</span>
-                  <span className="text-sm font-medium text-[#374151]">{participant.examLabel}</span>
-                  <span className="text-sm text-[#6B7280]">{participant.phone}</span>
-                  <div className="flex justify-center">
+                  <span className="min-w-0 justify-self-start text-left text-sm font-medium text-[#1A1A1A]">
+                    {participant.name}
+                  </span>
+                  <span className="min-w-0 justify-self-start text-left text-sm font-medium text-[#374151]">
+                    {participant.examLabel}
+                  </span>
+                  <div className="flex w-full min-w-0 items-center justify-center">
+                    <span className="whitespace-nowrap text-center text-sm text-[#6B7280]">
+                      {participant.phone}
+                    </span>
+                  </div>
+                  <div className="flex w-full min-w-0 items-center justify-center">
                     <ConnectionBadge status={participant.connectionStatus} />
                   </div>
-                  <div className="flex justify-center">
+                  <div className="flex w-full min-w-0 items-center justify-center">
                     <SubmissionBadge status={participant.submissionStatus} />
                   </div>
-                  <span className="text-right text-sm font-medium text-[#1A1A1A]">
-                    {participant.tokenUsage.toLocaleString()}
-                  </span>
+                  <div className="flex w-full min-w-0 items-center justify-end">
+                    <span className="text-right text-sm font-medium tabular-nums text-[#1A1A1A]">
+                      {participant.tokenUsage.toLocaleString()}
+                    </span>
+                  </div>
                 </div>
               ))
             )}

--- a/lib/admin-users-participant-status.ts
+++ b/lib/admin-users-participant-status.ts
@@ -1,0 +1,150 @@
+/**
+ * 관리자 참가자 목록(/admin/users) — 응시·제출 상태 표시 (FE 보정, API 변경 없음).
+ */
+
+import type { Exam, ExamineeBoardEntry } from "@/lib/api/admin"
+import { isExamSessionEnded } from "@/lib/master-test-sessions"
+
+export type AdminUsersConnectionStatus = "응시 완료" | "응시 중" | "대기 중" | "종료됨"
+
+export type AdminUsersSubmissionStatus =
+  | "시작 전"
+  | "진행 중"
+  | "채점 중"
+  | "제출 완료"
+  | "채점 완료"
+  | "미제출"
+  | "제출 실패"
+
+const PARTICIPANT_WAITING_STATES = new Set(["WAITING", "PENDING", "IDLE"])
+
+const PARTICIPANT_EXAMINING_STATES = new Set([
+  "ACTIVE",
+  "RUNNING",
+  "IN_PROGRESS",
+  "ENTRANCE",
+  "STARTED",
+  "JOINED",
+])
+
+function normalizeParticipantState(state: string | null | undefined): string {
+  return (state ?? "").trim().toUpperCase()
+}
+
+function normalizeSubmissionStatus(status: string | null | undefined): string {
+  return (status ?? "").trim().toUpperCase()
+}
+
+export function isAdminExamEnded(exam: Exam): boolean {
+  if (isExamSessionEnded(exam.state)) return true
+  if (exam.endsAt) {
+    const endMs = new Date(exam.endsAt).getTime()
+    if (!Number.isNaN(endMs) && endMs <= Date.now()) return true
+  }
+  return false
+}
+
+function isWaitingParticipant(entry: ExamineeBoardEntry): boolean {
+  const state = normalizeParticipantState(entry.state)
+  if (PARTICIPANT_WAITING_STATES.has(state)) return true
+  if (!state && (entry.tokenUsed ?? 0) === 0 && !entry.submitted) return true
+  return false
+}
+
+/** 응시가 진행 중인지 (시험·응시 종료 전용 판단에는 사용하지 않음) */
+export function isExamineeInProgress(entry: ExamineeBoardEntry): boolean {
+  if (entry.submitted) return false
+  const state = normalizeParticipantState(entry.state)
+  if (PARTICIPANT_EXAMINING_STATES.has(state)) return true
+  if ((entry.tokenUsed ?? 0) > 0) return true
+  if (
+    entry.submissionStatus === "QUEUED" ||
+    entry.submissionStatus === "RUNNING"
+  ) {
+    return true
+  }
+  return false
+}
+
+export function isSubmissionGradingComplete(entry: ExamineeBoardEntry): boolean {
+  if (!entry.submitted) return false
+  const status = normalizeSubmissionStatus(entry.submissionStatus)
+  if (status === "FAILED") return true
+
+  if (entry.evaluatedAt) return true
+  if (entry.totalScore != null && entry.totalScore !== undefined) {
+    const n = Number(entry.totalScore)
+    if (!Number.isNaN(n)) return true
+  }
+  if (status === "DONE") return true
+  return false
+}
+
+function isSubmissionGradingInFlight(entry: ExamineeBoardEntry): boolean {
+  const status = normalizeSubmissionStatus(entry.submissionStatus)
+  return status === "QUEUED" || status === "RUNNING"
+}
+
+export function isExamineeSessionEnded(
+  connectionStatus: AdminUsersConnectionStatus,
+  exam: Exam
+): boolean {
+  if (connectionStatus === "종료됨" || connectionStatus === "응시 완료") {
+    return true
+  }
+  return isAdminExamEnded(exam)
+}
+
+/** 응시 상태 (관리자 참가자 목록) */
+export function resolveAdminUsersConnectionStatus(
+  entry: ExamineeBoardEntry,
+  exam: Exam
+): AdminUsersConnectionStatus {
+  if (isAdminExamEnded(exam)) return "종료됨"
+  if (entry.submitted) return "응시 완료"
+  if (isWaitingParticipant(entry)) return "대기 중"
+  if (isExamineeInProgress(entry)) return "응시 중"
+  return "대기 중"
+}
+
+/**
+ * 제출 상태 — 응시가 종료된 경우 `진행 중`을 쓰지 않음.
+ */
+export function resolveAdminUsersSubmissionStatus(
+  entry: ExamineeBoardEntry,
+  exam: Exam,
+  connectionStatus: AdminUsersConnectionStatus
+): AdminUsersSubmissionStatus {
+  const examineeEnded = isExamineeSessionEnded(connectionStatus, exam)
+
+  if (!examineeEnded) {
+    if (!entry.submitted) {
+      if (isExamineeInProgress(entry)) return "진행 중"
+      return "시작 전"
+    }
+    if (normalizeSubmissionStatus(entry.submissionStatus) === "FAILED") {
+      return "제출 실패"
+    }
+    if (isSubmissionGradingComplete(entry)) return "채점 완료"
+    if (isSubmissionGradingInFlight(entry)) return "채점 중"
+    return "제출 완료"
+  }
+
+  if (!entry.submitted) {
+    return "미제출"
+  }
+
+  if (normalizeSubmissionStatus(entry.submissionStatus) === "FAILED") {
+    return "제출 실패"
+  }
+  if (isSubmissionGradingComplete(entry)) return "채점 완료"
+  if (isSubmissionGradingInFlight(entry)) return "채점 중"
+  return "제출 완료"
+}
+
+/** 제출·채점이 끝난 것으로 집계할 상태 (통계용) */
+export function isAdminUsersSubmissionCountedComplete(
+  status: AdminUsersSubmissionStatus
+): boolean {
+  return status === "제출 완료" || status === "채점 완료"
+}

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -107,6 +107,7 @@ export interface AdminLoginResponse {
 // AdminSignupRequest
 export interface AdminSignupRequest {
   adminNumber: string;
+  displayName: string;
   email: string;
   password: string;
 }
@@ -116,11 +117,26 @@ export interface MeResponse {
   role: string;
   participant: {
     id: number;
-    name: string; // ADMIN의 경우 adminNumber가 들어감
-    phone: string; // ADMIN의 경우 email이 들어감
+    name: string; // ADMIN: displayName(또는 fallback), USER: 참가자 이름
+    phone: string; // ADMIN: email, USER: 전화번호
+    adminNumber?: string | null; // ADMIN 전용
   };
   exam?: null;
   session?: null;
+}
+
+/** GET /api/auth/me 응답에서 관리자 표시 이름 해석 (displayName → adminNumber → "관리자") */
+export function resolveAdminDisplayNameFromMe(response: MeResponse): string {
+  const participant = response.participant;
+  const adminNumber =
+    participant.adminNumber?.trim() ||
+    participant.name?.trim() ||
+    "";
+  return (
+    participant.name?.trim() ||
+    adminNumber ||
+    "관리자"
+  );
 }
 
 // AdminInfo (AdminListResponse에서 사용)
@@ -130,6 +146,11 @@ export interface AdminInfo {
   email: string;
   role: 'ADMIN' | 'MASTER';
   is2faEnabled: boolean;
+  isActive?: boolean;
+  displayName?: string | null;
+  createdAt?: string | null;
+  adminNumberIssuedAt?: string | null;
+  lastLoginAt?: string | null;
 }
 
 // AdminListResponse
@@ -171,6 +192,11 @@ export interface ChangeAdminPasswordRequest {
   newPassword: string;
 }
 
+/** MASTER가 타 관리자 임시 비밀번호 재설정 응답 */
+export interface ResetAdminPasswordByMasterResponse {
+  temporaryPassword: string;
+}
+
 export interface AdminProblem {
   id: number;
   title: string;
@@ -178,6 +204,43 @@ export interface AdminProblem {
   tags: string | string[] | null;
   status: string;
   createdAt: string;
+  updatedAt?: string | null;
+  version?: number | string | null;
+  usedSessionCount?: number | null;
+  usedInSessions?: number | null;
+  sessionCount?: number | null;
+}
+
+export interface ProblemSpecResponse {
+  specId: number;
+  version: number;
+  changelogMd: string | null;
+  publishedAt: string | null;
+}
+
+export interface AdminProblemDetail {
+  id: number;
+  title: string;
+  difficulty: 'EASY' | 'MEDIUM' | 'HARD';
+  tags: string[];
+  version: number;
+  contentMd: string;
+  limits: {
+    timeMs: number;
+    memoryMb: number;
+  };
+  restrictions: {
+    allowedLangs: string[];
+    forbiddenApis: string[];
+  };
+  checker: {
+    type: string;
+  };
+  createdAt: string;
+  updatedAt: string | null;
+  publishedAt: string | null;
+  status: string;
+  usable: boolean;
 }
 
 /**
@@ -293,6 +356,74 @@ export async function getProblems(): Promise<AdminProblem[]> {
     }
 
     throw new NetworkError('문제 목록 조회 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+  }
+}
+
+/**
+ * 문제 스펙(버전) 목록 조회 — GET /api/admin/problems/{problemId}/specs
+ */
+export async function getProblemSpecs(problemId: number): Promise<ProblemSpecResponse[]> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/problems/${problemId}/specs`;
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: getAuthHeaders(),
+      credentials: 'include',
+    });
+
+    const data: BaseResponse<ProblemSpecResponse[]> = await response.json();
+
+    if (!response.ok || data.code !== 'COMMON200' || !data.result) {
+      throw new LoginFailedError(data.message || '문제 스펙 조회에 실패했습니다.', response.status, data.code);
+    }
+
+    return data.result;
+  } catch (error) {
+    if (error instanceof LoginFailedError) {
+      throw error;
+    }
+
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new NetworkError('서버에 연결할 수 없습니다. 네트워크 연결을 확인해주세요.');
+    }
+
+    throw new NetworkError('문제 스펙 조회 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+  }
+}
+
+/**
+ * 문제 상세 조회 — GET /api/admin/problems/{problemId}/detail
+ */
+export async function getProblemDetail(problemId: number): Promise<AdminProblemDetail> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/problems/${problemId}/detail`;
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: getAuthHeaders(),
+      credentials: 'include',
+    });
+
+    const data: BaseResponse<AdminProblemDetail> = await response.json();
+
+    if (!response.ok || data.code !== 'COMMON200' || !data.result) {
+      throw new LoginFailedError(data.message || '문제 상세 조회에 실패했습니다.', response.status, data.code);
+    }
+
+    return data.result;
+  } catch (error) {
+    if (error instanceof LoginFailedError) {
+      throw error;
+    }
+
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new NetworkError('서버에 연결할 수 없습니다. 네트워크 연결을 확인해주세요.');
+    }
+
+    throw new NetworkError('문제 상세 조회 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
   }
 }
 
@@ -504,6 +635,75 @@ export async function updateAdminNumber(
       console.warn('[Update Admin Number] 예상치 못한 오류:', error);
     }
     throw new NetworkError('관리자 번호 상태 변경 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+  }
+}
+
+/**
+ * MASTER가 타 관리자 임시 비밀번호 재설정 API 호출
+ */
+export async function resetAdminPasswordByMaster(
+  adminNumber: string
+): Promise<ResetAdminPasswordByMasterResponse> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/admin-numbers/${encodeURIComponent(adminNumber)}/password/reset`;
+  const isDev = process.env.NODE_ENV === 'development';
+
+  if (isDev) {
+    console.log('[Reset Admin Password By Master] API 호출:', url);
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: 'PATCH',
+      headers: getAuthHeaders(),
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      let errorMessage = '비밀번호 재설정에 실패했습니다.';
+
+      if (response.status === 401) {
+        errorMessage = '인증이 필요합니다. 다시 로그인해주세요.';
+      } else if (response.status === 403) {
+        errorMessage = '마스터 계정만 비밀번호를 재설정할 수 있습니다.';
+      }
+
+      try {
+        const errorText = await response.text();
+        if (errorText) {
+          try {
+            const errorData = JSON.parse(errorText);
+            if (errorData.message) {
+              errorMessage = errorData.message;
+            }
+          } catch {
+            // ignore
+          }
+        }
+      } catch {
+        // ignore
+      }
+
+      throw new LoginFailedError(errorMessage, response.status);
+    }
+
+    const data: BaseResponse<ResetAdminPasswordByMasterResponse> = await response.json();
+
+    if (data.code !== 'COMMON200' || !data.result?.temporaryPassword) {
+      throw new LoginFailedError(data.message || '비밀번호 재설정에 실패했습니다.');
+    }
+
+    return data.result;
+  } catch (error) {
+    if (error instanceof LoginFailedError) {
+      throw error;
+    }
+
+    if (error instanceof TypeError && error.message.includes('fetch')) {
+      throw new NetworkError('서버에 연결할 수 없습니다. 네트워크 연결을 확인해주세요.');
+    }
+
+    throw new NetworkError('비밀번호 재설정 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
   }
 }
 

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -117,26 +117,65 @@ export interface MeResponse {
   role: string;
   participant: {
     id: number;
-    name: string; // ADMIN: displayName(또는 fallback), USER: 참가자 이름
+    /** ADMIN: resolveDisplayName() 결과, USER: 참가자 이름 */
+    name: string;
     phone: string; // ADMIN: email, USER: 전화번호
     adminNumber?: string | null; // ADMIN 전용
+    /** ADMIN: DB display_name 원본 (nullable). USER는 null/미포함 */
+    displayName?: string | null;
   };
   exam?: null;
   session?: null;
 }
 
-/** GET /api/auth/me 응답에서 관리자 표시 이름 해석 (displayName → adminNumber → "관리자") */
+function pickFirstNonEmpty(
+  ...values: (string | null | undefined)[]
+): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+/**
+ * GET /api/auth/me — 관리자 표시 이름
+ * 우선순위: displayName → name(관리자번호와 다를 때) → name → adminNumber → "알 수 없음"
+ */
 export function resolveAdminDisplayNameFromMe(response: MeResponse): string {
   const participant = response.participant;
-  const adminNumber =
-    participant.adminNumber?.trim() ||
-    participant.name?.trim() ||
-    "";
-  return (
-    participant.name?.trim() ||
-    adminNumber ||
-    "관리자"
-  );
+  const displayName = pickFirstNonEmpty(participant.displayName);
+  const name = pickFirstNonEmpty(participant.name);
+  const adminNumber = pickFirstNonEmpty(participant.adminNumber);
+
+  if (displayName) return displayName;
+  if (name && adminNumber && name !== adminNumber) return name;
+  if (name) return name;
+  if (adminNumber) return adminNumber;
+  return "알 수 없음";
+}
+
+/** GET /api/auth/me — 관리자 번호 필드 (name fallback 사용하지 않음) */
+export function resolveAdminNumberFromMe(response: MeResponse): string {
+  return pickFirstNonEmpty(response.participant.adminNumber) ?? "";
+}
+
+/** 관리자 목록/상세 — 표시 이름 (displayName 원본 우선, 번호와 동일한 값은 이름으로 취급하지 않음) */
+export function resolveAdminAccountDisplayName(account: {
+  displayName?: string | null;
+  adminNumber: string;
+}): string {
+  const displayName = pickFirstNonEmpty(account.displayName);
+  const adminNumber = pickFirstNonEmpty(account.adminNumber);
+
+  if (displayName && adminNumber && displayName !== adminNumber) {
+    return displayName;
+  }
+  if (displayName && !adminNumber) {
+    return displayName;
+  }
+  if (adminNumber) return adminNumber;
+  return "알 수 없음";
 }
 
 // AdminInfo (AdminListResponse에서 사용)
@@ -1190,6 +1229,8 @@ export interface Exam {
   endsAt: string;   // ISO 8601 형식
   version: number;
   createdBy: number;
+  /** 생성 관리자 표시 이름 (GET /api/admin/exams) */
+  creatorName?: string | null;
   participantCount: number;
   completedCount: number;
   entryCode?: string; // 입장 코드 (선택적)

--- a/lib/api/master-admin-accounts.ts
+++ b/lib/api/master-admin-accounts.ts
@@ -7,6 +7,7 @@ import {
   issueAdminNumber,
   updateAdminNumber,
   resetAdminPasswordByMaster,
+  resolveAdminAccountDisplayName,
   LoginFailedError,
   NetworkError,
   type AdminInfo,
@@ -67,7 +68,10 @@ export function mapAdminApiRecordToAccount(record: MasterAdminApiRecord): Master
   return {
     id: record.id,
     adminNumber: record.adminNumber,
-    displayName: record.displayName?.trim() || record.adminNumber,
+    displayName: resolveAdminAccountDisplayName({
+      displayName: record.displayName,
+      adminNumber: record.adminNumber,
+    }),
     email: record.email,
     role: record.role,
     is2faEnabled: record.is2faEnabled,

--- a/lib/api/master-admin-accounts.ts
+++ b/lib/api/master-admin-accounts.ts
@@ -1,0 +1,168 @@
+/**
+ * Master 관리자 계정 관리 API (/master/admin-accounts)
+ */
+
+import {
+  getAllAdmins,
+  issueAdminNumber,
+  updateAdminNumber,
+  resetAdminPasswordByMaster,
+  LoginFailedError,
+  NetworkError,
+  type AdminInfo,
+  type AdminListResponse,
+  type AdminNumberIssueRequest,
+  type AdminNumberResponse,
+} from '@/lib/api/admin';
+import { formatSessionDateTime } from '@/lib/master-test-sessions';
+
+export { LoginFailedError, NetworkError };
+
+/** API 원본 관리자 정보 (GET /api/admin/admin-numbers/admins) */
+export type MasterAdminApiRecord = AdminInfo & {
+  isActive?: boolean;
+  createdAt?: string | null;
+  adminNumberIssuedAt?: string | null;
+  lastLoginAt?: string | null;
+};
+
+/** 화면 표시용 관리자 계정 */
+export type MasterAdminAccount = {
+  id: number;
+  adminNumber: string;
+  displayName: string;
+  email: string;
+  role: 'ADMIN' | 'MASTER';
+  is2faEnabled: boolean;
+  isActive: boolean;
+  status: '활성화' | '비활성화';
+  lastLogin: string | null;
+  createdAt: string | null;
+  passwordStatus: string;
+};
+
+export type MasterAdminAccountsListResult = {
+  admins: MasterAdminAccount[];
+};
+
+function formatDisplayDate(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function mapActiveToStatus(isActive: boolean): '활성화' | '비활성화' {
+  return isActive ? '활성화' : '비활성화';
+}
+
+export function mapAdminApiRecordToAccount(record: MasterAdminApiRecord): MasterAdminAccount {
+  const isActive = record.isActive !== false;
+  return {
+    id: record.id,
+    adminNumber: record.adminNumber,
+    displayName: record.displayName?.trim() || record.adminNumber,
+    email: record.email,
+    role: record.role,
+    is2faEnabled: record.is2faEnabled,
+    isActive,
+    status: mapActiveToStatus(isActive),
+    lastLogin: record.lastLoginAt
+      ? formatSessionDateTime(record.lastLoginAt)
+      : null,
+    createdAt: formatDisplayDate(record.createdAt ?? null),
+    passwordStatus: '비밀번호 설정됨',
+  };
+}
+
+export function mapAdminListResponse(response: AdminListResponse): MasterAdminAccountsListResult {
+  const admins = (response.admins as MasterAdminApiRecord[]).map(mapAdminApiRecordToAccount);
+  return { admins: sortMasterAdminAccounts(admins) };
+}
+
+/**
+ * MASTER를 최상단에 두고, MASTER끼리는 adminNumber(숫자 인식) → createdAt 순으로 정렬.
+ * ADMIN은 API에서 내려온 상대 순서를 유지한다.
+ */
+export function sortMasterAdminAccounts(
+  accounts: readonly MasterAdminAccount[]
+): MasterAdminAccount[] {
+  const masters: MasterAdminAccount[] = [];
+  const admins: MasterAdminAccount[] = [];
+
+  for (const account of accounts) {
+    if (account.role === 'MASTER') {
+      masters.push(account);
+    } else {
+      admins.push(account);
+    }
+  }
+
+  masters.sort((a, b) => {
+    const byNumber = a.adminNumber.localeCompare(b.adminNumber, undefined, {
+      numeric: true,
+      sensitivity: 'base',
+    });
+    if (byNumber !== 0) return byNumber;
+
+    const aCreated = a.createdAt ?? '';
+    const bCreated = b.createdAt ?? '';
+    return aCreated.localeCompare(bCreated, undefined, { numeric: true });
+  });
+
+  return [...masters, ...admins];
+}
+
+/** 관리자 목록 조회 */
+export async function fetchMasterAdminAccounts(): Promise<MasterAdminAccountsListResult> {
+  const response = await getAllAdmins();
+  return mapAdminListResponse(response);
+}
+
+/** 관리자 활성/비활성 상태 변경 */
+export async function updateMasterAdminAccountStatus(
+  account: MasterAdminAccount
+): Promise<MasterAdminAccount> {
+  const nextActive = !account.isActive;
+  await updateAdminNumber(account.adminNumber, {
+    active: nextActive,
+  });
+  return {
+    ...account,
+    isActive: nextActive,
+    status: mapActiveToStatus(nextActive),
+  };
+}
+
+/** 신규 관리자 번호 발급 (가입용) */
+export async function issueMasterAdminNumber(
+  request: AdminNumberIssueRequest = {}
+): Promise<AdminNumberResponse> {
+  return issueAdminNumber(request);
+}
+
+/** MASTER가 타 관리자 임시 비밀번호 재설정 */
+export async function resetMasterAdminPassword(
+  account: MasterAdminAccount
+): Promise<{ temporaryPassword: string }> {
+  const result = await resetAdminPasswordByMaster(account.adminNumber);
+  return { temporaryPassword: result.temporaryPassword };
+}
+
+/**
+ * TODO(BE): 관리자 계정 삭제 API 미구현
+ */
+export async function deleteMasterAdminAccount(
+  _account: MasterAdminAccount
+): Promise<void> {
+  throw new LoginFailedError(
+    '관리자 삭제 API가 아직 제공되지 않습니다. 백엔드 연동 후 호출해 주세요.',
+    501
+  );
+}

--- a/lib/api/master-admin-accounts.ts
+++ b/lib/api/master-admin-accounts.ts
@@ -38,7 +38,12 @@ export type MasterAdminAccount = {
   isActive: boolean;
   status: '활성화' | '비활성화';
   lastLogin: string | null;
+  /** 정렬용 — lastLoginAt ISO의 getTime(), 없거나 invalid면 null */
+  lastLoginSortKey: number | null;
+  /** UI 표시용 (locale 포맷) */
   createdAt: string | null;
+  /** 정렬용 — 원본 ISO의 getTime(), 없거나 invalid면 null */
+  createdAtSortKey: number | null;
   passwordStatus: string;
 };
 
@@ -63,6 +68,19 @@ function mapActiveToStatus(isActive: boolean): '활성화' | '비활성화' {
   return isActive ? '활성화' : '비활성화';
 }
 
+function parseIsoSortKey(iso: string | null | undefined): number | null {
+  if (!iso?.trim()) return null;
+  const time = new Date(iso).getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+function compareAdminNumber(a: MasterAdminAccount, b: MasterAdminAccount): number {
+  return a.adminNumber.localeCompare(b.adminNumber, undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
+}
+
 export function mapAdminApiRecordToAccount(record: MasterAdminApiRecord): MasterAdminAccount {
   const isActive = record.isActive !== false;
   return {
@@ -80,7 +98,9 @@ export function mapAdminApiRecordToAccount(record: MasterAdminApiRecord): Master
     lastLogin: record.lastLoginAt
       ? formatSessionDateTime(record.lastLoginAt)
       : null,
+    lastLoginSortKey: parseIsoSortKey(record.lastLoginAt),
     createdAt: formatDisplayDate(record.createdAt ?? null),
+    createdAtSortKey: parseIsoSortKey(record.createdAt),
     passwordStatus: '비밀번호 설정됨',
   };
 }
@@ -91,8 +111,8 @@ export function mapAdminListResponse(response: AdminListResponse): MasterAdminAc
 }
 
 /**
- * MASTER를 최상단에 두고, MASTER끼리는 adminNumber(숫자 인식) → createdAt 순으로 정렬.
- * ADMIN은 API에서 내려온 상대 순서를 유지한다.
+ * MASTER를 최상단에 두고, MASTER끼리는 adminNumber → createdAtSortKey 순.
+ * 일반 관리자(ADMIN)는 lastLoginSortKey 내림차순(최신 로그인 우선), 동률·미로그인은 adminNumber 등 fallback.
  */
 export function sortMasterAdminAccounts(
   accounts: readonly MasterAdminAccount[]
@@ -108,16 +128,23 @@ export function sortMasterAdminAccounts(
     }
   }
 
+  const lastLoginDescKey = (key: number | null) => key ?? Number.NEGATIVE_INFINITY;
+
   masters.sort((a, b) => {
-    const byNumber = a.adminNumber.localeCompare(b.adminNumber, undefined, {
-      numeric: true,
-      sensitivity: 'base',
-    });
+    const byNumber = compareAdminNumber(a, b);
+    if (byNumber !== 0) return byNumber;
+    return (a.createdAtSortKey ?? 0) - (b.createdAtSortKey ?? 0);
+  });
+
+  admins.sort((a, b) => {
+    const byLastLogin =
+      lastLoginDescKey(b.lastLoginSortKey) - lastLoginDescKey(a.lastLoginSortKey);
+    if (byLastLogin !== 0) return byLastLogin;
+
+    const byNumber = compareAdminNumber(a, b);
     if (byNumber !== 0) return byNumber;
 
-    const aCreated = a.createdAt ?? '';
-    const bCreated = b.createdAt ?? '';
-    return aCreated.localeCompare(bCreated, undefined, { numeric: true });
+    return (a.createdAtSortKey ?? 0) - (b.createdAtSortKey ?? 0);
   });
 
   return [...masters, ...admins];

--- a/lib/master-dashboard-kpi.ts
+++ b/lib/master-dashboard-kpi.ts
@@ -1,0 +1,147 @@
+import type { Exam, ExamineeBoardEntry, SystemStatusServiceItem } from "@/lib/api/admin"
+
+/** 진행 중으로 집계할 시험 상태 (Admin dashboard / test-sessions 와 동일) */
+export const ACTIVE_EXAM_STATES = new Set(["RUNNING", "IN_PROGRESS", "ACTIVE"])
+
+/** 오늘 참여로 볼 참가자 상태 */
+const PARTICIPANT_PARTICIPATED_STATES = new Set([
+  "ENTRANCE",
+  "ACTIVE",
+  "RUNNING",
+  "IN_PROGRESS",
+  "STARTED",
+  "JOINED",
+])
+
+export type MasterSystemStatusTone = "success" | "warning" | "danger" | "connectionFailed"
+
+export type MasterSystemStatusSource =
+  | { type: "fetch_failed" }
+  | { type: "services"; services: SystemStatusServiceItem[] }
+
+export type MasterSystemStatusDisplay = {
+  label: string
+  valueColor: string
+  iconColor: string
+  iconBg: string
+}
+
+export function isActiveExam(exam: Exam): boolean {
+  return ACTIVE_EXAM_STATES.has((exam.state ?? "").trim().toUpperCase())
+}
+
+export function countActiveExamSessions(exams: Exam[]): number {
+  return exams.filter(isActiveExam).length
+}
+
+export function isSameLocalCalendarDay(
+  iso: string | null | undefined,
+  ref: Date = new Date()
+): boolean {
+  if (!iso) return false
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return false
+  return (
+    d.getFullYear() === ref.getFullYear() &&
+    d.getMonth() === ref.getMonth() &&
+    d.getDate() === ref.getDate()
+  )
+}
+
+/**
+ * 오늘 참가자 수 — board API 기준
+ * - 오늘 제출/채점 활동(submittedAt, evaluatedAt)
+ * - 진행 중 시험 또는 오늘 시작된 시험에서 입장·응시 중인 참가자
+ */
+export function countTodayParticipants(
+  exams: Exam[],
+  boards: ExamineeBoardEntry[][]
+): number {
+  const seen = new Set<number>()
+
+  exams.forEach((exam, index) => {
+    const entries = boards[index] ?? []
+    const examActive = isActiveExam(exam)
+    const examStartsToday = isSameLocalCalendarDay(exam.startsAt)
+
+    for (const entry of entries) {
+      if (
+        isSameLocalCalendarDay(entry.submittedAt) ||
+        isSameLocalCalendarDay(entry.evaluatedAt)
+      ) {
+        seen.add(entry.examParticipantId)
+        continue
+      }
+
+      if (!examActive && !examStartsToday) continue
+
+      const state = (entry.state ?? "").trim().toUpperCase()
+      if (PARTICIPANT_PARTICIPATED_STATES.has(state)) {
+        seen.add(entry.examParticipantId)
+        continue
+      }
+
+      if ((entry.tokenUsed ?? 0) > 0) {
+        seen.add(entry.examParticipantId)
+      }
+    }
+  })
+
+  return seen.size
+}
+
+const SYSTEM_STATUS_STYLES: Record<MasterSystemStatusTone, MasterSystemStatusDisplay> = {
+  success: {
+    label: "운영 중",
+    valueColor: "#22C55E",
+    iconColor: "#22C55E",
+    iconBg: "#F0FDF4",
+  },
+  warning: {
+    label: "부분 장애",
+    valueColor: "#D97706",
+    iconColor: "#D97706",
+    iconBg: "#FFFBEB",
+  },
+  danger: {
+    label: "점검 중",
+    valueColor: "#DC2626",
+    iconColor: "#DC2626",
+    iconBg: "#FEF2F2",
+  },
+  connectionFailed: {
+    label: "연결 실패",
+    valueColor: "#6B7280",
+    iconColor: "#6B7280",
+    iconBg: "#F3F4F6",
+  },
+}
+
+/**
+ * server-status API 결과 → Master KPI 카드 문구
+ * - fetch_failed: getSystemStatus() 요청 자체 실패
+ * - services: 응답 수신 후 api / database / ai 상태 집계
+ */
+export function deriveMasterSystemStatusDisplay(
+  source: MasterSystemStatusSource
+): MasterSystemStatusDisplay {
+  if (source.type === "fetch_failed") {
+    return SYSTEM_STATUS_STYLES.connectionFailed
+  }
+
+  const services = source.services
+  if (!services.length) {
+    return SYSTEM_STATUS_STYLES.danger
+  }
+
+  const statuses = services.map((s) => (s.status ?? "").trim().toUpperCase())
+  const upCount = statuses.filter((s) => s === "UP").length
+
+  if (upCount === statuses.length) {
+    return SYSTEM_STATUS_STYLES.success
+  }
+  if (upCount === 0) {
+    return SYSTEM_STATUS_STYLES.danger
+  }
+  return SYSTEM_STATUS_STYLES.warning
+}

--- a/lib/master-problems.ts
+++ b/lib/master-problems.ts
@@ -1,0 +1,181 @@
+import type { AdminProblem, AdminProblemDetail } from "@/lib/api/admin"
+
+export type ProblemDifficultyKo = "쉬움" | "중간" | "어려움"
+
+export type MasterProblemListItem = {
+  id: number
+  title: string
+  titleWithVersion: string
+  versionLabel: string
+  difficulty: ProblemDifficultyKo
+  difficultyRaw: string
+  tags: string[]
+  lastUpdatedLabel: string
+  lastUpdatedIso: string | null
+  status: string
+  createdAt: string
+  searchText: string
+}
+
+export type MasterProblemDetail = MasterProblemListItem & {
+  contentMd: string
+  restrictionsInfo: string
+  usable: boolean
+}
+
+export function mapDifficultyToKo(
+  difficulty: AdminProblem["difficulty"] | string | null | undefined
+): ProblemDifficultyKo {
+  const normalized = String(difficulty ?? "").toUpperCase()
+  if (normalized === "MEDIUM") return "중간"
+  if (normalized === "HARD") return "어려움"
+  return "쉬움"
+}
+
+export function parseProblemTags(tags: AdminProblem["tags"] | string[] | null | undefined): string[] {
+  if (tags == null) return []
+  if (Array.isArray(tags)) {
+    return tags.map((t) => String(t).trim()).filter(Boolean)
+  }
+  const raw = String(tags).trim()
+  if (!raw) return []
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (Array.isArray(parsed)) {
+      return parsed.map((t) => String(t).trim()).filter(Boolean)
+    }
+  } catch {
+    if (raw.includes(",")) {
+      return raw.split(",").map((t) => t.trim()).filter(Boolean)
+    }
+  }
+  return [raw]
+}
+
+/** 1 → v1.0, "1.0" → v1.0, 이미 v1.0이면 유지 */
+export function formatProblemVersionLabel(
+  version: number | string | null | undefined
+): string {
+  if (version == null || String(version).trim() === "") return "v1.0"
+
+  const s = String(version).trim()
+  const numericPart = s.startsWith("v") || s.startsWith("V") ? s.slice(1) : s
+  const n = Number(numericPart)
+
+  if (Number.isFinite(n)) {
+    return `v${n.toFixed(1)}`
+  }
+
+  return s.startsWith("v") || s.startsWith("V") ? s : `v${s}`
+}
+
+export function formatProblemLastUpdated(
+  updatedAt: string | null | undefined,
+  createdAt: string | null | undefined
+): { label: string; iso: string | null } {
+  const iso = updatedAt?.trim() || createdAt?.trim() || null
+  if (!iso) return { label: "-", iso: null }
+
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return { label: iso.split("T")[0] ?? "-", iso }
+
+  const now = new Date()
+  const diffMs = now.getTime() - d.getTime()
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+
+  if (days < 1) return { label: "오늘", iso }
+  if (days === 1) return { label: "1일 전", iso }
+  if (days < 7) return { label: `${days}일 전`, iso }
+  if (days < 30) {
+    const weeks = Math.floor(days / 7)
+    return { label: `${weeks}주 전`, iso }
+  }
+
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return { label: `${y}-${m}-${day}`, iso }
+}
+
+function buildRestrictionsInfo(detail: AdminProblemDetail): string {
+  const parts: string[] = []
+  if (detail.limits) {
+    parts.push(`시간 제한 ${detail.limits.timeMs}ms · 메모리 ${detail.limits.memoryMb}MB`)
+  }
+  if (detail.restrictions?.allowedLangs?.length) {
+    parts.push(`허용 언어: ${detail.restrictions.allowedLangs.join(", ")}`)
+  }
+  if (detail.restrictions?.forbiddenApis?.length) {
+    parts.push(`금지 API: ${detail.restrictions.forbiddenApis.join(", ")}`)
+  }
+  if (detail.checker?.type) {
+    parts.push(`채점 방식: ${detail.checker.type}`)
+  }
+  return parts.length > 0 ? parts.join("\n") : "정보 없음"
+}
+
+export function mapAdminProblemToMasterListItem(problem: AdminProblem): MasterProblemListItem {
+  const tags = parseProblemTags(problem.tags)
+  const difficulty = mapDifficultyToKo(problem.difficulty)
+  const versionLabel = formatProblemVersionLabel(problem.version ?? 1)
+  const { label: lastUpdatedLabel, iso: lastUpdatedIso } = formatProblemLastUpdated(
+    problem.updatedAt,
+    problem.createdAt
+  )
+  const searchText = [problem.title, versionLabel, difficulty, ...tags, problem.status]
+    .join(" ")
+    .toLowerCase()
+
+  return {
+    id: problem.id,
+    title: problem.title,
+    titleWithVersion: `${problem.title} ${versionLabel}`,
+    versionLabel,
+    difficulty,
+    difficultyRaw: problem.difficulty,
+    tags,
+    lastUpdatedLabel,
+    lastUpdatedIso,
+    status: problem.status,
+    createdAt: problem.createdAt,
+    searchText,
+  }
+}
+
+export function buildMasterProblemDetailFromApi(
+  listItem: MasterProblemListItem,
+  detail: AdminProblemDetail
+): MasterProblemDetail {
+  const versionLabel = formatProblemVersionLabel(detail.version)
+  const { label: lastUpdatedLabel, iso: lastUpdatedIso } = formatProblemLastUpdated(
+    detail.updatedAt ?? detail.publishedAt,
+    detail.createdAt
+  )
+  const tags = parseProblemTags(detail.tags)
+
+  return {
+    ...listItem,
+    id: detail.id,
+    title: detail.title,
+    titleWithVersion: `${detail.title} ${versionLabel}`,
+    versionLabel,
+    difficulty: mapDifficultyToKo(detail.difficulty),
+    difficultyRaw: detail.difficulty,
+    tags,
+    lastUpdatedLabel,
+    lastUpdatedIso,
+    status: detail.status,
+    contentMd: detail.contentMd?.trim() ?? "",
+    restrictionsInfo: buildRestrictionsInfo(detail),
+    usable: detail.usable,
+  }
+}
+
+export function filterMasterProblems(
+  problems: MasterProblemListItem[],
+  query: string
+): MasterProblemListItem[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return problems
+  return problems.filter((p) => p.searchText.includes(q))
+}

--- a/lib/master-test-sessions.ts
+++ b/lib/master-test-sessions.ts
@@ -1,0 +1,234 @@
+import type { Exam, ExamineeBoardEntry } from "@/lib/api/admin"
+
+/** Test Sessions 목록 행 */
+export type TestSessionListItem = {
+  id: number
+  sessionId: string
+  createdBy: string
+  createdAt: string
+  /** 필터용: Active | Completed */
+  status: string
+  /** UI 표시용 한글 */
+  statusLabel: string
+  participants: number
+  sortKey: number
+  rawState: string
+  startsAt: string
+}
+
+/** Master Dashboard · Test Sessions 목록 공통 표시 모델 */
+export type MasterRecentSession = {
+  id: number
+  sessionId: string
+  createdAt: string
+  participants: number
+  status: string
+  sortKey: number
+}
+
+export const RECENT_SESSIONS_DISPLAY_LIMIT = 4
+
+type ExamWithOptionalCreatedAt = Exam & { createdAt?: string | null }
+
+/** URL params → examId (유효하지 않으면 null) */
+export function parseExamIdParam(raw: string | undefined | null): number | null {
+  if (raw == null || String(raw).trim() === "") return null
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n <= 0) return null
+  return Math.floor(n)
+}
+
+/** 정렬: createdAt 우선, 없으면 startsAt */
+export function getExamSortTimestamp(exam: Exam): number {
+  const extended = exam as ExamWithOptionalCreatedAt
+  const iso = extended.createdAt?.trim() || exam.startsAt?.trim() || ""
+  if (!iso) return 0
+  const t = new Date(iso).getTime()
+  return Number.isNaN(t) ? 0 : t
+}
+
+export function sortExamsByCreatedAtDesc(exams: Exam[]): Exam[] {
+  return [...exams].sort((a, b) => getExamSortTimestamp(b) - getExamSortTimestamp(a))
+}
+
+export function formatSessionCreatedAt(iso: string | null | undefined): string {
+  if (!iso) return "-"
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) {
+    return iso.split("T")[0] ?? "-"
+  }
+  return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`
+}
+
+/** 상세 화면용 날짜·시간 */
+export function formatSessionDateTime(iso: string | null | undefined): string {
+  if (!iso) return "-"
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso.replace("T", " ").slice(0, 16)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  const h = String(d.getHours()).padStart(2, "0")
+  const min = String(d.getMinutes()).padStart(2, "0")
+  return `${y}-${m}-${day} ${h}:${min}`
+}
+
+export function getExamDisplayDate(exam: Exam): string {
+  const extended = exam as ExamWithOptionalCreatedAt
+  const iso = extended.createdAt?.trim() || exam.startsAt?.trim()
+  return formatSessionDateTime(iso)
+}
+
+/** 목록 필터용 Active / Completed */
+export function getTestSessionFilterStatus(state: string | null | undefined): string {
+  const normalized = (state ?? "").trim().toUpperCase()
+  if (["RUNNING", "IN_PROGRESS", "ACTIVE"].includes(normalized)) return "Active"
+  return "Completed"
+}
+
+export function mapExamToTestSession(exam: Exam): TestSessionListItem {
+  const title = (exam.title ?? "").trim()
+  return {
+    id: exam.id,
+    sessionId: title || `시험 #${exam.id}`,
+    createdBy: "Admin",
+    createdAt: formatSessionCreatedAt(
+      (exam as ExamWithOptionalCreatedAt).createdAt ?? exam.startsAt
+    ),
+    status: getTestSessionFilterStatus(exam.state),
+    statusLabel: getMasterSessionStatusLabel(exam.state),
+    participants: exam.participantCount ?? 0,
+    sortKey: getExamSortTimestamp(exam),
+    rawState: exam.state ?? "",
+    startsAt: exam.startsAt ?? "",
+  }
+}
+
+export function mapExamsToTestSessions(exams: Exam[]): TestSessionListItem[] {
+  return sortExamsByCreatedAtDesc(exams).map(mapExamToTestSession)
+}
+
+/** 세션 종료 여부 (completed / ended / finished 계열) */
+export function isExamSessionEnded(state: string | null | undefined): boolean {
+  const normalized = (state ?? "").trim().toUpperCase()
+  return ["ENDED", "COMPLETED", "FINISHED", "CLOSED", "DONE"].includes(normalized)
+}
+
+/** 세션 진행 중 여부 (active / running / in_progress 계열) */
+export function isExamSessionActive(state: string | null | undefined): boolean {
+  const normalized = (state ?? "").trim().toUpperCase()
+  return ["RUNNING", "IN_PROGRESS", "ACTIVE"].includes(normalized)
+}
+
+export type ParticipantExamStatusInput = {
+  submitted?: boolean
+  submissionStatus?: string | null
+  submissionStatusLabel?: string
+  state?: string | null
+}
+
+function isParticipantSubmissionComplete(input: ParticipantExamStatusInput): boolean {
+  if (input.submitted === true) return true
+  const label = (input.submissionStatusLabel ?? "").trim()
+  if (label === "제출됨" || label.startsWith("채점 완료")) return true
+  const st = (input.submissionStatus ?? "").trim().toUpperCase()
+  return st === "DONE"
+}
+
+function isParticipantInProgress(input: ParticipantExamStatusInput): boolean {
+  const label = (input.submissionStatusLabel ?? "").trim()
+  if (label === "진행 중" || label === "제출·채점 중") return true
+  const st = (input.state ?? "").trim().toUpperCase()
+  return st === "ENTRANCE"
+}
+
+/** Master 테스트 세션 상세 — 참가자 응시 상태 */
+export function mapMasterParticipantExamStatus(
+  examState: string | null | undefined,
+  input: ParticipantExamStatusInput
+): string {
+  if (isExamSessionEnded(examState)) {
+    return "종료됨"
+  }
+
+  if (isExamSessionActive(examState)) {
+    if (isParticipantSubmissionComplete(input)) return "응시 완료"
+    if (isParticipantInProgress(input)) return "응시 중"
+    return "대기 중"
+  }
+
+  if (isParticipantSubmissionComplete(input)) return "응시 완료"
+  if (isParticipantInProgress(input)) return "응시 중"
+
+  const sessionLabel = getMasterSessionStatusLabel(examState)
+  if (sessionLabel === "대기 중") return "대기 중"
+
+  return "-"
+}
+
+export function mapBoardConnectionStatus(state: string | null | undefined): string {
+  const normalized = (state ?? "").trim().toUpperCase()
+  if (["ENTRANCE", "ACTIVE", "RUNNING", "IN_PROGRESS", "CONNECTED", "ONLINE", "JOINED", "STARTED"].includes(normalized)) {
+    return "Connected"
+  }
+  if (["PENDING", "WAITING", "IDLE"].includes(normalized)) {
+    return "Pending"
+  }
+  return "Disconnected"
+}
+
+export function mapBoardParticipant(entry: ExamineeBoardEntry) {
+  return {
+    id: entry.examParticipantId,
+    name: entry.name || "-",
+    phoneNumber: entry.phoneMasked || "-",
+    connectionStatus: mapBoardConnectionStatus(entry.state),
+    hasSubmission: entry.submitted === true,
+    submissionStatusLabel: entry.submitted ? "submitted" : "not_started",
+    tokenUsage: entry.tokenUsed ?? 0,
+  }
+}
+
+/** Dashboard / Test Sessions 상태 한글 라벨 */
+export function getMasterSessionStatusLabel(state: string | null | undefined): string {
+  const normalized = (state ?? "").trim().toUpperCase()
+  if (["RUNNING", "IN_PROGRESS", "ACTIVE"].includes(normalized)) {
+    return "진행 중"
+  }
+  if (["ENDED", "COMPLETED", "FINISHED", "CLOSED"].includes(normalized)) {
+    return "완료"
+  }
+  if (["WAITING", "PENDING", "SCHEDULED", "DRAFT"].includes(normalized)) {
+    return "대기 중"
+  }
+  return state?.trim() || "-"
+}
+
+export function isMasterSessionInProgress(statusLabel: string): boolean {
+  return statusLabel === "진행 중"
+}
+
+export function mapExamToMasterRecentSession(exam: Exam): MasterRecentSession {
+  const item = mapExamToTestSession(exam)
+  return {
+    id: item.id,
+    sessionId: item.sessionId,
+    createdAt: item.createdAt,
+    participants: item.participants,
+    status: item.statusLabel,
+    sortKey: item.sortKey,
+  }
+}
+
+export function sortMasterSessionsByCreatedAtDesc(
+  sessions: MasterRecentSession[]
+): MasterRecentSession[] {
+  return [...sessions].sort((a, b) => b.sortKey - a.sortKey)
+}
+
+export function pickRecentSessions(
+  exams: Exam[],
+  limit = RECENT_SESSIONS_DISPLAY_LIMIT
+): MasterRecentSession[] {
+  return sortMasterSessionsByCreatedAtDesc(exams.map(mapExamToMasterRecentSession)).slice(0, limit)
+}

--- a/lib/master-test-sessions.ts
+++ b/lib/master-test-sessions.ts
@@ -80,6 +80,15 @@ export function getExamDisplayDate(exam: Exam): string {
 }
 
 /** 목록 필터용 Active / Completed */
+const UNKNOWN_CREATOR_LABEL = "알 수 없음"
+
+/** API creatorName → 목록/상세 표시용 생성자 라벨 */
+export function resolveExamCreatorDisplayName(exam: Exam): string {
+  const name = exam.creatorName?.trim()
+  if (name) return name
+  return UNKNOWN_CREATOR_LABEL
+}
+
 export function getTestSessionFilterStatus(state: string | null | undefined): string {
   const normalized = (state ?? "").trim().toUpperCase()
   if (["RUNNING", "IN_PROGRESS", "ACTIVE"].includes(normalized)) return "Active"
@@ -91,7 +100,7 @@ export function mapExamToTestSession(exam: Exam): TestSessionListItem {
   return {
     id: exam.id,
     sessionId: title || `시험 #${exam.id}`,
-    createdBy: "Admin",
+    createdBy: resolveExamCreatorDisplayName(exam),
     createdAt: formatSessionCreatedAt(
       (exam as ExamWithOptionalCreatedAt).createdAt ?? exam.startsAt
     ),

--- a/lib/paths/master-participant-evaluation.ts
+++ b/lib/paths/master-participant-evaluation.ts
@@ -1,0 +1,19 @@
+/**
+ * Master 테스트 세션 — 참가자 평가 상세 URL
+ * 라우트: app/master/test-sessions/[ID]/participants/[participantId]/page.tsx
+ */
+export function masterParticipantEvaluationHref(opts: {
+  examId: string | number
+  participantId: string | number
+  participantName?: string
+}): string {
+  const examSeg = String(opts.examId).trim()
+  const pid = String(opts.participantId).trim()
+  const path = `/master/test-sessions/${encodeURIComponent(examSeg)}/participants/${encodeURIComponent(pid)}`
+  if (opts.participantName != null && String(opts.participantName).trim() !== "") {
+    const q = new URLSearchParams()
+    q.set("participantName", String(opts.participantName).trim())
+    return `${path}?${q.toString()}`
+  }
+  return path
+}

--- a/lib/problem-content-md.ts
+++ b/lib/problem-content-md.ts
@@ -1,0 +1,91 @@
+/** 응시 화면 contentMd(마크다운) → 상세 모달 필드 분리 */
+
+export type ParsedProblemContentMd = {
+  description: string
+  inputExample: string
+  outputExample: string
+  constraints: string
+}
+
+const EMPTY_INPUT = "등록된 예시가 없습니다."
+const EMPTY_OUTPUT = "등록된 예시가 없습니다."
+const EMPTY_DESCRIPTION = "등록된 설명이 없습니다."
+
+function extractFirstCodeBlockAfterHeading(contentMd: string, headingRe: RegExp): string {
+  const headingMatch = headingRe.exec(contentMd)
+  if (!headingMatch) return ""
+
+  const after = contentMd.slice(headingMatch.index + headingMatch[0].length)
+  const fenceMatch = after.match(/```[^\n]*\n([\s\S]*?)```/)
+  return fenceMatch?.[1]?.trim() ?? ""
+}
+
+function extractSectionText(contentMd: string, headingRe: RegExp): string {
+  const headingMatch = headingRe.exec(contentMd)
+  if (!headingMatch) return ""
+
+  const start = headingMatch.index + headingMatch[0].length
+  const rest = contentMd.slice(start)
+  const nextHeading = rest.search(/\n##\s+/)
+  const sectionBody = nextHeading >= 0 ? rest.slice(0, nextHeading) : rest
+  return sectionBody.replace(/```[\s\S]*?```/g, "").trim()
+}
+
+/**
+ * BOJ/프로젝트 초기 데이터 형식(## 문제, ## 입력, ## 출력, ## 예제 입력 N) 기준 파싱
+ */
+export function parseProblemContentMd(contentMd: string | null | undefined): ParsedProblemContentMd {
+  const raw = (contentMd ?? "").trim()
+  if (!raw) {
+    return {
+      description: EMPTY_DESCRIPTION,
+      inputExample: EMPTY_INPUT,
+      outputExample: EMPTY_OUTPUT,
+      constraints: "정보 없음",
+    }
+  }
+
+  const inputExample =
+    extractFirstCodeBlockAfterHeading(raw, /##\s*예제\s*입력\s*\d*/i) ||
+    extractFirstCodeBlockAfterHeading(raw, /##\s*입력\s*예시/i) ||
+    extractFirstCodeBlockAfterHeading(raw, /##\s*입력\s*예제/i) ||
+    EMPTY_INPUT
+
+  const outputExample =
+    extractFirstCodeBlockAfterHeading(raw, /##\s*예제\s*출력\s*\d*/i) ||
+    extractFirstCodeBlockAfterHeading(raw, /##\s*출력\s*예시/i) ||
+    extractFirstCodeBlockAfterHeading(raw, /##\s*출력\s*예제/i) ||
+    EMPTY_OUTPUT
+
+  const problemSection = extractSectionText(raw, /##\s*문제\b/i)
+  const firstSectionEnd = raw.search(/\n##\s+/)
+  const leading =
+    firstSectionEnd >= 0 && !/^##\s*문제\b/m.test(raw.slice(0, 20))
+      ? raw.slice(0, firstSectionEnd).trim()
+      : ""
+
+  const description =
+    problemSection ||
+    leading ||
+    raw.split(/\n##\s+(?:입력|출력|예제)/)[0]?.trim() ||
+    EMPTY_DESCRIPTION
+
+  const inputRules = extractSectionText(raw, /##\s*입력\b/i)
+  const outputRules = extractSectionText(raw, /##\s*출력\b/i)
+  const constraintParts = [inputRules, outputRules].filter(Boolean)
+  const constraints = constraintParts.length > 0 ? constraintParts.join("\n\n") : "정보 없음"
+
+  return {
+    description,
+    inputExample: inputExample || EMPTY_INPUT,
+    outputExample: outputExample || EMPTY_OUTPUT,
+    constraints,
+  }
+}
+
+export function formatAssignmentLimits(
+  limits: { timeMs: number; memoryMb: number } | undefined
+): string {
+  if (!limits) return ""
+  return `시간 제한 ${limits.timeMs}ms · 메모리 ${limits.memoryMb}MB`
+}


### PR DESCRIPTION
## 작업 내용

### Master Dashboard - Test Sessions
- 테스트 세션 목록(`/master/test-sessions`) 생성자 표시 개선
- 기존 `"Admin"` 하드코딩 제거
- 세션 목록과 상세 화면(`/master/test-sessions/[id]`)의 생성자 표시 기준 통일
- creatorName fallback 처리 개선

---

### Master Dashboard - 관리자 계정 관리
- 관리자 상세 패널 이름 표시 개선
- 이름(displayName)과 관리자 번호(adminNumber) 표시 분리
- 이름 필드에 관리자 번호가 표시되던 문제 수정
- displayName fallback 로직 정리

---

### 관리자 설정 / 사이드바 표시 개선
- 관리자 이름 표시 로직 개선
- 관리자 번호와 이름 혼동 방지
- fallback `"알 수 없음"` 처리 정리

---

### 관리자 참가자 목록 상태 표시 개선
- `/admin/users` 참가자 상태 표시 로직 개선
- 종료된 응시자에게 제출 상태가 `진행 중`으로 표시되지 않도록 수정
- 응시 상태와 제출 상태 조합 기반 표시 로직 정리
- 상태 계산 helper 공통화

---

### 공통 구조 개선
- 일부 Mock/하드코딩 제거
- helper 함수 공통화
- 목록/상세 간 표시 기준 통일
- 기존 UI 레이아웃 및 디자인 유지