### PR TITLE
QA기반 수정 및 관리자 삭제 기능 연동

### DIFF
--- a/components/account-delete-success-dialog.tsx
+++ b/components/account-delete-success-dialog.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { CheckCircle } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+/** 성공 모달 하단 단일 버튼 중앙 정렬 (DialogFooter 기본 sm:justify-end 덮어씀) */
+export const ACCOUNT_DELETE_SUCCESS_FOOTER_CLASS =
+  "flex flex-row justify-center gap-4 mt-4 sm:justify-center"
+
+export type AccountDeleteSuccessDialogProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description: string
+  buttonLabel: string
+  onConfirm: () => void
+}
+
+export function AccountDeleteSuccessDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  buttonLabel,
+  onConfirm,
+}: AccountDeleteSuccessDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader className="flex flex-col items-center text-center">
+          <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-[#D1FAE5]">
+            <CheckCircle className="h-8 w-8 text-[#10B981]" />
+          </div>
+          <DialogTitle className="text-lg font-semibold">{title}</DialogTitle>
+          <DialogDescription className="mt-2 text-[#6B7280]">{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter className={ACCOUNT_DELETE_SUCCESS_FOOTER_CLASS}>
+          <Button onClick={onConfirm} className="bg-[#3B82F6] text-white hover:bg-[#2563EB]">
+            {buttonLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/admin-accounts-content.tsx
+++ b/components/admin-accounts-content.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/lib/api/master-admin-accounts"
 import { isMasterAdmin, isSystemMasterAdmin } from "@/lib/auth/utils"
 import { useRouter } from "next/navigation"
+import { AccountDeleteSuccessDialog } from "@/components/account-delete-success-dialog"
 import { AdminPageHeader } from "@/components/admin-page-header"
 
 function displayValue(value: string | null | undefined): string {
@@ -60,6 +61,8 @@ export function AdminAccountsContent() {
   const [tempPassword, setTempPassword] = useState("")
   const [tempPasswordCopied, setTempPasswordCopied] = useState(false)
   const [isDeleteAdminOpen, setIsDeleteAdminOpen] = useState(false)
+  const [isDeleteAdminSuccessOpen, setIsDeleteAdminSuccessOpen] = useState(false)
+  const [deleteAdminError, setDeleteAdminError] = useState("")
   const [isDetailsOpen, setIsDetailsOpen] = useState(false)
   const [isChangingStatus, setIsChangingStatus] = useState(false)
   const [isResettingPassword, setIsResettingPassword] = useState(false)
@@ -324,12 +327,14 @@ export function AdminAccountsContent() {
       return;
     }
     
+    setDeleteAdminError("")
     setSelectedAdmin(admin)
     setIsDeleteAdminOpen(true)
   }
 
   const handleConfirmDeleteAdmin = async () => {
     if (!selectedAdmin) return
+    setDeleteAdminError("")
     setIsDeletingAdmin(true)
     try {
       await deleteMasterAdminAccount(selectedAdmin)
@@ -337,20 +342,13 @@ export function AdminAccountsContent() {
       setIsDeleteAdminOpen(false)
       setIsDetailsOpen(false)
       setSelectedAdmin(null)
-      toast({
-        title: "관리자 삭제 완료",
-        description: "관리자 계정이 삭제되었습니다.",
-      })
+      setIsDeleteAdminSuccessOpen(true)
     } catch (error) {
       const message =
         error instanceof LoginFailedError || error instanceof NetworkError
           ? error.message
           : "관리자 삭제에 실패했습니다."
-      toast({
-        title: "관리자 삭제 불가",
-        description: message,
-        variant: "destructive",
-      })
+      setDeleteAdminError(message)
     } finally {
       setIsDeletingAdmin(false)
     }
@@ -373,8 +371,9 @@ export function AdminAccountsContent() {
   }
 
   const handleDeleteAdminFromPanel = () => {
+    if (!selectedAdmin) return
     setIsDetailsOpen(false)
-    setIsDeleteAdminOpen(true)
+    handleOpenDeleteAdmin(selectedAdmin)
   }
 
   return (
@@ -994,9 +993,19 @@ export function AdminAccountsContent() {
             )}
 
             <p style={{ fontSize: "14px", color: "#374151" }}>해당 관리자의 접근 권한이 즉시 제거됩니다.</p>
+            {deleteAdminError && (
+              <p className="text-sm text-red-500">{deleteAdminError}</p>
+            )}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setIsDeleteAdminOpen(false)}>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setDeleteAdminError("")
+                setIsDeleteAdminOpen(false)
+              }}
+              disabled={isDeletingAdmin}
+            >
               취소
             </Button>
             <Button
@@ -1009,6 +1018,15 @@ export function AdminAccountsContent() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <AccountDeleteSuccessDialog
+        open={isDeleteAdminSuccessOpen}
+        onOpenChange={setIsDeleteAdminSuccessOpen}
+        title="관리자 계정이 삭제되었습니다."
+        description="해당 관리자 계정이 정상적으로 삭제되었습니다."
+        buttonLabel="확인"
+        onConfirm={() => setIsDeleteAdminSuccessOpen(false)}
+      />
 
       <Sheet open={isDetailsOpen} onOpenChange={setIsDetailsOpen}>
         <SheetContent side="right" className="w-[420px] max-w-full pl-4 pr-6 py-6 flex flex-col gap-6">

--- a/components/entry-codes-content.tsx
+++ b/components/entry-codes-content.tsx
@@ -78,6 +78,49 @@ function getExamEntryCodesActionPriority(state: string): number {
   return 0
 }
 
+const EXPIRES_AT_PAST_ERROR_MESSAGE = "만료일은 현재 이후여야 합니다."
+const TITLE_REQUIRED_FALLBACK_MESSAGE = "시험 제목은 필수입니다."
+
+/** 종료/만료 시각이 현재 이후인지 확인 (datetime-local 입력값 기준) */
+function isFutureDateTime(value: string): boolean {
+  if (!value) return false
+  const date = new Date(value)
+  return !Number.isNaN(date.getTime()) && date > new Date()
+}
+
+/** createExam 400 응답이 만료일(종료 시각) 검증 실패인지 여부 */
+function isExpiresAtValidationApiError(error: LoginFailedError, endsAt: string): boolean {
+  if (error.status !== 400) return false
+  if (error.fieldErrors?.endsAt) return true
+  const message = error.message ?? ""
+  if (message.includes("만료일") || message.includes("현재 이후")) return true
+  // BE가 공통 400 메시지만 내려줄 때, 과거 종료 시각이면 만료일 검증 실패로 처리
+  return !isFutureDateTime(endsAt)
+}
+
+/** createExam 400 응답에서 공통 오류 영역에 표시할 메시지 (필드 우선순위: title > endsAt > startsAt > message) */
+function resolveCreateExamValidationMessage(
+  error: LoginFailedError,
+  endsAt: string,
+  title: string,
+): string | null {
+  if (error.status !== 400) return null
+
+  const fields = error.fieldErrors ?? {}
+
+  if (fields.title) return fields.title
+  if (!title.trim()) return TITLE_REQUIRED_FALLBACK_MESSAGE
+
+  if (fields.endsAt) return fields.endsAt
+  if (isExpiresAtValidationApiError(error, endsAt)) {
+    return EXPIRES_AT_PAST_ERROR_MESSAGE
+  }
+
+  if (fields.startsAt) return fields.startsAt
+
+  return error.message || null
+}
+
 /** 상태 우선 정렬 후, 같은 그룹 내에서는 시작/생성 시각 내림차순(기존 시각 기준) */
 function sortExamsForEntryCodes<T extends Exam>(exams: T[]): T[] {
   return [...exams].sort((a, b) => {
@@ -94,6 +137,7 @@ export function EntryCodesContent() {
   const [examTitle, setExamTitle] = useState("")
   const [examStartsAt, setExamStartsAt] = useState("")
   const [examEndsAt, setExamEndsAt] = useState("")
+  const [createExamValidationError, setCreateExamValidationError] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   // 시험 조회 상태
@@ -212,18 +256,18 @@ export function EntryCodesContent() {
 
   // 시험 생성 핸들러
   const handleCreateExam = async () => {
-    // 입력값 검증
-    if (!examTitle.trim() || !examStartsAt || !examEndsAt) {
+    if (!examStartsAt || !examEndsAt) {
       toast({
         title: "입력 오류",
-        description: "제목, 시작 시각, 종료 시각을 모두 입력해주세요.",
+        description: "시작 시각과 종료 시각을 입력해주세요.",
         variant: "destructive",
       })
       return
     }
 
-    // 시작 시각이 종료 시각보다 이전인지 확인
-    if (new Date(examStartsAt) >= new Date(examEndsAt)) {
+    // 시작/종료 순서 검증은 종료 시각이 미래일 때만 FE에서 처리.
+    // 종료 시각이 과거(만료)인 경우는 BE 400 응답으로 처리한다.
+    if (isFutureDateTime(examEndsAt) && new Date(examStartsAt) >= new Date(examEndsAt)) {
       toast({
         title: "입력 오류",
         description: "종료 시각은 시작 시각보다 이후여야 합니다.",
@@ -247,6 +291,7 @@ export function EntryCodesContent() {
     }
 
     setIsSubmitting(true)
+    setCreateExamValidationError("")
     try {
       const createdExam = await createExam(payload)
       const responseEntryCode = pickEntryCode(createdExam)
@@ -284,6 +329,7 @@ export function EntryCodesContent() {
       setExamTitle("")
       setExamStartsAt("")
       setExamEndsAt("")
+      setCreateExamValidationError("")
 
       // 성공 토스트 표시
       toast({
@@ -293,11 +339,20 @@ export function EntryCodesContent() {
     } catch (error) {
       console.error("Failed to create exam", error)
       if (error instanceof LoginFailedError) {
-        toast({
-          title: "시험 생성 실패",
-          description: error.message,
-          variant: "destructive",
-        })
+        const validationMessage = resolveCreateExamValidationMessage(
+          error,
+          examEndsAt,
+          examTitle,
+        )
+        if (validationMessage) {
+          setCreateExamValidationError(validationMessage)
+        } else {
+          toast({
+            title: "시험 생성 실패",
+            description: error.message,
+            variant: "destructive",
+          })
+        }
       } else if (error instanceof NetworkError) {
         toast({
           title: "네트워크 오류",
@@ -877,7 +932,12 @@ export function EntryCodesContent() {
                 type="text"
                 placeholder="시험 제목을 입력하세요"
                 value={examTitle}
-                onChange={(e) => setExamTitle(e.target.value)}
+                onChange={(e) => {
+                  setExamTitle(e.target.value)
+                  if (createExamValidationError) {
+                    setCreateExamValidationError("")
+                  }
+                }}
                 disabled={isSubmitting}
                 className="col-span-3"
               />
@@ -890,7 +950,12 @@ export function EntryCodesContent() {
                 id="exam-starts-at"
                 type="datetime-local"
                 value={examStartsAt}
-                onChange={(e) => setExamStartsAt(e.target.value)}
+                onChange={(e) => {
+                  setExamStartsAt(e.target.value)
+                  if (createExamValidationError) {
+                    setCreateExamValidationError("")
+                  }
+                }}
                 disabled={isSubmitting}
                 className="col-span-3"
               />
@@ -903,10 +968,18 @@ export function EntryCodesContent() {
                 id="exam-ends-at"
                 type="datetime-local"
                 value={examEndsAt}
-                onChange={(e) => setExamEndsAt(e.target.value)}
+                onChange={(e) => {
+                  setExamEndsAt(e.target.value)
+                  if (createExamValidationError) {
+                    setCreateExamValidationError("")
+                  }
+                }}
                 disabled={isSubmitting}
                 className="col-span-3"
               />
+              {createExamValidationError && (
+                <p className="text-sm text-red-500">{createExamValidationError}</p>
+              )}
             </div>
           </div>
           <DialogFooter className="flex flex-row justify-end gap-4">
@@ -917,12 +990,17 @@ export function EntryCodesContent() {
                 setExamTitle("")
                 setExamStartsAt("")
                 setExamEndsAt("")
+                setCreateExamValidationError("")
               }}
               disabled={isSubmitting}
             >
               취소
             </Button>
-            <Button onClick={handleCreateExam} disabled={isSubmitting}>
+            <Button
+              type="button"
+              onClick={handleCreateExam}
+              disabled={isSubmitting || !examStartsAt || !examEndsAt}
+            >
               {isSubmitting ? "생성 중..." : "생성"}
             </Button>
           </DialogFooter>

--- a/components/entry-codes-content.tsx
+++ b/components/entry-codes-content.tsx
@@ -84,7 +84,26 @@ const TITLE_REQUIRED_FALLBACK_MESSAGE = "시험 제목은 필수입니다."
 /** 종료/만료 시각이 현재 이후인지 확인 (datetime-local 입력값 기준) */
 function isFutureDateTime(value: string): boolean {
   if (!value) return false
-  const date = new Date(value)
+  const [datePart, timePart] = value.split("T")
+  if (!datePart || !timePart) return false
+
+  const [year, month, day] = datePart.split("-").map(Number)
+  const [hour, minute] = timePart.split(":").map(Number)
+  if ([year, month, day, hour, minute].some((part) => !Number.isFinite(part))) {
+    return false
+  }
+
+  const date = new Date(year, month - 1, day, hour, minute)
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day ||
+    date.getHours() !== hour ||
+    date.getMinutes() !== minute
+  ) {
+    return false
+  }
+
   return !Number.isNaN(date.getTime()) && date > new Date()
 }
 

--- a/components/settings-content.tsx
+++ b/components/settings-content.tsx
@@ -55,6 +55,7 @@ export function SettingsContent() {
     adminNumber: adminProfile.adminNumber,
     role: adminProfile.role,
   })
+  const canDeleteOwnAccount = !isLoading && !isMasterAccount
 
   const router = useRouter();
   const { toast } = useToast()
@@ -127,6 +128,9 @@ export function SettingsContent() {
   }
 
   const handleDeleteAccount = async () => {
+    if (isLoading) {
+      return
+    }
     if (isMasterAccount) {
       setDeleteAccountError("마스터 관리자 계정은 삭제할 수 없습니다.")
       return
@@ -338,9 +342,9 @@ export function SettingsContent() {
               </div>
               <Button
                 className="bg-[#DC2626] hover:bg-[#B91C1C] text-white disabled:opacity-50"
-                disabled={isMasterAccount}
+                disabled={!canDeleteOwnAccount}
                 onClick={() => {
-                  if (isMasterAccount) return
+                  if (!canDeleteOwnAccount) return
                   setDeleteAccountError("")
                   setShowDeleteModal(true)
                 }}
@@ -411,7 +415,7 @@ export function SettingsContent() {
             </Button>
             <Button
               onClick={handleDeleteAccount}
-              disabled={isDeletingAccount}
+              disabled={isDeletingAccount || !canDeleteOwnAccount}
               className="bg-[#DC2626] hover:bg-[#B91C1C] text-white disabled:opacity-50"
             >
               {isDeletingAccount ? "삭제 중..." : "계정 삭제"}

--- a/components/settings-content.tsx
+++ b/components/settings-content.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { User, LogOut, AlertTriangle, CheckCircle } from "lucide-react"
+import { AccountDeleteSuccessDialog } from "@/components/account-delete-success-dialog"
 import { useRouter } from "next/navigation";
 import {
   Dialog,
@@ -18,19 +19,21 @@ import {
   logoutAdmin,
   getMe,
   changeAdminPassword,
+  deleteOwnAdminAccount,
   LoginFailedError,
   NetworkError,
   resolveAdminDisplayNameFromMe,
   resolveAdminNumberFromMe,
 } from "@/lib/api/admin"
+import { isMasterAdmin } from "@/lib/auth/utils"
 import { useToast } from "@/hooks/use-toast"
-import { Lock } from "lucide-react"
 
 export function SettingsContent() {
   const [showLogoutModal, setShowLogoutModal] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [showDeletedSuccessModal, setShowDeletedSuccessModal] = useState(false)
   const [showPasswordChangeModal, setShowPasswordChangeModal] = useState(false)
+  const [showPasswordChangeSuccessModal, setShowPasswordChangeSuccessModal] = useState(false)
   const [isLoggingOut, setIsLoggingOut] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [isChangingPassword, setIsChangingPassword] = useState(false)
@@ -40,10 +43,17 @@ export function SettingsContent() {
     confirmPassword: "",
   })
   const [passwordError, setPasswordError] = useState("")
+  const [deleteAccountError, setDeleteAccountError] = useState("")
+  const [isDeletingAccount, setIsDeletingAccount] = useState(false)
   const [adminProfile, setAdminProfile] = useState({
-    name: "", // 더미 데이터
-    email: "", // participant.phone에서 가져옴
-    adminNumber: "", // participant.name에서 가져옴
+    name: "",
+    email: "",
+    adminNumber: "",
+    role: "",
+  })
+  const isMasterAccount = isMasterAdmin({
+    adminNumber: adminProfile.adminNumber,
+    role: adminProfile.role,
   })
 
   const router = useRouter();
@@ -59,6 +69,7 @@ export function SettingsContent() {
           name: resolveAdminDisplayNameFromMe(response),
           email: response.participant.phone || "",
           adminNumber: resolveAdminNumberFromMe(response),
+          role: response.role || "",
         });
       } catch (error) {
         if (error instanceof LoginFailedError) {
@@ -115,9 +126,29 @@ export function SettingsContent() {
     }
   }
 
-  const handleDeleteAccount = () => {
-    setShowDeleteModal(false)
-    setShowDeletedSuccessModal(true)
+  const handleDeleteAccount = async () => {
+    if (isMasterAccount) {
+      setDeleteAccountError("마스터 관리자 계정은 삭제할 수 없습니다.")
+      return
+    }
+
+    setDeleteAccountError("")
+    setIsDeletingAccount(true)
+    try {
+      await deleteOwnAdminAccount()
+      setShowDeleteModal(false)
+      setShowDeletedSuccessModal(true)
+    } catch (error) {
+      if (error instanceof LoginFailedError) {
+        setDeleteAccountError(error.message)
+      } else if (error instanceof NetworkError) {
+        setDeleteAccountError(error.message)
+      } else {
+        setDeleteAccountError("계정 삭제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")
+      }
+    } finally {
+      setIsDeletingAccount(false)
+    }
   }
 
   const handleGoToLogin = () => {
@@ -125,14 +156,18 @@ export function SettingsContent() {
     window.location.href = "/"
   }
 
-  const handlePasswordChangeClick = () => {
-    setShowPasswordChangeModal(true)
+  const resetPasswordForm = () => {
     setPasswordForm({
       currentPassword: "",
       newPassword: "",
       confirmPassword: "",
     })
     setPasswordError("")
+  }
+
+  const handlePasswordChangeClick = () => {
+    setShowPasswordChangeModal(true)
+    resetPasswordForm()
   }
 
   const handlePasswordFormChange = (field: "currentPassword" | "newPassword" | "confirmPassword", value: string) => {
@@ -172,18 +207,9 @@ export function SettingsContent() {
         newPassword: passwordForm.newPassword.trim(),
       })
 
-      toast({
-        title: "비밀번호 변경 성공",
-        description: "비밀번호가 성공적으로 변경되었습니다.",
-      })
-
       setShowPasswordChangeModal(false)
-      setPasswordForm({
-        currentPassword: "",
-        newPassword: "",
-        confirmPassword: "",
-      })
-      setPasswordError("")
+      resetPasswordForm()
+      setShowPasswordChangeSuccessModal(true)
     } catch (error) {
       if (error instanceof LoginFailedError) {
         setPasswordError(error.message)
@@ -305,10 +331,20 @@ export function SettingsContent() {
               <div>
                 <h2 className="text-lg font-semibold text-[#111111]">계정 삭제</h2>
                 <p className="text-sm text-[#6B7280] mt-1">
-                  관리자 계정을 삭제하면 대시보드 접근 권한이 영구적으로 제거됩니다.
+                  {isMasterAccount
+                    ? "마스터 관리자 계정은 삭제할 수 없습니다."
+                    : "관리자 계정을 삭제하면 대시보드 접근 권한이 영구적으로 제거됩니다."}
                 </p>
               </div>
-              <Button className="bg-[#DC2626] hover:bg-[#B91C1C] text-white" onClick={() => setShowDeleteModal(true)}>
+              <Button
+                className="bg-[#DC2626] hover:bg-[#B91C1C] text-white disabled:opacity-50"
+                disabled={isMasterAccount}
+                onClick={() => {
+                  if (isMasterAccount) return
+                  setDeleteAccountError("")
+                  setShowDeleteModal(true)
+                }}
+              >
                 계정 삭제
               </Button>
             </div>
@@ -357,41 +393,41 @@ export function SettingsContent() {
             <DialogDescription className="text-[#6B7280] mt-4">
               이 작업은 되돌릴 수 없습니다. 관리자 계정을 삭제하면 대시보드 접근 권한이 모두 제거됩니다.
             </DialogDescription>
+            {deleteAccountError && (
+              <p className="text-sm text-red-500 mt-2">{deleteAccountError}</p>
+            )}
           </DialogHeader>
           <DialogFooter className="flex flex-row justify-end gap-4 mt-4">
             <Button
               variant="outline"
-              onClick={() => setShowDeleteModal(false)}
+              onClick={() => {
+                setDeleteAccountError("")
+                setShowDeleteModal(false)
+              }}
               className="border-[#E5E5E5] text-[#374151]"
+              disabled={isDeletingAccount}
             >
               취소
             </Button>
-            <Button onClick={handleDeleteAccount} className="bg-[#DC2626] hover:bg-[#B91C1C] text-white">
-              계정 삭제
+            <Button
+              onClick={handleDeleteAccount}
+              disabled={isDeletingAccount}
+              className="bg-[#DC2626] hover:bg-[#B91C1C] text-white disabled:opacity-50"
+            >
+              {isDeletingAccount ? "삭제 중..." : "계정 삭제"}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      {/* Modal #3: Account Deleted Success */}
-      <Dialog open={showDeletedSuccessModal} onOpenChange={setShowDeletedSuccessModal}>
-        <DialogContent className="sm:max-w-[400px]">
-          <DialogHeader className="flex flex-col items-center text-center">
-            <div className="w-16 h-16 rounded-full bg-[#D1FAE5] flex items-center justify-center mb-4">
-              <CheckCircle className="w-8 h-8 text-[#10B981]" />
-            </div>
-            <DialogTitle className="text-lg font-semibold">계정이 삭제되었습니다.</DialogTitle>
-            <DialogDescription className="text-[#6B7280] mt-2">
-              계정이 정상적으로 삭제되었습니다. 더 이상 관리자 대시보드에 접근할 수 없습니다.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="flex justify-center mt-4">
-            <Button onClick={handleGoToLogin} className="bg-[#3B82F6] hover:bg-[#2563EB] text-white">
-              로그인 페이지로 이동
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <AccountDeleteSuccessDialog
+        open={showDeletedSuccessModal}
+        onOpenChange={setShowDeletedSuccessModal}
+        title="계정이 삭제되었습니다."
+        description="계정이 정상적으로 삭제되었습니다. 더 이상 관리자 대시보드에 접근할 수 없습니다."
+        buttonLabel="로그인 페이지로 이동"
+        onConfirm={handleGoToLogin}
+      />
 
       {/* Modal #4: Change Password */}
       <Dialog open={showPasswordChangeModal} onOpenChange={setShowPasswordChangeModal}>
@@ -453,12 +489,7 @@ export function SettingsContent() {
               variant="outline"
               onClick={() => {
                 setShowPasswordChangeModal(false)
-                setPasswordForm({
-                  currentPassword: "",
-                  newPassword: "",
-                  confirmPassword: "",
-                })
-                setPasswordError("")
+                resetPasswordForm()
               }}
               disabled={isChangingPassword}
               className="border-[#E5E5E5] text-[#374151]"
@@ -471,6 +502,29 @@ export function SettingsContent() {
               className="bg-[#3B82F6] hover:bg-[#2563EB] text-white disabled:opacity-50"
             >
               {isChangingPassword ? "변경 중..." : "비밀번호 변경"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Modal #5: Password Change Success */}
+      <Dialog open={showPasswordChangeSuccessModal} onOpenChange={setShowPasswordChangeSuccessModal}>
+        <DialogContent className="sm:max-w-[400px]">
+          <DialogHeader className="flex flex-col items-center text-center">
+            <div className="w-16 h-16 rounded-full bg-[#D1FAE5] flex items-center justify-center mb-4">
+              <CheckCircle className="w-8 h-8 text-[#10B981]" />
+            </div>
+            <DialogTitle className="text-lg font-semibold">비밀번호 변경 완료</DialogTitle>
+            <DialogDescription className="text-[#6B7280] mt-2">
+              비밀번호가 성공적으로 변경되었습니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="mt-4 flex w-full justify-center sm:justify-center">
+            <Button
+              onClick={() => setShowPasswordChangeSuccessModal(false)}
+              className="bg-[#3B82F6] hover:bg-[#2563EB] text-white"
+            >
+              확인
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -1262,12 +1262,29 @@ export async function deleteAdminByMaster(adminNumber: string): Promise<void> {
     credentials: 'include',
   });
 
+  const contentType = response.headers.get('content-type') ?? '';
+  const contentLength = response.headers.get('content-length');
+  const hasJsonBody =
+    response.status !== 204 &&
+    contentLength !== '0' &&
+    contentType.toLowerCase().includes('application/json');
+
   if (!response.ok) {
-    const data = await response.json().catch(() => ({ message: '관리자 삭제에 실패했습니다.' } as BaseResponse<null>));
+    const data = hasJsonBody
+      ? await response.json().catch(() => ({ message: '관리자 삭제에 실패했습니다.' } as BaseResponse<null>))
+      : ({ message: '관리자 삭제에 실패했습니다.' } as BaseResponse<null>);
     throw new LoginFailedError(data.message || '관리자 삭제에 실패했습니다.', response.status, data.code);
   }
 
-  const data: BaseResponse<null> = await response.json();
+  if (!hasJsonBody) {
+    return;
+  }
+
+  const data: BaseResponse<null> | null = await response.json().catch(() => null);
+  if (!data) {
+    return;
+  }
+
   if (data.code !== 'COMMON200') {
     throw new LoginFailedError(data.message || '관리자 삭제에 실패했습니다.');
   }
@@ -1291,12 +1308,29 @@ export async function deleteOwnAdminAccount(): Promise<void> {
     credentials: 'include',
   });
 
+  const contentType = response.headers.get('content-type') ?? '';
+  const contentLength = response.headers.get('content-length');
+  const hasJsonBody =
+    response.status !== 204 &&
+    contentLength !== '0' &&
+    contentType.toLowerCase().includes('application/json');
+
   if (!response.ok) {
-    const data = await response.json().catch(() => ({ message: '계정 삭제에 실패했습니다.' } as BaseResponse<null>));
+    const data = hasJsonBody
+      ? await response.json().catch(() => ({ message: '계정 삭제에 실패했습니다.' } as BaseResponse<null>))
+      : ({ message: '계정 삭제에 실패했습니다.' } as BaseResponse<null>);
     throw new LoginFailedError(data.message || '계정 삭제에 실패했습니다.', response.status, data.code);
   }
 
-  const data: BaseResponse<null> = await response.json();
+  if (!hasJsonBody) {
+    return;
+  }
+
+  const data: BaseResponse<null> | null = await response.json().catch(() => null);
+  if (!data) {
+    return;
+  }
+
   if (data.code !== 'COMMON200') {
     throw new LoginFailedError(data.message || '계정 삭제에 실패했습니다.');
   }

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -4,13 +4,31 @@
 export class LoginFailedError extends Error {
   status?: number;
   code?: string;
+  fieldErrors?: Record<string, string>;
   
-  constructor(message: string = '아이디 또는 비밀번호가 일치하지 않습니다.', status?: number, code?: string) {
+  constructor(
+    message: string = '아이디 또는 비밀번호가 일치하지 않습니다.',
+    status?: number,
+    code?: string,
+    fieldErrors?: Record<string, string>,
+  ) {
     super(message);
     this.name = 'LoginFailedError';
     this.status = status;
     this.code = code;
+    this.fieldErrors = fieldErrors;
   }
+}
+
+function isValidationFieldErrorMap(result: unknown): result is Record<string, string> {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) {
+    return false;
+  }
+  const values = Object.values(result as Record<string, unknown>);
+  if (values.length === 0) {
+    return false;
+  }
+  return values.every((value) => typeof value === 'string');
 }
 
 export class NetworkError extends Error {
@@ -44,21 +62,62 @@ export function handleAdminAuthError(status: number): void {
   }
 }
 
+let reissueInFlight: Promise<boolean> | null = null;
+
 /**
  * admin refresh token으로 access token을 재발급한다.
  * BE가 새 access_token / refresh_token 쿠키를 Set-Cookie로 내려준다.
  * 성공 여부(boolean)를 반환한다.
+ * 동시 401 발생 시 reissue 요청은 1회만 실행된다.
  */
 export async function reissueAdminToken(): Promise<boolean> {
-  try {
-    const response = await fetch(`${getApiBaseUrl()}/api/auth/admin/reissue`, {
-      method: 'POST',
-      credentials: 'include',
-    });
-    return response.ok;
-  } catch {
-    return false;
+  if (reissueInFlight) {
+    return reissueInFlight;
   }
+
+  const isDev = process.env.NODE_ENV === 'development';
+
+  reissueInFlight = (async () => {
+    try {
+      const response = await fetch(`${getApiBaseUrl()}/api/auth/admin/reissue`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+
+      if (response.ok) {
+        if (isDev) {
+          console.log('[Admin Reissue] 재발급 성공');
+        }
+        return true;
+      }
+
+      let errorBody: { code?: string; message?: string } | null = null;
+      try {
+        errorBody = await response.json();
+      } catch {
+        // JSON 파싱 실패 시 status만 로깅
+      }
+
+      if (isDev) {
+        console.warn('[Admin Reissue] 재발급 실패:', {
+          status: response.status,
+          code: errorBody?.code,
+          message: errorBody?.message,
+        });
+      }
+
+      return false;
+    } catch (error) {
+      if (isDev) {
+        console.warn('[Admin Reissue] 네트워크 오류:', error);
+      }
+      return false;
+    } finally {
+      reissueInFlight = null;
+    }
+  })();
+
+  return reissueInFlight;
 }
 
 /**
@@ -372,7 +431,7 @@ export async function getProblems(): Promise<AdminProblem[]> {
   const url = `${apiBaseUrl}/api/admin/problems`;
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'GET',
       headers: getAuthHeaders(),
       credentials: 'include',
@@ -406,7 +465,7 @@ export async function getProblemSpecs(problemId: number): Promise<ProblemSpecRes
   const url = `${apiBaseUrl}/api/admin/problems/${problemId}/specs`;
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'GET',
       headers: getAuthHeaders(),
       credentials: 'include',
@@ -440,7 +499,7 @@ export async function getProblemDetail(problemId: number): Promise<AdminProblemD
   const url = `${apiBaseUrl}/api/admin/problems/${problemId}/detail`;
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'GET',
       headers: getAuthHeaders(),
       credentials: 'include',
@@ -479,7 +538,7 @@ export async function getAllAdmins(): Promise<AdminListResponse> {
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'GET',
       headers: getAuthHeaders(),
       credentials: 'include',
@@ -585,7 +644,7 @@ export async function updateAdminNumber(
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'PATCH',
       headers: getAuthHeaders(),
       body: JSON.stringify(request),
@@ -692,7 +751,7 @@ export async function resetAdminPasswordByMaster(
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'PATCH',
       headers: getAuthHeaders(),
       credentials: 'include',
@@ -760,7 +819,7 @@ export async function issueAdminNumber(request: AdminNumberIssueRequest): Promis
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'POST',
       headers: getAuthHeaders(),
       body: JSON.stringify(request),
@@ -1004,7 +1063,7 @@ export async function getMe(): Promise<MeResponse> {
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'GET',
       headers: getAuthHeaders(),
       credentials: 'include',
@@ -1101,7 +1160,7 @@ export async function changeAdminPassword(request: ChangeAdminPasswordRequest): 
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'PATCH',
       headers: getAuthHeaders(),
       body: JSON.stringify(request),
@@ -1182,6 +1241,64 @@ export async function changeAdminPassword(request: ChangeAdminPasswordRequest): 
       console.warn('[Change Admin Password] 예상치 못한 오류:', error);
     }
     throw new NetworkError('비밀번호 변경 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+  }
+}
+
+/**
+ * MASTER가 관리자 계정 삭제 API 호출 (soft delete)
+ */
+export async function deleteAdminByMaster(adminNumber: string): Promise<void> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/admin-numbers/${encodeURIComponent(adminNumber)}`;
+  const isDev = process.env.NODE_ENV === 'development';
+
+  if (isDev) {
+    console.log('[Delete Admin By Master] API 호출:', url);
+  }
+
+  const response = await fetchAdminWithRetry(url, {
+    method: 'DELETE',
+    headers: getAuthHeaders(),
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({ message: '관리자 삭제에 실패했습니다.' } as BaseResponse<null>));
+    throw new LoginFailedError(data.message || '관리자 삭제에 실패했습니다.', response.status, data.code);
+  }
+
+  const data: BaseResponse<null> = await response.json();
+  if (data.code !== 'COMMON200') {
+    throw new LoginFailedError(data.message || '관리자 삭제에 실패했습니다.');
+  }
+}
+
+/**
+ * 로그인한 관리자 본인 계정 삭제 API 호출 (soft delete, 쿠키 삭제는 BE 응답)
+ */
+export async function deleteOwnAdminAccount(): Promise<void> {
+  const apiBaseUrl = getApiBaseUrl();
+  const url = `${apiBaseUrl}/api/admin/account`;
+  const isDev = process.env.NODE_ENV === 'development';
+
+  if (isDev) {
+    console.log('[Delete Own Admin Account] API 호출:', url);
+  }
+
+  const response = await fetchAdminWithRetry(url, {
+    method: 'DELETE',
+    headers: getAuthHeaders(),
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({ message: '계정 삭제에 실패했습니다.' } as BaseResponse<null>));
+    throw new LoginFailedError(data.message || '계정 삭제에 실패했습니다.', response.status, data.code);
+  }
+
+  const data: BaseResponse<null> = await response.json();
+  if (data.code !== 'COMMON200') {
+    throw new LoginFailedError(data.message || '계정 삭제에 실패했습니다.');
   }
 }
 
@@ -1273,7 +1390,7 @@ export async function createExam(request: CreateExamRequest): Promise<Exam> {
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'POST',
       headers: getAuthHeaders(),
       body: JSON.stringify(request),
@@ -1312,15 +1429,21 @@ export async function createExam(request: CreateExamRequest): Promise<Exam> {
         errorMessage = data.message || '입력한 정보가 올바르지 않습니다.';
       }
 
+      const fieldErrors =
+        response.status === 400 && isValidationFieldErrorMap(data.result)
+          ? data.result
+          : undefined;
+
       if (isDev) {
         console.warn('[Create Exam] 생성 실패:', {
           status: response.status,
           code: data.code,
           message: errorMessage,
+          fieldErrors,
         });
       }
 
-      throw new LoginFailedError(errorMessage, response.status, data.code);
+      throw new LoginFailedError(errorMessage, response.status, data.code, fieldErrors);
     }
 
     if (isDev) {
@@ -1374,7 +1497,7 @@ export async function getExams(): Promise<Exam[]> {
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'GET',
       headers: getAuthHeaders(),
       credentials: 'include',
@@ -1473,7 +1596,7 @@ export async function createEntryCode(request: CreateEntryCodeRequest): Promise<
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'POST',
       headers: getAuthHeaders(),
       body: JSON.stringify(request),
@@ -1876,7 +1999,7 @@ export async function getEntryCodes(examId: number, isActive?: boolean): Promise
   }
 
   try {
-    const response = await fetch(url, {
+    const response = await fetchAdminWithRetry(url, {
       method: 'GET',
       headers: getAuthHeaders(),
       credentials: 'include',
@@ -2048,7 +2171,7 @@ export async function extendExam(examId: number, minutes: number): Promise<void>
   const apiBaseUrl = getApiBaseUrl();
   const url = `${apiBaseUrl}/api/admin/exams/${examId}/extend`;
 
-  const response = await fetch(url, {
+  const response = await fetchAdminWithRetry(url, {
     method: 'POST',
     headers: getAuthHeaders(),
     body: JSON.stringify({ minutes }),
@@ -2071,7 +2194,7 @@ export async function updateEntryCode(code: string, isActive: boolean): Promise<
   const apiBaseUrl = getApiBaseUrl();
   const url = `${apiBaseUrl}/api/admin/entry-codes/${encodeURIComponent(code)}`;
 
-  const response = await fetch(url, {
+  const response = await fetchAdminWithRetry(url, {
     method: 'PATCH',
     headers: getAuthHeaders(),
     body: JSON.stringify({ isActive }),
@@ -2093,7 +2216,7 @@ export async function deleteEntryCode(code: string): Promise<void> {
   const apiBaseUrl = getApiBaseUrl();
   const url = `${apiBaseUrl}/api/admin/entry-codes/${encodeURIComponent(code)}`;
 
-  const response = await fetch(url, {
+  const response = await fetchAdminWithRetry(url, {
     method: 'DELETE',
     headers: getAuthHeaders(),
     credentials: 'include',
@@ -2136,7 +2259,7 @@ export async function getMetrics(examId: number): Promise<AdminMetrics> {
   const apiBaseUrl = getApiBaseUrl();
   const url = `${apiBaseUrl}/api/admin/metrics?examId=${examId}`;
 
-  const response = await fetch(url, {
+  const response = await fetchAdminWithRetry(url, {
     method: 'GET',
     headers: getAuthHeaders(),
     credentials: 'include',
@@ -2157,7 +2280,7 @@ export async function getBoard(examId: number): Promise<ExamineeBoardEntry[]> {
   const apiBaseUrl = getApiBaseUrl();
   const url = `${apiBaseUrl}/api/admin/board?examId=${examId}`;
 
-  const response = await fetch(url, {
+  const response = await fetchAdminWithRetry(url, {
     method: 'GET',
     headers: getAuthHeaders(),
     credentials: 'include',

--- a/lib/api/master-admin-accounts.ts
+++ b/lib/api/master-admin-accounts.ts
@@ -7,6 +7,7 @@ import {
   issueAdminNumber,
   updateAdminNumber,
   resetAdminPasswordByMaster,
+  deleteAdminByMaster,
   resolveAdminAccountDisplayName,
   LoginFailedError,
   NetworkError,
@@ -186,14 +187,9 @@ export async function resetMasterAdminPassword(
   return { temporaryPassword: result.temporaryPassword };
 }
 
-/**
- * TODO(BE): 관리자 계정 삭제 API 미구현
- */
+/** MASTER가 타 관리자 계정 삭제 (soft delete) */
 export async function deleteMasterAdminAccount(
-  _account: MasterAdminAccount
+  account: MasterAdminAccount
 ): Promise<void> {
-  throw new LoginFailedError(
-    '관리자 삭제 API가 아직 제공되지 않습니다. 백엔드 연동 후 호출해 주세요.',
-    501
-  );
+  await deleteAdminByMaster(account.adminNumber);
 }


### PR DESCRIPTION
## 작업 개요

QA 대응 및 추가 제품 개선 작업으로, 관리자 계정 삭제 기능을 실제 API와 연동하고 삭제 성공 피드백 UX를 개선했습니다.

기존에는 `/admin/settings` 화면의 계정 삭제 기능이 실제 API 호출 없이 성공 모달만 표시되는 하드코딩 흐름이었고, `/master/admin-accounts` 화면의 관리자 삭제 기능도 실제 API 호출이 연결되지 않은 상태였습니다.

이번 작업에서는 BE에서 추가된 관리자 삭제 API를 FE에 연결하고, 삭제 성공 시 사용자에게 명확한 완료 피드백을 제공하도록 성공 모달을 공통 컴포넌트로 정리했습니다.

---

## 주요 변경 사항

### 1. 관리자 계정 삭제 API 연동

관리자 계정 삭제 관련 API 함수를 추가하고, 기존 TODO/하드코딩 흐름을 실제 API 호출로 교체했습니다.

#### 추가된 API 함수

- `deleteAdminByMaster`
- `deleteOwnAdminAccount`

#### 적용 화면

- `/master/admin-accounts`
- `/admin/settings`

인증 방식은 기존 구조를 유지했습니다.

- HttpOnly Cookie 기반 인증 유지
- `credentials: "include"` 유지
- 기존 `fetchAdminWithRetry` 흐름 유지
- Authorization Bearer 방식으로 변경하지 않음
- localStorage/sessionStorage 토큰 저장 방식 사용하지 않음

---

### 2. `/master/admin-accounts` 관리자 삭제 기능 개선

MASTER가 관리자 계정을 삭제하는 흐름을 실제 API와 연결했습니다.

#### 기존 문제

- 3-dot 메뉴에 “관리자 삭제” 항목은 존재했지만 실제 API 호출이 연결되지 않음
- 삭제 성공 후 사용자에게 명확한 완료 피드백이 부족함

#### 개선 내용

- 관리자 삭제 시 `DELETE /api/admin/admin-numbers/{adminNumber}` 호출
- 삭제 성공 시 기존 확인 모달 닫기
- 삭제된 관리자 row를 목록에서 제거
- 삭제 성공 완료 모달 표시
- 실패 시 기존 삭제 확인 모달을 유지하고 오류 메시지 표시
- 성공 toast는 제거하고 성공 모달로 피드백 통일

#### 성공 모달 문구

- 제목: `관리자 계정이 삭제되었습니다.`
- 설명: `해당 관리자 계정이 정상적으로 삭제되었습니다.`
- 버튼: `확인`

`확인` 버튼 클릭 시 로그인 페이지로 이동하지 않고 현재 `/master/admin-accounts` 화면에 머무르도록 처리했습니다.

---

### 3. `/admin/settings` 본인 계정 삭제 기능 개선

관리자 본인 계정 삭제 기능을 실제 API와 연결했습니다.

#### 기존 문제

- 계정 삭제 버튼 클릭 시 경고 모달과 삭제 완료 모달은 표시되지만 실제 API 호출이 없음
- 실제 DB 상태가 변경되지 않는 하드코딩 흐름

#### 개선 내용

- 계정 삭제 시 `DELETE /api/admin/account` 호출
- 삭제 성공 시 삭제 완료 모달 표시
- 삭제 완료 모달의 `로그인 페이지로 이동` 버튼 클릭 시 로그인 페이지로 이동
- 실패 시 삭제 완료 모달을 띄우지 않고 기존 경고 모달 안에 오류 메시지 표시
- MASTER 계정은 본인 삭제 버튼 비활성화 처리

---

### 4. 계정 삭제 성공 모달 공통 컴포넌트 추가

계정 삭제 성공 피드백을 재사용할 수 있도록 공통 컴포넌트를 추가했습니다.

#### 신규 파일

- `components/account-delete-success-dialog.tsx`

#### 공통 모달 구성

- 초록색 체크 아이콘
- 제목
- 설명
- 단일 파란색 버튼
- 중앙 정렬된 버튼 레이아웃

#### 버튼 중앙 정렬 처리

`DialogFooter` 기본 스타일인 `sm:justify-end`로 인해 단일 버튼이 우측에 붙는 문제가 있어, 성공 모달 전용 footer class를 추가했습니다.

- `ACCOUNT_DELETE_SUCCESS_FOOTER_CLASS`

이를 통해 `/admin/settings`와 `/master/admin-accounts`의 삭제 성공 모달 버튼이 모두 중앙 정렬되도록 개선했습니다.

---

### 5. 삭제 실패 UX 유지

삭제 실패 시에는 사용자가 상황을 확인할 수 있도록 기존 확인 모달을 닫지 않고 오류 메시지를 표시합니다.

#### 처리 방식

- 삭제 확인 모달 유지
- 서버 응답 메시지가 있으면 우선 표시
- 빨간색 오류 메시지 표시
- 성공 모달은 표시하지 않음

---

## 수동 확인

### MASTER 관리자 삭제

1. MASTER 계정으로 로그인
2. `/master/admin-accounts` 이동
3. 일반 관리자 3-dot 메뉴 클릭
4. `관리자 삭제` 클릭
5. 삭제 확인 모달에서 삭제 실행
6. Network 확인

```http
DELETE /api/admin/admin-numbers/{adminNumber} → 200