### PR TITLE
AI 채팅 토큰 중복 누적 방지 및 코드 관리 버튼 위치 조정

### DIFF
--- a/components/ai-assistant-sidebar.tsx
+++ b/components/ai-assistant-sidebar.tsx
@@ -5,7 +5,7 @@ import { ChevronLeft, ChevronRight, Send, Bot, User } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { useChatSocket } from "@/hooks/use-chat-socket"
-import { updateTokenUsage, getChatHistory } from "@/lib/api/chat"
+import { getChatHistory } from "@/lib/api/chat"
 import { MarkdownContent } from "@/components/markdown-content"
 
 interface Message {
@@ -128,16 +128,9 @@ export function AiAssistantSidebar({
     const tokensDelta: number = response.tokenCount ?? 0;
 
     if (tokensDelta > 0) {
-      updateTokenUsage({ examId, participantId, tokens: tokensDelta })
-        .then(() => { onTokensUpdate(tokensDelta); })
-        .catch((err) => {
-          if (process.env.NODE_ENV === "development") {
-            console.warn("[WS Chat] Token update failed:", err);
-          }
-          onTokensUpdate(tokensDelta);
-        });
+      onTokensUpdate(tokensDelta);
     }
-  }, [examId, participantId, onTokensUpdate]);
+  }, [onTokensUpdate]);
 
   const handleChatError = useCallback((errorMessage: string) => {
     console.error('[AiAssistant] WS 에러로 로딩 해제:', errorMessage);

--- a/components/entry-codes-content.tsx
+++ b/components/entry-codes-content.tsx
@@ -675,12 +675,12 @@ export function EntryCodesContent() {
   return (
     <div className="flex h-full min-w-0 flex-1 flex-col">
       {/* Top Header Bar */}
-      <header className="flex h-[88px] shrink-0 items-center justify-between border-b border-[#E5E5E5] bg-white px-8">
+      <header className="flex h-[88px] shrink-0 items-center justify-between border-b border-[#E5E5E5] bg-white px-8 lg:pr-8 xl:pr-10">
         <div>
           <h1 className="text-2xl font-semibold text-[#1A1A1A]">코드 관리</h1>
           <p className="text-sm text-[#6B7280]">참가자 시험 입장 코드를 관리합니다</p>
         </div>
-        <div className="flex gap-2 lg:mr-8 xl:mr-12 2xl:mr-16">
+        <div className="flex shrink-0 gap-2">
           <button
             onClick={() => setIsCreateExamOpen(true)}
             className="rounded-full bg-[#3B82F6] px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-[#2563EB]"


### PR DESCRIPTION
## 변경 내용

- AI 채팅 토큰 사용량 중복 누적 방지
  - WebSocket AI 응답 후 `/api/chat/tokens/update` 호출 제거
  - `onTokensUpdate(tokenCount)` 흐름은 유지
  - 참가자 화면과 관리자 참가자 목록의 토큰 사용량이 중복 누적되지 않도록 개선

- 코드 관리 화면 시험 생성 버튼 위치 조정
  - `/admin/entry-codes` 상단 `시험 생성` 버튼의 우측 여백 조정
  - 큰 margin으로 버튼을 왼쪽으로 밀던 구조 제거
  - `shrink-0` 적용으로 창 축소 시 버튼이 눌리거나 깨지지 않도록 조정

## 검증

- FE 타입 체크 통과
  - `npx tsc --noEmit -p .`

- 수동 검증
  - 새 시험/새 참가자 기준 AI 채팅 후 참가자 화면과 관리자 목록 토큰 사용량이 동일하게 표시되는 것 확인
  - 코드 관리 화면의 `시험 생성` 버튼 위치가 의도한 위치로 표시되는 것 확인