### PR TITLE
마스터 화면 사용성 개선

### DIFF
--- a/components/admin-accounts-content.tsx
+++ b/components/admin-accounts-content.tsx
@@ -377,18 +377,28 @@ export function AdminAccountsContent() {
   }
 
   return (
-    <div className="flex h-full flex-1 flex-col">
+    <div className="flex h-full min-w-0 flex-1 flex-col">
       <AdminPageHeader
         title="관리자 계정 관리"
         description="관리자 계정과 접근 권한을 관리합니다."
+        actions={
+          <Button
+            size="sm"
+            className="shrink-0 whitespace-nowrap bg-primary px-3 text-primary-foreground hover:bg-primary/90 md:px-4"
+            onClick={handleOpenGenerateModal}
+          >
+            <span className="md:hidden">+ 발급</span>
+            <span className="hidden md:inline">+ 관리자 번호 발급</span>
+          </Button>
+        }
       />
 
-      <main className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-6">
+      <main className="flex min-h-0 min-w-0 flex-1 flex-col gap-4 overflow-x-hidden overflow-y-auto p-4 sm:p-6">
       {/* Admin Users Card */}
       <Card className="flex min-w-0 flex-1 flex-col border border-[#E5E5E5] shadow-sm">
-        <CardHeader className="flex min-w-0 flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <CardHeader className="px-4 py-3 sm:px-6">
           <CardTitle
-            className="min-w-0 shrink"
+            className="min-w-0"
             style={{
               fontSize: "20px",
               fontWeight: 700,
@@ -397,13 +407,6 @@ export function AdminAccountsContent() {
           >
             관리자 목록
           </CardTitle>
-          <Button
-            size="sm"
-            className="w-full shrink-0 bg-primary text-primary-foreground hover:bg-primary/90 sm:w-auto"
-            onClick={handleOpenGenerateModal}
-          >
-            + 관리자 번호 발급
-          </Button>
         </CardHeader>
         <CardContent className="flex min-w-0 flex-1 flex-col overflow-hidden px-0 pb-0 pt-0">
           {listError && !isLoading && (

--- a/components/admin-page-header.tsx
+++ b/components/admin-page-header.tsx
@@ -8,10 +8,10 @@ export type AdminPageHeaderProps = {
 
 export function AdminPageHeader({ title, description, actions }: AdminPageHeaderProps) {
   return (
-    <header className="flex h-[88px] shrink-0 items-center justify-between border-b border-[#E5E5E5] bg-white px-8">
-      <div>
-        <h1 className="text-2xl font-semibold text-[#1A1A1A]">{title}</h1>
-        {description ? <p className="text-sm text-[#6B7280]">{description}</p> : null}
+    <header className="flex h-[88px] min-w-0 shrink-0 items-center justify-between gap-3 border-b border-[#E5E5E5] bg-white px-4 sm:px-6 lg:px-8">
+      <div className="min-w-0 flex-1 overflow-hidden">
+        <h1 className="truncate text-2xl font-semibold text-[#1A1A1A]">{title}</h1>
+        {description ? <p className="truncate text-sm text-[#6B7280]">{description}</p> : null}
       </div>
       {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
     </header>

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import Link from "next/link";
-import { useRouter } from "next/navigation"
+import { usePathname, useRouter } from "next/navigation"
 import type React from "react"
 
 import { LayoutDashboard, Users, CalendarClock, Settings, FileCode, List, User, LogOut } from "lucide-react"
@@ -73,10 +73,30 @@ const menuGroupB: MenuItem[] = [
   },
 ]
 
+function isMasterMenuActive(pathname: string, href: string): boolean {
+  if (href === "/master") {
+    return pathname === "/master" || pathname === "/master/"
+  }
+  return pathname === href || pathname.startsWith(`${href}/`)
+}
+
 export function Sidebar({ activeItem, onItemClick }: SidebarProps) {
+  const pathname = usePathname()
   const router = useRouter()
   const [showLogoutModal, setShowLogoutModal] = useState(false)
   const [isLoggingOut, setIsLoggingOut] = useState(false)
+
+  const menuLinkClassName = (href: string) => {
+    const active = isMasterMenuActive(pathname, href)
+    return `flex items-center gap-3 px-5 py-2.5 rounded-xl border-l-[3px] transition-colors ${
+      active
+        ? "border-app-focus bg-app-sidebar-active font-medium text-app-accent-soft-foreground"
+        : "border-transparent text-muted-foreground hover:bg-app-accent-soft/60 hover:text-foreground"
+    }`
+  }
+
+  const menuLabelClassName = (href: string) =>
+    isMasterMenuActive(pathname, href) ? "text-sm font-semibold" : "text-sm"
 
   const handleLogoutClick = () => {
     setShowLogoutModal(true)
@@ -169,14 +189,14 @@ export function Sidebar({ activeItem, onItemClick }: SidebarProps) {
           <Link
             key={item.label}
             href={item.href}
-            className="flex items-center gap-3 px-5 py-2.5 rounded-xl border-l-[3px] border-transparent hover:border-app-ring hover:bg-app-accent-soft/60"
+            className={menuLinkClassName(item.href)}
             onClick={() => onItemClick && onItemClick(item.label)}
           >
             <div className="flex h-5 w-5 items-center justify-center shrink-0">
               {item.icon}
             </div>
             
-            <span style={textStyle}>{item.label}</span>
+            <span className={menuLabelClassName(item.href)}>{item.label}</span>
           </Link>
         ))}
       </nav>
@@ -190,14 +210,14 @@ export function Sidebar({ activeItem, onItemClick }: SidebarProps) {
           <Link
             key={item.label}
             href={item.href}
-            className="flex items-center gap-3 px-5 py-2.5 rounded-xl border-l-[3px] border-transparent hover:border-app-ring hover:bg-app-accent-soft/60"
+            className={menuLinkClassName(item.href)}
             onClick={() => onItemClick && onItemClick(item.label)}
           >
             <div className="flex h-5 w-5 items-center justify-center shrink-0">
               {item.icon}
             </div>
 
-            <span style={textStyle}>{item.label}</span>
+            <span className={menuLabelClassName(item.href)}>{item.label}</span>
           </Link>
         ))}
       </nav>


### PR DESCRIPTION
## 작업 내용

마스터 화면의 사용성을 개선했습니다.

- Master 사이드바에서 현재 접속 중인 메뉴가 active 상태로 표시되도록 수정
- 상세 경로에서도 상위 메뉴 active 상태 유지
  - 예: `/master/test-sessions/...` → 테스트 세션 active
- Admin 사이드바와 비슷한 active 스타일 적용
- Master 관리자 계정 관리 화면의 `+ 관리자 번호 발급` 버튼을 페이지 헤더 actions 영역으로 이동
- 좁은 화면에서도 버튼이 쉽게 잘리지 않도록 제목 영역 truncate, 버튼 shrink 처리, 짧은 라벨 적용

## 검증

- `npx tsc --noEmit -p .` 통과
- `/master`
- `/master/admin-accounts`
- `/master/test-sessions`
- `/master/test-sessions/{sessionId}`
- `/master/problem`
- `/master/global-settings`
- `/master/platform-logs`